### PR TITLE
[core] RestCatalog: set up paged list tables/views/partitions

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/PagedList.java
+++ b/paimon-common/src/main/java/org/apache/paimon/PagedList.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon;
+
+import java.io.Serializable;
+import java.util.List;
+
+/** Paged List which supports request data from page streaming. */
+public class PagedList<T> implements Serializable {
+    private final List<T> pagedLists;
+
+    private final String nextPageToken;
+
+    public PagedList(List<T> pagedLists, String nextPageToken) {
+        this.pagedLists = pagedLists;
+        this.nextPageToken = nextPageToken;
+    }
+
+    public List<T> getPagedLists() {
+        return this.pagedLists;
+    }
+
+    public String getNextPageToken() {
+        return this.nextPageToken;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.PagedList;
 import org.apache.paimon.factories.FactoryUtil;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileStatus;
@@ -38,12 +39,16 @@ import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.RowType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -64,6 +69,8 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Common implementation of {@link Catalog}. */
 public abstract class AbstractCatalog implements Catalog {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractCatalog.class);
 
     protected final FileIO fileIO;
     protected final Map<String, String> tableDefaultOptions;
@@ -184,6 +191,13 @@ public abstract class AbstractCatalog implements Catalog {
         return listPartitionsFromFileSystem(getTable(identifier));
     }
 
+    @Override
+    public PagedList<Partition> listPartitionsPaged(
+            Identifier identifier, Integer maxResults, String pageToken)
+            throws TableNotExistException {
+        return new PagedList<>(listPartitions(identifier), null);
+    }
+
     protected abstract void createDatabaseImpl(String name, Map<String, String> properties);
 
     @Override
@@ -240,7 +254,68 @@ public abstract class AbstractCatalog implements Catalog {
         return listTablesImpl(databaseName).stream().sorted().collect(Collectors.toList());
     }
 
+    @Override
+    public PagedList<String> listTablesPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        return new PagedList<>(listTables(databaseName), null);
+    }
+
+    @Override
+    public PagedList<Table> listTableDetailsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        if (isSystemDatabase(databaseName)) {
+            List<Table> systemTables =
+                    SystemTableLoader.loadGlobalTableNames().stream()
+                            .map(
+                                    tableName -> {
+                                        try {
+                                            return getTable(
+                                                    Identifier.create(databaseName, tableName));
+                                        } catch (TableNotExistException ignored) {
+                                            LOG.warn(
+                                                    "system table {}.{} does not exist",
+                                                    databaseName,
+                                                    tableName);
+                                            return null;
+                                        }
+                                    })
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList());
+            return new PagedList<>(systemTables, null);
+        }
+
+        // check db exists
+        getDatabase(databaseName);
+
+        return listTableDetailsPagedImpl(databaseName, maxResults, pageToken);
+    }
+
     protected abstract List<String> listTablesImpl(String databaseName);
+
+    protected PagedList<Table> listTableDetailsPagedImpl(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        PagedList<String> pagedTableNames = listTablesPaged(databaseName, maxResults, pageToken);
+        return new PagedList<>(
+                pagedTableNames.getPagedLists().stream()
+                        .map(
+                                tableName -> {
+                                    try {
+                                        return getTable(Identifier.create(databaseName, tableName));
+                                    } catch (TableNotExistException ignored) {
+                                        LOG.warn(
+                                                "table {}.{} does not exist",
+                                                databaseName,
+                                                tableName);
+                                        return null;
+                                    }
+                                })
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList()),
+                pagedTableNames.getNextPageToken());
+    }
 
     @Override
     public void dropTable(Identifier identifier, boolean ignoreIfNotExists)

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.catalog;
 
+import org.apache.paimon.PagedList;
 import org.apache.paimon.annotation.Public;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.schema.Schema;
@@ -129,6 +130,44 @@ public interface Catalog extends AutoCloseable {
      * @throws DatabaseNotExistException if the database does not exist
      */
     List<String> listTables(String databaseName) throws DatabaseNotExistException;
+
+    /**
+     * Get paged list names of tables under this database. An empty list is returned if none exists.
+     *
+     * <p>NOTE: System tables will not be listed.
+     *
+     * @param databaseName Name of the database to list tables.
+     * @param maxResults Optional parameter indicating the maximum number of results to include in
+     *     the result. If maxResults is not specified or set to 0, will return the default number of
+     *     max results.
+     * @param pageToken Optional parameter indicating the next page token allows list to be start
+     *     from a specific point.
+     * @return a list of the names of tables with provided page size in this database and next page
+     *     token
+     * @throws DatabaseNotExistException if the database does not exist
+     */
+    PagedList<String> listTablesPaged(String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException;
+
+    /**
+     * Get paged list of table details under this database. An empty list is returned if none
+     * exists.
+     *
+     * <p>NOTE: System tables will not be listed.
+     *
+     * @param databaseName Name of the database to list table details.
+     * @param maxResults Optional parameter indicating the maximum number of results to include in
+     *     the result. If maxResults is not specified or set to 0, will return the default number of
+     *     max results.
+     * @param pageToken Optional parameter indicating the next page token allows list to be start
+     *     from a specific point.
+     * @return a list of the table details with provided page size in this database and next page
+     *     token
+     * @throws DatabaseNotExistException if the database does not exist
+     */
+    PagedList<Table> listTableDetailsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException;
 
     /**
      * Drop a table.
@@ -275,6 +314,23 @@ public interface Catalog extends AutoCloseable {
      */
     List<Partition> listPartitions(Identifier identifier) throws TableNotExistException;
 
+    /**
+     * Get paged partitioned list of the table.
+     *
+     * @param identifier path of the table to list partitions
+     * @param maxResults Optional parameter indicating the maximum number of results to include in
+     *     the result. If maxResults is not specified or set to 0, will return the default number of
+     *     max results.
+     * @param pageToken Optional parameter indicating the next page token allows list to be start
+     *     from a specific point.
+     * @return a list of the partitions with provided page size(@param maxResults) in this table and
+     *     next page token
+     * @throws TableNotExistException if the table does not exist
+     */
+    PagedList<Partition> listPartitionsPaged(
+            Identifier identifier, Integer maxResults, String pageToken)
+            throws TableNotExistException;
+
     // ======================= view methods ===============================
 
     /**
@@ -324,6 +380,46 @@ public interface Catalog extends AutoCloseable {
      */
     default List<String> listViews(String databaseName) throws DatabaseNotExistException {
         return Collections.emptyList();
+    }
+
+    /**
+     * Get paged list names of views under this database. An empty list is returned if none view
+     * exists.
+     *
+     * @param databaseName Name of the database to list views.
+     * @param maxResults Optional parameter indicating the maximum number of results to include in
+     *     the result. If maxResults is not specified or set to 0, will return the default number of
+     *     max results.
+     * @param pageToken Optional parameter indicating the next page token allows list to be start
+     *     from a specific point.
+     * @return a list of the names of views with provided page size in this database and next page
+     *     token
+     * @throws DatabaseNotExistException if the database does not exist
+     */
+    default PagedList<String> listViewsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        return new PagedList<>(listViews(databaseName), null);
+    }
+
+    /**
+     * Get paged list view details under this database. An empty list is returned if none view
+     * exists.
+     *
+     * @param databaseName Name of the database to list views.
+     * @param maxResults Optional parameter indicating the maximum number of results to include in
+     *     the result. If maxResults is not specified or set to 0, will return the default number of
+     *     max results.
+     * @param pageToken Optional parameter indicating the next page token allows list to be start
+     *     from a specific point.
+     * @return a list of the view details with provided page size (@param maxResults) in this
+     *     database and next page token
+     * @throws DatabaseNotExistException if the database does not exist
+     */
+    default PagedList<View> listViewDetailsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        return new PagedList<>(Collections.emptyList(), null);
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.catalog;
 
+import org.apache.paimon.PagedList;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
@@ -81,6 +82,20 @@ public abstract class DelegateCatalog implements Catalog {
     @Override
     public List<String> listTables(String databaseName) throws DatabaseNotExistException {
         return wrapped.listTables(databaseName);
+    }
+
+    @Override
+    public PagedList<String> listTablesPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        return wrapped.listTablesPaged(databaseName, maxResults, pageToken);
+    }
+
+    @Override
+    public PagedList<Table> listTableDetailsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        return wrapped.listTableDetailsPaged(databaseName, maxResults, pageToken);
     }
 
     @Override
@@ -160,6 +175,20 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public PagedList<String> listViewsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        return wrapped.listViewsPaged(databaseName, maxResults, pageToken);
+    }
+
+    @Override
+    public PagedList<View> listViewDetailsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        return wrapped.listViewDetailsPaged(databaseName, maxResults, pageToken);
+    }
+
+    @Override
     public void renameView(Identifier fromView, Identifier toView, boolean ignoreIfNotExists)
             throws ViewNotExistException, ViewAlreadyExistException {
         wrapped.renameView(fromView, toView, ignoreIfNotExists);
@@ -168,6 +197,13 @@ public abstract class DelegateCatalog implements Catalog {
     @Override
     public List<Partition> listPartitions(Identifier identifier) throws TableNotExistException {
         return wrapped.listPartitions(identifier);
+    }
+
+    @Override
+    public PagedList<Partition> listPartitionsPaged(
+            Identifier identifier, Integer maxResults, String pageToken)
+            throws TableNotExistException {
+        return wrapped.listPartitionsPaged(identifier, maxResults, pageToken);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.rest;
 
+import org.apache.paimon.PagedList;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
@@ -64,7 +65,9 @@ import org.apache.paimon.rest.responses.GetTableTokenResponse;
 import org.apache.paimon.rest.responses.GetViewResponse;
 import org.apache.paimon.rest.responses.ListDatabasesResponse;
 import org.apache.paimon.rest.responses.ListPartitionsResponse;
+import org.apache.paimon.rest.responses.ListTableDetailsResponse;
 import org.apache.paimon.rest.responses.ListTablesResponse;
+import org.apache.paimon.rest.responses.ListViewDetailsResponse;
 import org.apache.paimon.rest.responses.ListViewsResponse;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
@@ -78,6 +81,10 @@ import org.apache.paimon.view.ViewImpl;
 import org.apache.paimon.view.ViewSchema;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
+import org.apache.paimon.shade.guava30.com.google.common.collect.Maps;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -85,9 +92,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.createCommitUser;
 import static org.apache.paimon.catalog.CatalogUtils.checkNotBranch;
@@ -105,7 +114,11 @@ import static org.apache.paimon.utils.ThreadPoolUtils.createScheduledThreadPool;
 /** A catalog implementation for REST. */
 public class RESTCatalog implements Catalog, SupportsSnapshots {
 
+    private static final Logger LOG = LoggerFactory.getLogger(RESTCatalog.class);
+
     public static final String HEADER_PREFIX = "header.";
+    public static final String MAX_RESULTS = "maxResults";
+    public static final String PAGE_TOKEN = "pageToken";
 
     private final RESTClient client;
     private final ResourcePaths resourcePaths;
@@ -256,15 +269,132 @@ public class RESTCatalog implements Catalog, SupportsSnapshots {
     @Override
     public List<String> listTables(String databaseName) throws DatabaseNotExistException {
         try {
+            String pageToken = null;
+            Map<String, String> queryParams = Maps.newHashMap();
+            Integer maxResults = context.options().get(RESTCatalogOptions.REST_PAGE_MAX_RESULTS);
+            if (Objects.nonNull(maxResults) && maxResults > 0) {
+                queryParams.put(MAX_RESULTS, String.valueOf(maxResults));
+            }
+            List<String> tables = new ArrayList<>();
+            do {
+                queryParams.put(PAGE_TOKEN, pageToken);
+                ListTablesResponse response =
+                        client.get(
+                                resourcePaths.tables(databaseName),
+                                queryParams,
+                                ListTablesResponse.class,
+                                restAuthFunction);
+                if (Objects.nonNull(response)) {
+                    pageToken = response.getNextPageToken();
+                    tables.addAll(response.getTables());
+                } else {
+                    LOG.warn(
+                            "response of listTables for {} is null with params {}",
+                            databaseName,
+                            queryParams);
+                }
+            } while (pageToken != null);
+            return tables;
+        } catch (NoSuchResourceException e) {
+            throw new DatabaseNotExistException(databaseName);
+        }
+    }
+
+    @Override
+    public PagedList<String> listTablesPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        Map<String, String> queryParams = Maps.newHashMap();
+        if (Objects.nonNull(maxResults) && maxResults > 0) {
+            queryParams.put(MAX_RESULTS, maxResults.toString());
+        }
+        if (Objects.nonNull(pageToken)) {
+            queryParams.put(PAGE_TOKEN, pageToken);
+        }
+        try {
             ListTablesResponse response =
                     client.get(
                             resourcePaths.tables(databaseName),
+                            queryParams,
                             ListTablesResponse.class,
                             restAuthFunction);
-            if (response.getTables() != null) {
-                return response.getTables();
+            if (Objects.nonNull(response) && Objects.nonNull(response.getTables())) {
+                return new PagedList<>(response.getTables(), response.getNextPageToken());
+            } else {
+                LOG.warn(
+                        "response of listTablesPaged for {} is null with maxResults {} and pageToken {}",
+                        databaseName,
+                        maxResults,
+                        pageToken);
+                return new PagedList<>(Collections.emptyList(), null);
             }
-            return ImmutableList.of();
+        } catch (NoSuchResourceException e) {
+            throw new DatabaseNotExistException(databaseName);
+        }
+    }
+
+    @Override
+    public PagedList<Table> listTableDetailsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        Map<String, String> queryParams = Maps.newHashMap();
+        if (Objects.nonNull(maxResults) && maxResults > 0) {
+            queryParams.put(MAX_RESULTS, maxResults.toString());
+        }
+        if (Objects.nonNull(pageToken)) {
+            queryParams.put(PAGE_TOKEN, pageToken);
+        }
+        try {
+            ListTableDetailsResponse response =
+                    client.get(
+                            resourcePaths.tableDetails(databaseName),
+                            queryParams,
+                            ListTableDetailsResponse.class,
+                            restAuthFunction);
+            if (Objects.nonNull(response) && Objects.nonNull(response.getTableDetails())) {
+                return new PagedList<>(
+                        response.getTableDetails().stream()
+                                .map(
+                                        getTableResponse -> {
+                                            Identifier identifier =
+                                                    Identifier.create(
+                                                            databaseName,
+                                                            getTableResponse.getName());
+                                            try {
+                                                return CatalogUtils.loadTable(
+                                                        this,
+                                                        identifier,
+                                                        path -> fileIOForData(path, identifier),
+                                                        this::fileIOFromOptions,
+                                                        tableIdentifier -> {
+                                                            TableSchema schema =
+                                                                    TableSchema.create(
+                                                                            getTableResponse
+                                                                                    .getSchemaId(),
+                                                                            getTableResponse
+                                                                                    .getSchema());
+                                                            return new TableMetadata(
+                                                                    schema,
+                                                                    getTableResponse.isExternal(),
+                                                                    getTableResponse.getId());
+                                                        },
+                                                        null,
+                                                        null);
+                                            } catch (TableNotExistException e) {
+                                                LOG.error("Failed to load table {}", identifier, e);
+                                                throw new RuntimeException(e);
+                                            }
+                                        })
+                                .collect(Collectors.toList()),
+                        response.getNextPageToken());
+            } else {
+                LOG.warn(
+                        "response of listTableDetailsPaged for {} is null with maxResults {} and pageToken {}",
+                        databaseName,
+                        maxResults,
+                        pageToken);
+                return new PagedList<>(Collections.emptyList(), null);
+            }
         } catch (NoSuchResourceException e) {
             throw new DatabaseNotExistException(databaseName);
         }
@@ -558,16 +688,34 @@ public class RESTCatalog implements Catalog, SupportsSnapshots {
     @Override
     public List<Partition> listPartitions(Identifier identifier) throws TableNotExistException {
         try {
-            ListPartitionsResponse response =
-                    client.get(
-                            resourcePaths.partitions(
-                                    identifier.getDatabaseName(), identifier.getTableName()),
-                            ListPartitionsResponse.class,
-                            restAuthFunction);
-            if (response == null || response.getPartitions() == null) {
-                return Collections.emptyList();
+            String pageToken = null;
+            Map<String, String> queryParams = Maps.newHashMap();
+            Integer maxResults = context.options().get(RESTCatalogOptions.REST_PAGE_MAX_RESULTS);
+            if (Objects.nonNull(maxResults) && maxResults > 0) {
+                queryParams.put(MAX_RESULTS, String.valueOf(maxResults));
             }
-            return response.getPartitions();
+            List<Partition> partitions = new ArrayList<>();
+            do {
+                queryParams.put(PAGE_TOKEN, pageToken);
+                ListPartitionsResponse response =
+                        client.get(
+                                resourcePaths.partitions(
+                                        identifier.getDatabaseName(), identifier.getTableName()),
+                                queryParams,
+                                ListPartitionsResponse.class,
+                                restAuthFunction);
+                if (Objects.nonNull(response)) {
+                    pageToken = response.getNextPageToken();
+                    partitions.addAll(response.getPartitions());
+                } else {
+                    LOG.warn(
+                            "response of listPartitions for {}.{} is null with params {}",
+                            identifier.getDatabaseName(),
+                            identifier.getTableName(),
+                            queryParams);
+                }
+            } while (pageToken != null);
+            return partitions;
         } catch (NoSuchResourceException e) {
             throw new TableNotExistException(identifier);
         } catch (ForbiddenException e) {
@@ -575,6 +723,41 @@ public class RESTCatalog implements Catalog, SupportsSnapshots {
         } catch (NotImplementedException e) {
             // not a metastore partitioned table
             return listPartitionsFromFileSystem(getTable(identifier));
+        }
+    }
+
+    @Override
+    public PagedList<Partition> listPartitionsPaged(
+            Identifier identifier, Integer maxResults, String pageToken)
+            throws TableNotExistException {
+        Map<String, String> queryParams = Maps.newHashMap();
+        if (Objects.nonNull(maxResults) && maxResults > 0) {
+            queryParams.put(MAX_RESULTS, maxResults.toString());
+        }
+        if (Objects.nonNull(pageToken)) {
+            queryParams.put(PAGE_TOKEN, pageToken);
+        }
+        try {
+            ListPartitionsResponse response =
+                    client.get(
+                            resourcePaths.partitions(
+                                    identifier.getDatabaseName(), identifier.getTableName()),
+                            queryParams,
+                            ListPartitionsResponse.class,
+                            restAuthFunction);
+            if (Objects.nonNull(response)) {
+                return new PagedList<>(response.getPartitions(), response.getNextPageToken());
+            } else {
+                return new PagedList<>(Collections.emptyList(), null);
+            }
+
+        } catch (NoSuchResourceException e) {
+            throw new TableNotExistException(identifier);
+        } catch (ForbiddenException e) {
+            throw new TableNoPermissionException(identifier, e);
+        } catch (NotImplementedException e) {
+            // not a metastore partitioned table
+            return new PagedList<>(listPartitionsFromFileSystem(getTable(identifier)), null);
         }
     }
 
@@ -641,12 +824,113 @@ public class RESTCatalog implements Catalog, SupportsSnapshots {
     @Override
     public List<String> listViews(String databaseName) throws DatabaseNotExistException {
         try {
+            String pageToken = null;
+            Map<String, String> queryParams = Maps.newHashMap();
+            Integer maxResults = context.options().get(RESTCatalogOptions.REST_PAGE_MAX_RESULTS);
+            if (maxResults != null) {
+                queryParams.put(MAX_RESULTS, String.valueOf(maxResults));
+            }
+            List<String> views = new ArrayList<>();
+            do {
+                queryParams.put(PAGE_TOKEN, pageToken);
+                ListViewsResponse response =
+                        client.get(
+                                resourcePaths.views(databaseName),
+                                queryParams,
+                                ListViewsResponse.class,
+                                restAuthFunction);
+                if (Objects.nonNull(response)) {
+                    pageToken = response.getNextPageToken();
+                    views.addAll(response.getViews());
+                } else {
+                    LOG.warn(
+                            "response of listViews for {} is null with params {}",
+                            databaseName,
+                            queryParams);
+                }
+            } while (pageToken != null);
+            return views;
+        } catch (NoSuchResourceException e) {
+            throw new DatabaseNotExistException(databaseName);
+        }
+    }
+
+    @Override
+    public PagedList<String> listViewsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        Map<String, String> queryParams = Maps.newHashMap();
+        if (Objects.nonNull(maxResults) && maxResults > 0) {
+            queryParams.put(MAX_RESULTS, maxResults.toString());
+        }
+        if (Objects.nonNull(pageToken)) {
+            queryParams.put(PAGE_TOKEN, pageToken);
+        }
+        try {
             ListViewsResponse response =
                     client.get(
                             resourcePaths.views(databaseName),
+                            queryParams,
                             ListViewsResponse.class,
                             restAuthFunction);
-            return response.getViews();
+            if (Objects.nonNull(response) && Objects.nonNull(response.getViews())) {
+                return new PagedList<>(response.getViews(), response.getNextPageToken());
+            } else {
+                LOG.warn(
+                        "response of listViewsPaged for {} is null with maxResults {} and pageToken {}",
+                        databaseName,
+                        maxResults,
+                        pageToken);
+                return new PagedList<>(Collections.emptyList(), null);
+            }
+        } catch (NoSuchResourceException e) {
+            throw new DatabaseNotExistException(databaseName);
+        }
+    }
+
+    @Override
+    public PagedList<View> listViewDetailsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        Map<String, String> queryParams = Maps.newHashMap();
+        if (Objects.nonNull(maxResults) && maxResults > 0) {
+            queryParams.put(MAX_RESULTS, maxResults.toString());
+        }
+        if (Objects.nonNull(pageToken)) {
+            queryParams.put(PAGE_TOKEN, pageToken);
+        }
+        try {
+            ListViewDetailsResponse response =
+                    client.get(
+                            resourcePaths.viewDetails(databaseName),
+                            queryParams,
+                            ListViewDetailsResponse.class,
+                            restAuthFunction);
+            if (Objects.nonNull(response) && Objects.nonNull(response.getViewDetails())) {
+                return new PagedList<>(
+                        response.getViewDetails().stream()
+                                .map(
+                                        viewResponse -> {
+                                            ViewSchema schema = viewResponse.getSchema();
+                                            return new ViewImpl(
+                                                    Identifier.create(
+                                                            databaseName, viewResponse.getName()),
+                                                    schema.fields(),
+                                                    schema.query(),
+                                                    schema.dialects(),
+                                                    schema.comment(),
+                                                    schema.options());
+                                        })
+                                .collect(Collectors.toList()),
+                        response.getNextPageToken());
+            } else {
+                LOG.warn(
+                        "response of listViewDetailsPaged for {} is null with maxResults {} and pageToken {}",
+                        databaseName,
+                        maxResults,
+                        pageToken);
+                return new PagedList<>(Collections.emptyList(), null);
+            }
         } catch (NoSuchResourceException e) {
             throw new DatabaseNotExistException(databaseName);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
@@ -79,4 +79,10 @@ public class RESTCatalogOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Whether to support data token provided by the REST server.");
+
+    public static final ConfigOption<Integer> REST_PAGE_MAX_RESULTS =
+            ConfigOptions.key("rest.page.max.results")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription("the page size of each paged listing request in rest catalog");
 }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTClient.java
@@ -21,12 +21,19 @@ package org.apache.paimon.rest;
 import org.apache.paimon.rest.auth.RESTAuthFunction;
 
 import java.io.Closeable;
+import java.util.Map;
 
 /** Interface for a basic HTTP Client for interfacing with the REST catalog. */
 public interface RESTClient extends Closeable {
 
     <T extends RESTResponse> T get(
             String path, Class<T> responseType, RESTAuthFunction restAuthFunction);
+
+    <T extends RESTResponse> T get(
+            String path,
+            Map<String, String> queryParams,
+            Class<T> responseType,
+            RESTAuthFunction restAuthFunction);
 
     <T extends RESTResponse> T post(
             String path, RESTRequest body, RESTAuthFunction restAuthFunction);

--- a/paimon-core/src/main/java/org/apache/paimon/rest/ResourcePaths.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/ResourcePaths.java
@@ -29,6 +29,8 @@ public class ResourcePaths {
     private static final String V1 = "/v1";
     private static final String DATABASES = "databases";
     private static final String TABLES = "tables";
+    private static final String TABLE_DETAILS = "table-details";
+    private static final String VIEW_DETAILS = "view-details";
     public static final String QUERY_PARAMETER_WAREHOUSE_KEY = "warehouse";
 
     public static String config(String warehouse) {
@@ -59,6 +61,10 @@ public class ResourcePaths {
 
     public String tables(String databaseName) {
         return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES);
+    }
+
+    public String tableDetails(String databaseName) {
+        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLE_DETAILS);
     }
 
     public String table(String databaseName, String tableName) {
@@ -102,6 +108,10 @@ public class ResourcePaths {
 
     public String views(String databaseName) {
         return SLASH.join(V1, prefix, DATABASES, databaseName, "views");
+    }
+
+    public String viewDetails(String databaseName) {
+        return SLASH.join(V1, prefix, DATABASES, databaseName, VIEW_DETAILS);
     }
 
     public String view(String databaseName, String viewName) {

--- a/paimon-core/src/main/java/org/apache/paimon/rest/responses/ListPartitionsResponse.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/responses/ListPartitionsResponse.java
@@ -34,16 +34,33 @@ public class ListPartitionsResponse implements RESTResponse {
 
     public static final String FIELD_PARTITIONS = "partitions";
 
+    private static final String FIELD_NEXT_PAGE_TOKEN = "nextPageToken";
+
     @JsonProperty(FIELD_PARTITIONS)
     private final List<Partition> partitions;
 
-    @JsonCreator
+    @JsonProperty(FIELD_NEXT_PAGE_TOKEN)
+    private final String nextPageToken;
+
     public ListPartitionsResponse(@JsonProperty(FIELD_PARTITIONS) List<Partition> partitions) {
+        this(partitions, null);
+    }
+
+    @JsonCreator
+    public ListPartitionsResponse(
+            @JsonProperty(FIELD_PARTITIONS) List<Partition> partitions,
+            @JsonProperty(FIELD_NEXT_PAGE_TOKEN) String nextPageToken) {
         this.partitions = partitions;
+        this.nextPageToken = nextPageToken;
     }
 
     @JsonGetter(FIELD_PARTITIONS)
     public List<Partition> getPartitions() {
         return partitions;
+    }
+
+    @JsonGetter(FIELD_NEXT_PAGE_TOKEN)
+    public String getNextPageToken() {
+        return this.nextPageToken;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/responses/ListTableDetailsResponse.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/responses/ListTableDetailsResponse.java
@@ -27,34 +27,35 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonPro
 
 import java.util.List;
 
-/** Response for listing tables. */
+/** Response for listing table details. */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ListTablesResponse implements RESTResponse {
+public class ListTableDetailsResponse implements RESTResponse {
 
-    private static final String FIELD_TABLES = "tables";
+    private static final String FIELD_TABLE_DETAILS = "tableDetails";
     private static final String FIELD_NEXT_PAGE_TOKEN = "nextPageToken";
 
-    @JsonProperty(FIELD_TABLES)
-    private final List<String> tables;
+    @JsonProperty(FIELD_TABLE_DETAILS)
+    private final List<GetTableResponse> tableDetails;
 
     @JsonProperty(FIELD_NEXT_PAGE_TOKEN)
     private final String nextPageToken;
 
-    public ListTablesResponse(@JsonProperty(FIELD_TABLES) List<String> tables) {
-        this(tables, null);
+    public ListTableDetailsResponse(
+            @JsonProperty(FIELD_TABLE_DETAILS) List<GetTableResponse> tableDetails) {
+        this(tableDetails, null);
     }
 
     @JsonCreator
-    public ListTablesResponse(
-            @JsonProperty(FIELD_TABLES) List<String> tables,
+    public ListTableDetailsResponse(
+            @JsonProperty(FIELD_TABLE_DETAILS) List<GetTableResponse> tableDetails,
             @JsonProperty(FIELD_NEXT_PAGE_TOKEN) String nextPageToken) {
-        this.tables = tables;
+        this.tableDetails = tableDetails;
         this.nextPageToken = nextPageToken;
     }
 
-    @JsonGetter(FIELD_TABLES)
-    public List<String> getTables() {
-        return this.tables;
+    @JsonGetter(FIELD_TABLE_DETAILS)
+    public List<GetTableResponse> getTableDetails() {
+        return this.tableDetails;
     }
 
     @JsonGetter(FIELD_NEXT_PAGE_TOKEN)

--- a/paimon-core/src/main/java/org/apache/paimon/rest/responses/ListViewDetailsResponse.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/responses/ListViewDetailsResponse.java
@@ -27,34 +27,35 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonPro
 
 import java.util.List;
 
-/** Response for listing tables. */
+/** Response for listing view details. */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ListTablesResponse implements RESTResponse {
+public class ListViewDetailsResponse implements RESTResponse {
 
-    private static final String FIELD_TABLES = "tables";
+    private static final String FIELD_VIEW_DETAILS = "viewDetails";
     private static final String FIELD_NEXT_PAGE_TOKEN = "nextPageToken";
 
-    @JsonProperty(FIELD_TABLES)
-    private final List<String> tables;
+    @JsonProperty(FIELD_VIEW_DETAILS)
+    private final List<GetViewResponse> viewDetails;
 
     @JsonProperty(FIELD_NEXT_PAGE_TOKEN)
     private final String nextPageToken;
 
-    public ListTablesResponse(@JsonProperty(FIELD_TABLES) List<String> tables) {
-        this(tables, null);
+    public ListViewDetailsResponse(
+            @JsonProperty(FIELD_VIEW_DETAILS) List<GetViewResponse> viewDetails) {
+        this(viewDetails, null);
     }
 
     @JsonCreator
-    public ListTablesResponse(
-            @JsonProperty(FIELD_TABLES) List<String> tables,
+    public ListViewDetailsResponse(
+            @JsonProperty(FIELD_VIEW_DETAILS) List<GetViewResponse> viewDetails,
             @JsonProperty(FIELD_NEXT_PAGE_TOKEN) String nextPageToken) {
-        this.tables = tables;
+        this.viewDetails = viewDetails;
         this.nextPageToken = nextPageToken;
     }
 
-    @JsonGetter(FIELD_TABLES)
-    public List<String> getTables() {
-        return this.tables;
+    @JsonGetter(FIELD_VIEW_DETAILS)
+    public List<GetViewResponse> getViewDetails() {
+        return this.viewDetails;
     }
 
     @JsonGetter(FIELD_NEXT_PAGE_TOKEN)

--- a/paimon-core/src/main/java/org/apache/paimon/rest/responses/ListViewsResponse.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/responses/ListViewsResponse.java
@@ -27,22 +27,39 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonPro
 
 import java.util.List;
 
-/** Response for listing tables. */
+/** Response for listing views. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ListViewsResponse implements RESTResponse {
 
     private static final String FIELD_VIEWS = "views";
 
+    private static final String FIELD_NEXT_PAGE_TOKEN = "nextPageToken";
+
     @JsonProperty(FIELD_VIEWS)
     private final List<String> views;
 
-    @JsonCreator
+    @JsonProperty(FIELD_NEXT_PAGE_TOKEN)
+    private final String nextPageToken;
+
     public ListViewsResponse(@JsonProperty(FIELD_VIEWS) List<String> views) {
+        this(views, null);
+    }
+
+    @JsonCreator
+    public ListViewsResponse(
+            @JsonProperty(FIELD_VIEWS) List<String> views,
+            @JsonProperty(FIELD_NEXT_PAGE_TOKEN) String nextPageToken) {
         this.views = views;
+        this.nextPageToken = nextPageToken;
     }
 
     @JsonGetter(FIELD_VIEWS)
     public List<String> getViews() {
         return this.views;
+    }
+
+    @JsonGetter(FIELD_NEXT_PAGE_TOKEN)
+    public String getNextPageToken() {
+        return this.nextPageToken;
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.PagedList;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.ResolvingFileIO;
 import org.apache.paimon.options.CatalogOptions;
@@ -26,6 +27,7 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FormatTable;
 import org.apache.paimon.table.Table;
@@ -64,6 +66,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /** Base test class of paimon catalog in {@link Catalog}. */
 public abstract class CatalogTestBase {
@@ -257,6 +260,102 @@ public abstract class CatalogTestBase {
         // List tables throws DatabaseNotExistException when the database does not exist
         assertThatExceptionOfType(Catalog.DatabaseNotExistException.class)
                 .isThrownBy(() -> catalog.listTables("non_existing_db"));
+    }
+
+    @Test
+    public void testListTablesPaged() throws Exception {
+        // List tables paged returns an empty list when there are no tables in the database
+        String databaseName = "tables_paged_db";
+        catalog.createDatabase(databaseName, false);
+        PagedList<String> pagedTables = catalog.listTablesPaged(databaseName, null, null);
+        assertThat(pagedTables.getPagedLists()).isEmpty();
+        assertNull(pagedTables.getNextPageToken());
+
+        String[] tableNames = {"table1", "table2", "table3", "abd", "def", "opr"};
+        for (String tableName : tableNames) {
+            catalog.createTable(
+                    Identifier.create(databaseName, tableName), DEFAULT_TABLE_SCHEMA, false);
+        }
+
+        // List tables paged returns a list with the names of all tables in the database in all
+        // catalogs except RestCatalog
+        // even if the maxResults or pageToken is not null
+        pagedTables = catalog.listTablesPaged(databaseName, null, null);
+        assertPagedTables(pagedTables, tableNames);
+
+        int maxResults = 2;
+        pagedTables = catalog.listTablesPaged(databaseName, maxResults, null);
+        assertPagedTables(pagedTables, tableNames);
+
+        String pageToken = "table1";
+        pagedTables = catalog.listTablesPaged(databaseName, maxResults, pageToken);
+        assertPagedTables(pagedTables, tableNames);
+
+        maxResults = 8;
+        pagedTables = catalog.listTablesPaged(databaseName, maxResults, null);
+        assertPagedTables(pagedTables, tableNames);
+
+        pagedTables = catalog.listTablesPaged(databaseName, maxResults, pageToken);
+        assertPagedTables(pagedTables, tableNames);
+
+        // List tables throws DatabaseNotExistException when the database does not exist
+        final int finalMaxResults = maxResults;
+        assertThatExceptionOfType(Catalog.DatabaseNotExistException.class)
+                .isThrownBy(
+                        () ->
+                                catalog.listTablesPaged(
+                                        "non_existing_db", finalMaxResults, pageToken));
+    }
+
+    @Test
+    public void testListTableDetailsPaged() throws Exception {
+        // List table details returns an empty list when there are no tables in the database
+        String databaseName = "table_details_paged_db";
+        catalog.createDatabase(databaseName, false);
+        PagedList<Table> pagedTableDetails =
+                catalog.listTableDetailsPaged(databaseName, null, null);
+        assertThat(pagedTableDetails.getPagedLists()).isEmpty();
+        assertNull(pagedTableDetails.getNextPageToken());
+
+        // List table details paged returns a list with all table in the database in all catalogs
+        // except RestCatalog
+        // even if the maxResults or pageToken is not null
+        String[] tableNames = {"table1", "table2", "table3", "abd", "def", "opr"};
+        for (String tableName : tableNames) {
+            catalog.createTable(
+                    Identifier.create(databaseName, tableName), DEFAULT_TABLE_SCHEMA, false);
+        }
+
+        pagedTableDetails = catalog.listTableDetailsPaged(databaseName, null, null);
+        assertPagedTableDetails(pagedTableDetails, tableNames.length, tableNames);
+        assertNull(pagedTableDetails.getNextPageToken());
+
+        int maxResults = 2;
+        pagedTableDetails = catalog.listTableDetailsPaged(databaseName, maxResults, null);
+        assertPagedTableDetails(pagedTableDetails, tableNames.length, tableNames);
+        assertNull(pagedTableDetails.getNextPageToken());
+
+        String pageToken = "table1";
+        pagedTableDetails = catalog.listTableDetailsPaged(databaseName, maxResults, pageToken);
+        assertPagedTableDetails(pagedTableDetails, tableNames.length, tableNames);
+        assertNull(pagedTableDetails.getNextPageToken());
+
+        maxResults = 8;
+        pagedTableDetails = catalog.listTableDetailsPaged(databaseName, maxResults, null);
+        assertPagedTableDetails(pagedTableDetails, tableNames.length, tableNames);
+        assertNull(pagedTableDetails.getNextPageToken());
+
+        pagedTableDetails = catalog.listTableDetailsPaged(databaseName, maxResults, pageToken);
+        assertPagedTableDetails(pagedTableDetails, tableNames.length, tableNames);
+        assertNull(pagedTableDetails.getNextPageToken());
+
+        // List table details throws DatabaseNotExistException when the database does not exist
+        final int finalMaxResults = maxResults;
+        assertThatExceptionOfType(Catalog.DatabaseNotExistException.class)
+                .isThrownBy(
+                        () ->
+                                catalog.listTableDetailsPaged(
+                                        "non_existing_db", finalMaxResults, pageToken));
     }
 
     @Test
@@ -985,6 +1084,110 @@ public abstract class CatalogTestBase {
     }
 
     @Test
+    public void testListViewsPaged() throws Exception {
+        if (!supportsView()) {
+            return;
+        }
+
+        // List views returns an empty list when there are no views in the database
+        String databaseName = "views_paged_db";
+        catalog.createDatabase(databaseName, false);
+        PagedList<String> pagedViews = catalog.listViewsPaged(databaseName, null, null);
+        assertThat(pagedViews.getPagedLists()).isEmpty();
+        assertNull(pagedViews.getNextPageToken());
+
+        // List views paged returns a list with the names of all views in the database in all
+        // catalogs except RestCatalog
+        // even if the maxResults or pageToken is not null
+        View view = buildView(databaseName);
+        String[] viewNames = {"view1", "view2", "view3", "abd", "def", "opr"};
+        for (String viewName : viewNames) {
+            catalog.createView(Identifier.create(databaseName, viewName), view, false);
+        }
+
+        pagedViews = catalog.listViewsPaged(databaseName, null, null);
+        assertPagedViews(pagedViews, viewNames);
+
+        int maxResults = 2;
+        pagedViews = catalog.listViewsPaged(databaseName, maxResults, null);
+        assertPagedViews(pagedViews, viewNames);
+
+        String pageToken = "view1";
+        pagedViews = catalog.listViewsPaged(databaseName, maxResults, pageToken);
+        assertPagedViews(pagedViews, viewNames);
+
+        maxResults = 8;
+        pagedViews = catalog.listViewsPaged(databaseName, maxResults, null);
+        assertPagedViews(pagedViews, viewNames);
+
+        pagedViews = catalog.listViewsPaged(databaseName, maxResults, pageToken);
+        assertPagedViews(pagedViews, viewNames);
+
+        // List views throws DatabaseNotExistException when the database does not exist
+        final int finalMaxResults = maxResults;
+        assertThatExceptionOfType(Catalog.DatabaseNotExistException.class)
+                .isThrownBy(
+                        () ->
+                                catalog.listViewsPaged(
+                                        "non_existing_db", finalMaxResults, pageToken));
+    }
+
+    @Test
+    public void testListViewDetailsPaged() throws Exception {
+        if (!supportsView()) {
+            return;
+        }
+
+        // List views returns an empty list when there are no views in the database
+        String databaseName = "view_details_paged_db";
+        catalog.createDatabase(databaseName, false);
+        PagedList<View> pagedViewDetailsPaged =
+                catalog.listViewDetailsPaged(databaseName, null, null);
+        assertThat(pagedViewDetailsPaged.getPagedLists()).isEmpty();
+        assertNull(pagedViewDetailsPaged.getNextPageToken());
+
+        // List view details paged returns a list with all view in the database in all catalogs
+        // except RestCatalog
+        // even if the maxResults or pageToken is not null
+        View view = buildView(databaseName);
+        String[] viewNames = {"view1", "view2", "view3", "abd", "def", "opr"};
+        for (String viewName : viewNames) {
+            catalog.createView(Identifier.create(databaseName, viewName), view, false);
+        }
+
+        pagedViewDetailsPaged = catalog.listViewDetailsPaged(databaseName, null, null);
+        assertPagedViewDetails(pagedViewDetailsPaged, view, viewNames.length, viewNames);
+        assertNull(pagedViewDetailsPaged.getNextPageToken());
+
+        int maxResults = 2;
+        pagedViewDetailsPaged = catalog.listViewDetailsPaged(databaseName, maxResults, null);
+        assertPagedViewDetails(pagedViewDetailsPaged, view, viewNames.length, viewNames);
+        assertNull(pagedViewDetailsPaged.getNextPageToken());
+
+        String pageToken = "view1";
+        pagedViewDetailsPaged = catalog.listViewDetailsPaged(databaseName, maxResults, pageToken);
+        assertPagedViewDetails(pagedViewDetailsPaged, view, viewNames.length, viewNames);
+        assertNull(pagedViewDetailsPaged.getNextPageToken());
+
+        maxResults = 8;
+        pagedViewDetailsPaged = catalog.listViewDetailsPaged(databaseName, maxResults, null);
+        assertPagedViewDetails(pagedViewDetailsPaged, view, viewNames.length, viewNames);
+        assertNull(pagedViewDetailsPaged.getNextPageToken());
+
+        pagedViewDetailsPaged = catalog.listViewDetailsPaged(databaseName, maxResults, pageToken);
+        assertPagedViewDetails(pagedViewDetailsPaged, view, viewNames.length, viewNames);
+        assertNull(pagedViewDetailsPaged.getNextPageToken());
+
+        // List view details throws DatabaseNotExistException when the database does not exist
+        final int finalMaxResults = maxResults;
+        assertThatExceptionOfType(Catalog.DatabaseNotExistException.class)
+                .isThrownBy(
+                        () ->
+                                catalog.listViewDetailsPaged(
+                                        "non_existing_db", finalMaxResults, pageToken));
+    }
+
+    @Test
     public void testFormatTable() throws Exception {
         if (!supportsFormatTable()) {
             return;
@@ -1092,6 +1295,69 @@ public abstract class CatalogTestBase {
     }
 
     @Test
+    public void testListPartitionsPaged() throws Exception {
+        if (!supportPartitions()) {
+            return;
+        }
+        String databaseName = "partitions_paged_db";
+        List<Map<String, String>> partitionSpecs =
+                Arrays.asList(
+                        Collections.singletonMap("dt", "20250101"),
+                        Collections.singletonMap("dt", "20250102"),
+                        Collections.singletonMap("dt", "20240102"),
+                        Collections.singletonMap("dt", "20260101"),
+                        Collections.singletonMap("dt", "20250104"),
+                        Collections.singletonMap("dt", "20250103"));
+        catalog.dropDatabase(databaseName, true, true);
+        catalog.createDatabase(databaseName, true);
+        Identifier identifier = Identifier.create(databaseName, "table");
+        catalog.createTable(
+                identifier,
+                Schema.newBuilder()
+                        .option(METASTORE_PARTITIONED_TABLE.key(), "true")
+                        .option(METASTORE_TAG_TO_PARTITION.key(), "dt")
+                        .column("col", DataTypes.INT())
+                        .column("dt", DataTypes.STRING())
+                        .partitionKeys("dt")
+                        .build(),
+                true);
+
+        catalog.createPartitions(identifier, partitionSpecs);
+
+        // List partitions paged returns a list with all partitions of the table in all catalogs
+        // except RestCatalog even
+        // if the maxResults or pageToken is not null
+        PagedList<Partition> pagedPartitions = catalog.listPartitionsPaged(identifier, null, null);
+        Map[] specs = partitionSpecs.toArray(new Map[0]);
+        assertPagedPartitions(pagedPartitions, specs.length, specs);
+
+        int maxResults = 2;
+        pagedPartitions = catalog.listPartitionsPaged(identifier, maxResults, null);
+        assertPagedPartitions(pagedPartitions, specs.length, specs);
+
+        String pageToken = "dt=20250101";
+        pagedPartitions = catalog.listPartitionsPaged(identifier, maxResults, pageToken);
+        assertPagedPartitions(pagedPartitions, specs.length, specs);
+
+        maxResults = 8;
+        pagedPartitions = catalog.listPartitionsPaged(identifier, maxResults, null);
+        assertPagedPartitions(pagedPartitions, specs.length, specs);
+
+        pagedPartitions = catalog.listPartitionsPaged(identifier, maxResults, pageToken);
+        assertPagedPartitions(pagedPartitions, specs.length, specs);
+
+        // List partitions throws TableNotExistException when the table does not exist
+        final int finalMaxResults = maxResults;
+        assertThatExceptionOfType(Catalog.TableNotExistException.class)
+                .isThrownBy(
+                        () ->
+                                catalog.listPartitionsPaged(
+                                        Identifier.create(databaseName, "non_existing_table"),
+                                        finalMaxResults,
+                                        pageToken));
+    }
+
+    @Test
     public void testAlterPartitions() throws Exception {
         if (!supportPartitions()) {
             return;
@@ -1156,5 +1422,151 @@ public abstract class CatalogTestBase {
 
     protected boolean supportPartitions() {
         return false;
+    }
+
+    protected boolean supportPagedList() {
+        return false;
+    }
+
+    private void assertPagedTables(PagedList<String> tablePagedList, String... tableNames) {
+        List<String> tables = tablePagedList.getPagedLists();
+        if (supportPagedList()) {
+            assertThat(tables).containsExactly(tableNames);
+        } else {
+            assertThat(tables).containsExactlyInAnyOrder(tableNames);
+        }
+        assertNull(tablePagedList.getNextPageToken());
+    }
+
+    protected void assertPagedTableDetails(
+            PagedList<Table> tableDetailsPagedList, int size, String... tableNames) {
+        List<Table> tableDetails = tableDetailsPagedList.getPagedLists();
+        assertEquals(size, tableDetails.size());
+        if (supportPagedList()) {
+            assertThat(tableDetails.stream().map(Table::name).collect(Collectors.toList()))
+                    .containsExactly(tableNames);
+        } else {
+            assertThat(tableDetails.stream().map(Table::name).collect(Collectors.toList()))
+                    .containsExactlyInAnyOrder(tableNames);
+        }
+        List<Schema> schemas =
+                tableDetails.stream()
+                        .filter(table -> table instanceof FileStoreTable)
+                        .map(table -> (FileStoreTable) table)
+                        .map(FileStoreTable::schema)
+                        .map(TableSchema::toSchema)
+                        .collect(Collectors.toList());
+        assertThat(
+                        schemas.stream()
+                                .map(Schema::fields)
+                                .allMatch(fields -> DEFAULT_TABLE_SCHEMA.fields().equals(fields)))
+                .isTrue();
+        assertThat(
+                        schemas.stream()
+                                .map(Schema::partitionKeys)
+                                .allMatch(
+                                        partitionKeys ->
+                                                DEFAULT_TABLE_SCHEMA
+                                                        .partitionKeys()
+                                                        .equals(partitionKeys)))
+                .isTrue();
+        assertThat(
+                        schemas.stream()
+                                .map(Schema::primaryKeys)
+                                .allMatch(
+                                        primaryKeys ->
+                                                DEFAULT_TABLE_SCHEMA
+                                                        .primaryKeys()
+                                                        .equals(primaryKeys)))
+                .isTrue();
+        assertThat(
+                        schemas.stream()
+                                .map(Schema::options)
+                                .allMatch(
+                                        options ->
+                                                DEFAULT_TABLE_SCHEMA.options().size()
+                                                        <= options.size()))
+                .isTrue(); // output schema has path
+        assertThat(
+                        schemas.stream()
+                                .map(Schema::comment)
+                                .allMatch(
+                                        comment -> DEFAULT_TABLE_SCHEMA.comment().equals(comment)))
+                .isTrue();
+    }
+
+    protected View buildView(String databaseName) {
+        Identifier identifier = new Identifier(databaseName, "my_view");
+        RowType rowType = RowType.builder().field("str", DataTypes.STRING()).build();
+        String query = "SELECT * FROM OTHER_TABLE";
+
+        Map<String, String> dialects = new HashMap<>();
+        if (supportsViewDialects()) {
+            dialects.put("spark", "SELECT * FROM SPARK_TABLE");
+        }
+        return new ViewImpl(
+                identifier, rowType.getFields(), query, dialects, null, new HashMap<>());
+    }
+
+    protected void assertPagedViews(PagedList<String> viewPagedList, String... viewNames) {
+        List<String> views = viewPagedList.getPagedLists();
+        if (supportPagedList()) {
+            assertThat(views).containsExactly(viewNames);
+        } else {
+            assertThat(views).containsExactlyInAnyOrder(viewNames);
+        }
+    }
+
+    protected void assertPagedViewDetails(
+            PagedList<View> viewDetailsPagedList, View view, int size, String... viewNames) {
+        List<View> viewDetails = viewDetailsPagedList.getPagedLists();
+        assertEquals(size, viewDetails.size());
+        if (supportPagedList()) {
+            assertThat(viewDetails.stream().map(View::name).collect(Collectors.toList()))
+                    .containsExactlyInAnyOrder(viewNames);
+        } else {
+            assertThat(viewDetails.stream().map(View::name).collect(Collectors.toList()))
+                    .containsExactlyInAnyOrder(viewNames);
+        }
+        assertThat(
+                        viewDetails.stream()
+                                .map(View::rowType)
+                                .allMatch(rowType -> view.rowType().equals(rowType)))
+                .isTrue();
+        assertThat(
+                        viewDetails.stream()
+                                .map(View::query)
+                                .allMatch(query -> view.query().equals(query)))
+                .isTrue();
+        assertThat(
+                        viewDetails.stream()
+                                .map(View::dialects)
+                                .allMatch(dialects -> view.dialects().equals(dialects)))
+                .isTrue();
+        assertThat(
+                        viewDetails.stream()
+                                .map(View::comment)
+                                .allMatch(comment -> view.comment().equals(comment)))
+                .isTrue();
+        assertThat(
+                        viewDetails.stream()
+                                .map(View::options)
+                                .allMatch(options -> view.options().size() <= options.size()))
+                .isTrue(); // last ddl time
+    }
+
+    @SafeVarargs
+    protected final void assertPagedPartitions(
+            PagedList<Partition> partitionsPagedList,
+            int size,
+            Map<String, String>... partitionSpecs) {
+        List<Partition> partitions = partitionsPagedList.getPagedLists();
+        assertEquals(size, partitions.size());
+        if (supportPagedList()) {
+            assertThat(partitions.stream().map(Partition::spec)).containsExactly(partitionSpecs);
+        } else {
+            assertThat(partitions.stream().map(Partition::spec))
+                    .containsExactlyInAnyOrder(partitionSpecs);
+        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.rest;
 
+import org.apache.paimon.PagedList;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
@@ -32,8 +33,10 @@ import org.apache.paimon.rest.auth.RESTAuthParameter;
 import org.apache.paimon.rest.exceptions.NotAuthorizedException;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.view.View;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
@@ -43,16 +46,21 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.paimon.CoreOptions.METASTORE_PARTITIONED_TABLE;
+import static org.apache.paimon.CoreOptions.METASTORE_TAG_TO_PARTITION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /** Test for REST Catalog. */
 class RESTCatalogTest extends CatalogTestBase {
@@ -104,6 +112,341 @@ class RESTCatalogTest extends CatalogTestBase {
     }
 
     @Test
+    public void testListTables() throws Exception {
+        super.testListTables();
+
+        String databaseName = "tables_db";
+        Options options = new Options(this.catalog.options());
+        options.set(RESTCatalogOptions.REST_PAGE_MAX_RESULTS, 2);
+        try (RESTCatalog restCatalog = new RESTCatalog(CatalogContext.create(options))) {
+
+            restCatalog.createDatabase(databaseName, false);
+            List<String> restTables = restCatalog.listTables(databaseName);
+            assertThat(restTables).isEmpty();
+
+            // List tables returns a list with the names of all tables in the database
+            String[] tableNames = {"table4", "table5", "table1", "table2", "table3"};
+            for (String tableName : tableNames) {
+                restCatalog.createTable(
+                        Identifier.create(databaseName, tableName), DEFAULT_TABLE_SCHEMA, false);
+            }
+
+            restTables = restCatalog.listTables(databaseName);
+            assertThat(restTables).containsExactlyInAnyOrder(tableNames);
+
+            // List tables throws DatabaseNotExistException when the database does not exist
+            assertThatExceptionOfType(Catalog.DatabaseNotExistException.class)
+                    .isThrownBy(() -> restCatalog.listTables("non_existing_db"));
+        }
+
+        options.set(RESTCatalogOptions.REST_PAGE_MAX_RESULTS.key(), "dummy");
+        try (RESTCatalog dummyCatalog = new RESTCatalog(CatalogContext.create(options))) {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> dummyCatalog.listTables(databaseName));
+        }
+    }
+
+    @Test
+    public void testListTablesPaged() throws Exception {
+        // List tables paged returns an empty list when there are no tables in the database
+        String databaseName = "tables_paged_db";
+        catalog.createDatabase(databaseName, false);
+        PagedList<String> pagedTables = catalog.listTablesPaged(databaseName, null, null);
+        assertThat(pagedTables.getPagedLists()).isEmpty();
+        assertNull(pagedTables.getNextPageToken());
+
+        String[] tableNames = {"table1", "table2", "table3", "abd", "def", "opr"};
+        for (String tableName : tableNames) {
+            catalog.createTable(
+                    Identifier.create(databaseName, tableName), DEFAULT_TABLE_SCHEMA, false);
+        }
+
+        // when maxResults is null or 0, the page length is set to a server configured value
+        pagedTables = catalog.listTablesPaged(databaseName, null, null);
+        List<String> tables = pagedTables.getPagedLists();
+        assertThat(tables).containsExactlyInAnyOrder(tableNames);
+        assertNull(pagedTables.getNextPageToken());
+
+        // when maxResults is greater than 0, the page length is the minimum of this value and a
+        // server configured value
+        // when pageToken is null, will list tables from the beginning
+        int maxResults = 2;
+        pagedTables = catalog.listTablesPaged(databaseName, maxResults, null);
+        tables = pagedTables.getPagedLists();
+        assertEquals(maxResults, tables.size());
+        assertThat(tables).containsExactly("abd", "def");
+        assertEquals("def", pagedTables.getNextPageToken());
+
+        // when pageToken is not null, will list tables from the pageToken (exclusive)
+        pagedTables =
+                catalog.listTablesPaged(databaseName, maxResults, pagedTables.getNextPageToken());
+        tables = pagedTables.getPagedLists();
+        assertEquals(maxResults, tables.size());
+        assertThat(tables).containsExactly("opr", "table1");
+        assertEquals("table1", pagedTables.getNextPageToken());
+
+        pagedTables =
+                catalog.listTablesPaged(databaseName, maxResults, pagedTables.getNextPageToken());
+        tables = pagedTables.getPagedLists();
+        assertEquals(maxResults, tables.size());
+        assertThat(tables).containsExactly("table2", "table3");
+        assertEquals("table3", pagedTables.getNextPageToken());
+
+        pagedTables =
+                catalog.listTablesPaged(databaseName, maxResults, pagedTables.getNextPageToken());
+        tables = pagedTables.getPagedLists();
+        assertEquals(0, tables.size());
+        assertNull(pagedTables.getNextPageToken());
+
+        maxResults = 8;
+        pagedTables = catalog.listTablesPaged(databaseName, maxResults, null);
+        tables = pagedTables.getPagedLists();
+        String[] expectedTableNames = Arrays.stream(tableNames).sorted().toArray(String[]::new);
+        assertThat(tables).containsExactly(expectedTableNames);
+        assertNull(pagedTables.getNextPageToken());
+
+        pagedTables = catalog.listTablesPaged(databaseName, maxResults, "table1");
+        tables = pagedTables.getPagedLists();
+        assertEquals(2, tables.size());
+        assertThat(tables).containsExactly("table2", "table3");
+        assertNull(pagedTables.getNextPageToken());
+
+        // List tables throws DatabaseNotExistException when the database does not exist
+        assertThatExceptionOfType(Catalog.DatabaseNotExistException.class)
+                .isThrownBy(() -> catalog.listTables("non_existing_db"));
+    }
+
+    @Test
+    public void testListTableDetailsPaged() throws Exception {
+        // List table details returns an empty list when there are no tables in the database
+        String databaseName = "table_details_paged_db";
+        catalog.createDatabase(databaseName, false);
+        PagedList<Table> pagedTableDetails =
+                catalog.listTableDetailsPaged(databaseName, null, null);
+        assertThat(pagedTableDetails.getPagedLists()).isEmpty();
+        assertNull(pagedTableDetails.getNextPageToken());
+
+        String[] tableNames = {"table1", "table2", "table3", "abd", "def", "opr"};
+        String[] expectedTableNames = Arrays.stream(tableNames).sorted().toArray(String[]::new);
+        for (String tableName : tableNames) {
+            catalog.createTable(
+                    Identifier.create(databaseName, tableName), DEFAULT_TABLE_SCHEMA, false);
+        }
+
+        pagedTableDetails = catalog.listTableDetailsPaged(databaseName, null, null);
+        assertPagedTableDetails(pagedTableDetails, tableNames.length, expectedTableNames);
+        assertNull(pagedTableDetails.getNextPageToken());
+
+        int maxResults = 2;
+        pagedTableDetails = catalog.listTableDetailsPaged(databaseName, maxResults, null);
+        assertPagedTableDetails(pagedTableDetails, maxResults, "abd", "def");
+        assertEquals("def", pagedTableDetails.getNextPageToken());
+
+        pagedTableDetails =
+                catalog.listTableDetailsPaged(
+                        databaseName, maxResults, pagedTableDetails.getNextPageToken());
+        assertPagedTableDetails(pagedTableDetails, maxResults, "opr", "table1");
+        assertEquals("table1", pagedTableDetails.getNextPageToken());
+
+        pagedTableDetails =
+                catalog.listTableDetailsPaged(
+                        databaseName, maxResults, pagedTableDetails.getNextPageToken());
+        assertPagedTableDetails(pagedTableDetails, maxResults, "table2", "table3");
+        assertEquals("table3", pagedTableDetails.getNextPageToken());
+
+        pagedTableDetails =
+                catalog.listTableDetailsPaged(
+                        databaseName, maxResults, pagedTableDetails.getNextPageToken());
+        assertEquals(0, pagedTableDetails.getPagedLists().size());
+        assertNull(pagedTableDetails.getNextPageToken());
+
+        maxResults = 8;
+        pagedTableDetails = catalog.listTableDetailsPaged(databaseName, maxResults, null);
+        assertPagedTableDetails(
+                pagedTableDetails, Math.min(maxResults, tableNames.length), expectedTableNames);
+        assertNull(pagedTableDetails.getNextPageToken());
+
+        String pageToken = "table1";
+        pagedTableDetails = catalog.listTableDetailsPaged(databaseName, maxResults, pageToken);
+        assertPagedTableDetails(pagedTableDetails, 2, "table2", "table3");
+        assertNull(pagedTableDetails.getNextPageToken());
+
+        // List table details throws DatabaseNotExistException when the database does not exist
+        final int finalMaxResults = maxResults;
+        assertThatExceptionOfType(Catalog.DatabaseNotExistException.class)
+                .isThrownBy(
+                        () ->
+                                catalog.listTableDetailsPaged(
+                                        "non_existing_db", finalMaxResults, pageToken));
+    }
+
+    @Test
+    void testListViews() throws Exception {
+        Options options = new Options(this.catalog.options());
+        options.set(RESTCatalogOptions.REST_PAGE_MAX_RESULTS, 2);
+        String databaseName;
+        List<String> views;
+        String[] viewNames;
+        List<String> restViews;
+        try (RESTCatalog restCatalog = new RESTCatalog(CatalogContext.create(options))) {
+
+            // List tables returns an empty list when there are no tables in the database
+            databaseName = "views_paged_db";
+            restCatalog.createDatabase(databaseName, false);
+            views = restCatalog.listViews(databaseName);
+            assertThat(views).isEmpty();
+
+            View view = buildView(databaseName);
+            viewNames = new String[] {"view1", "view2", "view3", "abd", "def", "opr", "xyz"};
+
+            for (String viewName : viewNames) {
+                restCatalog.createView(Identifier.create(databaseName, viewName), view, false);
+            }
+
+            // when maxResults is null or 0, the page length is set to a server configured value
+            views = restCatalog.listViews(databaseName);
+            restViews = restCatalog.listViews(databaseName);
+        }
+
+        assertThat(views).containsExactlyInAnyOrder(viewNames);
+        assertThat(restViews).containsExactlyInAnyOrder(viewNames);
+
+        options.set(RESTCatalogOptions.REST_PAGE_MAX_RESULTS.key(), "dummy");
+        try (RESTCatalog dummyCatalog = new RESTCatalog(CatalogContext.create(options))) {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> dummyCatalog.listTables(databaseName));
+        }
+    }
+
+    @Test
+    public void testListViewsPaged() throws Exception {
+        if (!supportsView()) {
+            return;
+        }
+
+        // List views returns an empty list when there are no views in the database
+        String databaseName = "views_paged_db";
+        catalog.createDatabase(databaseName, false);
+        PagedList<String> pagedViews = catalog.listViewsPaged(databaseName, null, null);
+        assertThat(pagedViews.getPagedLists()).isEmpty();
+        assertNull(pagedViews.getNextPageToken());
+
+        // List views paged returns a list with the names of all views in the database in all
+        // catalogs except RestCatalog
+        // even if the maxResults or pageToken is not null
+        View view = buildView(databaseName);
+        String[] viewNames = {"view1", "view2", "view3", "abd", "def", "opr"};
+        String[] sortedViewNames = Arrays.stream(viewNames).sorted().toArray(String[]::new);
+        for (String viewName : viewNames) {
+            catalog.createView(Identifier.create(databaseName, viewName), view, false);
+        }
+
+        pagedViews = catalog.listViewsPaged(databaseName, null, null);
+        assertThat(pagedViews.getPagedLists()).containsExactlyInAnyOrder(viewNames);
+        assertNull(pagedViews.getNextPageToken());
+
+        int maxResults = 2;
+        pagedViews = catalog.listViewsPaged(databaseName, maxResults, null);
+        assertPagedViews(pagedViews, "abd", "def");
+        assertEquals("def", pagedViews.getNextPageToken());
+
+        pagedViews =
+                catalog.listViewsPaged(databaseName, maxResults, pagedViews.getNextPageToken());
+        assertPagedViews(pagedViews, "opr", "view1");
+        assertEquals("view1", pagedViews.getNextPageToken());
+
+        pagedViews =
+                catalog.listViewsPaged(databaseName, maxResults, pagedViews.getNextPageToken());
+        assertPagedViews(pagedViews, "view2", "view3");
+        assertEquals("view3", pagedViews.getNextPageToken());
+
+        maxResults = 8;
+        String[] expectedViewNames = Arrays.stream(viewNames).sorted().toArray(String[]::new);
+        pagedViews = catalog.listViewsPaged(databaseName, maxResults, null);
+        assertPagedViews(pagedViews, expectedViewNames);
+        assertNull(pagedViews.getNextPageToken());
+
+        String pageToken = "view1";
+        pagedViews = catalog.listViewsPaged(databaseName, maxResults, pageToken);
+        assertPagedViews(pagedViews, "view2", "view3");
+        assertNull(pagedViews.getNextPageToken());
+
+        // List views throws DatabaseNotExistException when the database does not exist
+        final int finalMaxResults = 9;
+        assertThatExceptionOfType(Catalog.DatabaseNotExistException.class)
+                .isThrownBy(
+                        () ->
+                                catalog.listViewsPaged(
+                                        "non_existing_db", finalMaxResults, pageToken));
+    }
+
+    @Test
+    public void testListViewDetailsPaged() throws Exception {
+        // List view details returns an empty list when there are no views in the database
+        String databaseName = "view_details_paged_db";
+        catalog.createDatabase(databaseName, false);
+        PagedList<View> pagedViewDetails = catalog.listViewDetailsPaged(databaseName, null, null);
+        assertThat(pagedViewDetails.getPagedLists()).isEmpty();
+        assertNull(pagedViewDetails.getNextPageToken());
+
+        String[] viewNames = {"view1", "view2", "view3", "abd", "def", "opr"};
+        View view = buildView(databaseName);
+        for (String viewName : viewNames) {
+            catalog.createView(Identifier.create(databaseName, viewName), view, false);
+        }
+
+        pagedViewDetails = catalog.listViewDetailsPaged(databaseName, null, null);
+        assertPagedViewDetails(pagedViewDetails, view, viewNames.length, viewNames);
+        assertNull(pagedViewDetails.getNextPageToken());
+
+        int maxResults = 2;
+        pagedViewDetails = catalog.listViewDetailsPaged(databaseName, maxResults, null);
+        assertPagedViewDetails(pagedViewDetails, view, maxResults, "abd", "def");
+        assertEquals("def", pagedViewDetails.getNextPageToken());
+
+        pagedViewDetails =
+                catalog.listViewDetailsPaged(
+                        databaseName, maxResults, pagedViewDetails.getNextPageToken());
+        assertPagedViewDetails(pagedViewDetails, view, maxResults, "opr", "view1");
+        assertEquals("view1", pagedViewDetails.getNextPageToken());
+
+        pagedViewDetails =
+                catalog.listViewDetailsPaged(
+                        databaseName, maxResults, pagedViewDetails.getNextPageToken());
+        assertPagedViewDetails(pagedViewDetails, view, maxResults, "view2", "view3");
+        assertEquals("view3", pagedViewDetails.getNextPageToken());
+
+        pagedViewDetails =
+                catalog.listViewDetailsPaged(
+                        databaseName, maxResults, pagedViewDetails.getNextPageToken());
+        assertEquals(0, pagedViewDetails.getPagedLists().size());
+        assertNull(pagedViewDetails.getNextPageToken());
+
+        maxResults = 8;
+        pagedViewDetails = catalog.listViewDetailsPaged(databaseName, maxResults, null);
+        String[] expectedViewNames = Arrays.stream(viewNames).sorted().toArray(String[]::new);
+        assertPagedViewDetails(
+                pagedViewDetails,
+                view,
+                Math.min(maxResults, expectedViewNames.length),
+                expectedViewNames);
+        assertNull(pagedViewDetails.getNextPageToken());
+
+        String pageToken = "view1";
+        pagedViewDetails = catalog.listViewDetailsPaged(databaseName, maxResults, pageToken);
+        assertPagedViewDetails(pagedViewDetails, view, 2, "view2", "view3");
+        assertNull(pagedViewDetails.getNextPageToken());
+
+        // List view details throws DatabaseNotExistException when the database does not exist
+        final int finalMaxResults = maxResults;
+        assertThatExceptionOfType(Catalog.DatabaseNotExistException.class)
+                .isThrownBy(
+                        () ->
+                                catalog.listViewDetailsPaged(
+                                        "non_existing_db", finalMaxResults, pageToken));
+    }
+
+    @Test
     void testListPartitionsWhenMetastorePartitionedIsTrue() throws Exception {
         Identifier identifier = Identifier.create("test_db", "test_table");
         createTable(
@@ -120,6 +463,141 @@ class RESTCatalogTest extends CatalogTestBase {
         createTable(identifier, Maps.newHashMap(), Lists.newArrayList("col1"));
         List<Partition> result = catalog.listPartitions(identifier);
         assertEquals(0, result.size());
+    }
+
+    @Test
+    void testListPartitions() throws Exception {
+        Options options = new Options(this.catalog.options());
+        options.set(RESTCatalogOptions.REST_PAGE_MAX_RESULTS, 2);
+        Identifier identifier;
+        try (RESTCatalog restCatalog = new RESTCatalog(CatalogContext.create(options))) {
+
+            String databaseName = "partitions_db";
+            identifier = Identifier.create(databaseName, "table");
+            Schema schema =
+                    Schema.newBuilder()
+                            .option(METASTORE_PARTITIONED_TABLE.key(), "true")
+                            .option(METASTORE_TAG_TO_PARTITION.key(), "dt")
+                            .column("col", DataTypes.INT())
+                            .column("dt", DataTypes.STRING())
+                            .partitionKeys("dt")
+                            .build();
+            List<Map<String, String>> partitionSpecs =
+                    Arrays.asList(
+                            Collections.singletonMap("dt", "20250101"),
+                            Collections.singletonMap("dt", "20250102"),
+                            Collections.singletonMap("dt", "20240102"),
+                            Collections.singletonMap("dt", "20260101"),
+                            Collections.singletonMap("dt", "20250104"),
+                            Collections.singletonMap("dt", "20250103"));
+
+            restCatalog.createDatabase(databaseName, true);
+            restCatalog.createTable(identifier, schema, true);
+            restCatalog.createPartitions(identifier, partitionSpecs);
+
+            List<Partition> restPartitions = restCatalog.listPartitions(identifier);
+            assertThat(restPartitions.stream().map(Partition::spec))
+                    .containsExactlyInAnyOrder(partitionSpecs.toArray(new Map[] {}));
+
+            assertThatExceptionOfType(Catalog.TableNotExistException.class)
+                    .isThrownBy(
+                            () ->
+                                    restCatalog.listPartitions(
+                                            Identifier.create(databaseName, "non_existing_table")));
+        }
+
+        options.set(RESTCatalogOptions.REST_PAGE_MAX_RESULTS.key(), "dummy");
+        try (RESTCatalog dummyCatalog = new RESTCatalog(CatalogContext.create(options))) {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> dummyCatalog.listPartitions(identifier));
+        }
+    }
+
+    @Test
+    public void testListPartitionsPaged() throws Exception {
+        String databaseName = "partitions_paged_db";
+        List<Map<String, String>> partitionSpecs =
+                Arrays.asList(
+                        Collections.singletonMap("dt", "20250101"),
+                        Collections.singletonMap("dt", "20250102"),
+                        Collections.singletonMap("dt", "20240102"),
+                        Collections.singletonMap("dt", "20260101"),
+                        Collections.singletonMap("dt", "20250104"),
+                        Collections.singletonMap("dt", "20250103"));
+        catalog.dropDatabase(databaseName, true, true);
+        catalog.createDatabase(databaseName, true);
+        Identifier identifier = Identifier.create(databaseName, "table");
+        catalog.createTable(
+                identifier,
+                Schema.newBuilder()
+                        .option(METASTORE_PARTITIONED_TABLE.key(), "true")
+                        .option(METASTORE_TAG_TO_PARTITION.key(), "dt")
+                        .column("col", DataTypes.INT())
+                        .column("dt", DataTypes.STRING())
+                        .partitionKeys("dt")
+                        .build(),
+                true);
+
+        catalog.createPartitions(identifier, partitionSpecs);
+        PagedList<Partition> pagedPartitions = catalog.listPartitionsPaged(identifier, null, null);
+        assertPagedPartitions(
+                pagedPartitions, partitionSpecs.size(), partitionSpecs.toArray(new Map[0]));
+
+        int maxResults = 2;
+        pagedPartitions = catalog.listPartitionsPaged(identifier, maxResults, null);
+        assertPagedPartitions(
+                pagedPartitions, maxResults, partitionSpecs.get(2), partitionSpecs.get(0));
+        assertEquals("dt=20250101", pagedPartitions.getNextPageToken());
+
+        pagedPartitions =
+                catalog.listPartitionsPaged(
+                        identifier, maxResults, pagedPartitions.getNextPageToken());
+        assertPagedPartitions(
+                pagedPartitions, maxResults, partitionSpecs.get(1), partitionSpecs.get(5));
+        assertEquals("dt=20250103", pagedPartitions.getNextPageToken());
+
+        pagedPartitions =
+                catalog.listPartitionsPaged(
+                        identifier, maxResults, pagedPartitions.getNextPageToken());
+        assertPagedPartitions(
+                pagedPartitions, maxResults, partitionSpecs.get(4), partitionSpecs.get(3));
+        assertEquals("dt=20260101", pagedPartitions.getNextPageToken());
+
+        pagedPartitions =
+                catalog.listPartitionsPaged(
+                        identifier, maxResults, pagedPartitions.getNextPageToken());
+        assertThat(pagedPartitions.getPagedLists()).isEmpty();
+        assertNull(pagedPartitions.getNextPageToken());
+
+        maxResults = 8;
+        pagedPartitions = catalog.listPartitionsPaged(identifier, maxResults, null);
+        Map[] sortedSpecs =
+                partitionSpecs.stream()
+                        .sorted(Comparator.comparing(i -> i.get("dt")))
+                        .toArray(Map[]::new);
+        assertPagedPartitions(
+                pagedPartitions, Math.min(maxResults, partitionSpecs.size()), sortedSpecs);
+        assertNull(pagedPartitions.getNextPageToken());
+
+        pagedPartitions = catalog.listPartitionsPaged(identifier, maxResults, "dt=20250101");
+        assertPagedPartitions(
+                pagedPartitions,
+                4,
+                partitionSpecs.get(1),
+                partitionSpecs.get(5),
+                partitionSpecs.get(4),
+                partitionSpecs.get(3));
+        assertNull(pagedPartitions.getNextPageToken());
+
+        // List partitions paged throws TableNotExistException when the table does not exist
+        final int finalMaxResults = maxResults;
+        assertThatExceptionOfType(Catalog.TableNotExistException.class)
+                .isThrownBy(
+                        () ->
+                                catalog.listPartitionsPaged(
+                                        Identifier.create(databaseName, "non_existing_table"),
+                                        finalMaxResults,
+                                        "dt=20250101"));
     }
 
     @Test
@@ -172,6 +650,11 @@ class RESTCatalogTest extends CatalogTestBase {
 
     @Override
     protected boolean supportsView() {
+        return true;
+    }
+
+    @Override
+    protected boolean supportPagedList() {
         return true;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/rest/TestRESTCatalog.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/TestRESTCatalog.java
@@ -19,7 +19,9 @@
 package org.apache.paimon.rest;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.PagedList;
 import org.apache.paimon.TableType;
+import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.catalog.FileSystemCatalog;
@@ -32,17 +34,29 @@ import org.apache.paimon.partition.Partition;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.Table;
 import org.apache.paimon.view.View;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
+
+import static org.apache.paimon.rest.RESTCatalogServer.DEFAULT_MAX_RESULTS;
 
 /** A catalog for testing RESTCatalog. */
 public class TestRESTCatalog extends FileSystemCatalog {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractCatalog.class);
 
     public Map<String, TableSchema> tableFullName2Schema = new HashMap<String, TableSchema>();
     public Map<String, List<Partition>> tableFullName2Partitions =
@@ -133,6 +147,44 @@ public class TestRESTCatalog extends FileSystemCatalog {
     }
 
     @Override
+    public PagedList<Partition> listPartitionsPaged(
+            Identifier identifier, Integer maxResults, String pageToken)
+            throws TableNotExistException {
+        getTable(identifier);
+        List<Partition> partitions = tableFullName2Partitions.get(identifier.getFullName());
+        if (Objects.nonNull(partitions)) {
+            List<Partition> sortedPartitions =
+                    partitions.stream()
+                            .sorted(Comparator.comparing(this::getPartitionSortKey))
+                            .collect(Collectors.toList());
+            if (Objects.isNull(maxResults) || maxResults <= 0) {
+                maxResults = DEFAULT_MAX_RESULTS;
+            }
+
+            if ((maxResults > sortedPartitions.size()) && pageToken == null) {
+                return new PagedList<>(sortedPartitions, null);
+            } else {
+                List<Partition> pagedPartitions = new ArrayList<>();
+                for (Partition partition : sortedPartitions) {
+                    if (pagedPartitions.size() < maxResults) {
+                        if (pageToken == null) {
+                            pagedPartitions.add(partition);
+                        } else if (getPartitionSortKey(partition).compareTo(pageToken) > 0) {
+                            pagedPartitions.add(partition);
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                String nextPageToken = getNextPageTokenForPartitions(pagedPartitions, maxResults);
+                return new PagedList<>(pagedPartitions, nextPageToken);
+            }
+        } else {
+            return new PagedList<>(Collections.emptyList(), null);
+        }
+    }
+
+    @Override
     public View getView(Identifier identifier) throws ViewNotExistException {
         if (viewFullName2View.containsKey(identifier.getFullName())) {
             return viewFullName2View.get(identifier.getFullName());
@@ -172,6 +224,91 @@ public class TestRESTCatalog extends FileSystemCatalog {
     }
 
     @Override
+    public PagedList<String> listViewsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        List<String> views = listViews(databaseName);
+        if (Objects.nonNull(views)) {
+            List<String> sortedViews =
+                    views.stream().sorted(String::compareTo).collect(Collectors.toList());
+            if (Objects.isNull(maxResults) || maxResults <= 0) {
+                maxResults = DEFAULT_MAX_RESULTS;
+            }
+
+            if ((maxResults > sortedViews.size()) && pageToken == null) {
+                return new PagedList<>(sortedViews, null);
+            } else {
+                List<String> pagedViews = new ArrayList<>();
+                for (String view : sortedViews) {
+                    if (pagedViews.size() < maxResults) {
+                        if (pageToken == null) {
+                            pagedViews.add(view);
+                        } else if (view.compareTo(pageToken) > 0) {
+                            pagedViews.add(view);
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                String nextPageToken = getNextPageTokenForNames(pagedViews, maxResults);
+                return new PagedList<>(pagedViews, nextPageToken);
+            }
+        } else {
+            return new PagedList<>(Collections.emptyList(), null);
+        }
+    }
+
+    @Override
+    public PagedList<View> listViewDetailsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        List<View> viewDetails =
+                listViews(databaseName).stream()
+                        .map(
+                                tableName -> {
+                                    try {
+                                        return this.getView(
+                                                Identifier.create(databaseName, tableName));
+                                    } catch (ViewNotExistException e) {
+                                        LOG.warn(
+                                                "view {}.{} does not exist",
+                                                databaseName,
+                                                tableName);
+                                        return null;
+                                    }
+                                })
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+        List<View> sortedViewDetails =
+                viewDetails.stream()
+                        .sorted(Comparator.comparing(View::name))
+                        .collect(Collectors.toList());
+
+        if (Objects.isNull(maxResults) || maxResults <= 0) {
+            maxResults = DEFAULT_MAX_RESULTS;
+        }
+        if ((maxResults > sortedViewDetails.size()) && pageToken == null) {
+            return new PagedList<>(sortedViewDetails, null);
+        } else {
+            List<View> pagedViewDetails = new ArrayList<>();
+            for (View view : sortedViewDetails) {
+                if (pagedViewDetails.size() < maxResults) {
+                    if (pageToken == null) {
+                        pagedViewDetails.add(view);
+                        pageToken = view.name();
+                    } else if (view.name().compareTo(pageToken) > 0) {
+                        pagedViewDetails.add(view);
+                    }
+                } else {
+                    break;
+                }
+            }
+            String nextPageToken = getNextPageTokenForViews(pagedViewDetails, maxResults);
+            return new PagedList<>(pagedViewDetails, nextPageToken);
+        }
+    }
+
+    @Override
     public void renameView(Identifier fromView, Identifier toView, boolean ignoreIfNotExists)
             throws ViewNotExistException, ViewAlreadyExistException {
         if (!viewFullName2View.containsKey(fromView.getFullName()) && !ignoreIfNotExists) {
@@ -197,6 +334,89 @@ public class TestRESTCatalog extends FileSystemCatalog {
             }
         }
         return tables;
+    }
+
+    @Override
+    public PagedList<String> listTablesPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        List<String> tables = listTables(databaseName);
+        if (Objects.nonNull(tables)) {
+            List<String> sortedTables =
+                    tables.stream().sorted(String::compareTo).collect(Collectors.toList());
+            if (Objects.isNull(maxResults) || maxResults <= 0) {
+                maxResults = DEFAULT_MAX_RESULTS;
+            }
+            if ((maxResults > sortedTables.size()) && pageToken == null) {
+                return new PagedList<>(sortedTables, null);
+            } else {
+                List<String> pagedTables = new ArrayList<>();
+                for (String sortedTable : sortedTables) {
+                    if (pagedTables.size() < maxResults) {
+                        if (pageToken == null) {
+                            pagedTables.add(sortedTable);
+                        } else if (sortedTable.compareTo(pageToken) > 0) {
+                            pagedTables.add(sortedTable);
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                String nextPageToken = getNextPageTokenForNames(pagedTables, maxResults);
+                return new PagedList<>(pagedTables, nextPageToken);
+            }
+        } else {
+            return new PagedList<>(Collections.emptyList(), null);
+        }
+    }
+
+    @Override
+    public PagedList<Table> listTableDetailsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        List<Table> tableDetails =
+                listTables(databaseName).stream()
+                        .map(
+                                tableName -> {
+                                    try {
+                                        return this.getTable(
+                                                Identifier.create(databaseName, tableName));
+                                    } catch (TableNotExistException ignored) {
+                                        LOG.warn(
+                                                "table {}.{} does not exist",
+                                                databaseName,
+                                                tableName);
+                                        return null;
+                                    }
+                                })
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+        List<Table> sortedTableDetails =
+                tableDetails.stream()
+                        .sorted(Comparator.comparing(Table::name))
+                        .collect(Collectors.toList());
+        if (Objects.isNull(maxResults) || maxResults <= 0) {
+            maxResults = DEFAULT_MAX_RESULTS;
+        }
+
+        if ((maxResults > sortedTableDetails.size()) && pageToken == null) {
+            return new PagedList<>(sortedTableDetails, null);
+        } else {
+            List<Table> pagedTableDetails = new ArrayList<>();
+            for (Table table : sortedTableDetails) {
+                if (pagedTableDetails.size() < maxResults) {
+                    if (pageToken == null) {
+                        pagedTableDetails.add(table);
+                    } else if (table.name().compareTo(pageToken) > 0) {
+                        pagedTableDetails.add(table);
+                    }
+                } else {
+                    break;
+                }
+            }
+            String nextPageToken = getNextPageTokenForTables(pagedTableDetails, maxResults);
+            return new PagedList<>(pagedTableDetails, nextPageToken);
+        }
     }
 
     @Override
@@ -260,5 +480,53 @@ public class TestRESTCatalog extends FileSystemCatalog {
 
     private Partition spec2Partition(Map<String, String> spec) {
         return new Partition(spec, 123, 456, 789, 123);
+    }
+
+    private String getNextPageTokenForNames(List<String> names, Integer maxResults) {
+        if (names == null
+                || names.isEmpty()
+                || Objects.isNull(maxResults)
+                || names.size() < maxResults) {
+            return null;
+        }
+        // return the last name
+        return names.get(names.size() - 1);
+    }
+
+    private String getNextPageTokenForTables(List<Table> entities, Integer maxResults) {
+        if (entities == null
+                || entities.isEmpty()
+                || Objects.isNull(maxResults)
+                || entities.size() < maxResults) {
+            return null;
+        }
+        // return the last entity name
+        return entities.get(entities.size() - 1).name();
+    }
+
+    private String getNextPageTokenForViews(List<View> entities, Integer maxResults) {
+        if (entities == null
+                || entities.isEmpty()
+                || Objects.isNull(maxResults)
+                || entities.size() < maxResults) {
+            return null;
+        }
+        // return the last entity name
+        return entities.get(entities.size() - 1).name();
+    }
+
+    private String getNextPageTokenForPartitions(List<Partition> entities, Integer maxResults) {
+        if (entities == null
+                || entities.isEmpty()
+                || Objects.isNull(maxResults)
+                || entities.size() < maxResults) {
+            return null;
+        }
+        // return the last entity name
+        return getPartitionSortKey(entities.get(entities.size() - 1));
+    }
+
+    private String getPartitionSortKey(Partition partition) {
+        return partition.spec().toString().replace("{", "").replace("}", "");
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.hive;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.PagedList;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.Catalog;
@@ -90,6 +91,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -849,6 +851,35 @@ public class HiveCatalog extends AbstractCatalog {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Interrupted in call to getTables " + databaseName, e);
         }
+    }
+
+    @Override
+    public PagedList<View> listViewDetailsPaged(
+            String databaseName, Integer maxResults, String pageToken)
+            throws DatabaseNotExistException {
+        if (isSystemDatabase(databaseName)) {
+            return new PagedList<>(Collections.emptyList(), null);
+        }
+        getDatabase(databaseName);
+
+        PagedList<String> pagedViewNames = listViewsPaged(databaseName, maxResults, pageToken);
+        return new PagedList<>(
+                pagedViewNames.getPagedLists().stream()
+                        .map(
+                                viewName -> {
+                                    try {
+                                        return getView(Identifier.create(databaseName, viewName));
+                                    } catch (ViewNotExistException ignored) {
+                                        LOG.warn(
+                                                "view {}.{} does not exist",
+                                                databaseName,
+                                                viewName);
+                                        return null;
+                                    }
+                                })
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList()),
+                pagedViewNames.getNextPageToken());
     }
 
     @Override

--- a/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
+++ b/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
@@ -18,6 +18,9 @@
 
 package org.apache.paimon.open.api;
 
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.rest.requests.AlterDatabaseRequest;
 import org.apache.paimon.rest.requests.AlterPartitionsRequest;
@@ -42,7 +45,9 @@ import org.apache.paimon.rest.responses.GetTableTokenResponse;
 import org.apache.paimon.rest.responses.GetViewResponse;
 import org.apache.paimon.rest.responses.ListDatabasesResponse;
 import org.apache.paimon.rest.responses.ListPartitionsResponse;
+import org.apache.paimon.rest.responses.ListTableDetailsResponse;
 import org.apache.paimon.rest.responses.ListTablesResponse;
+import org.apache.paimon.rest.responses.ListViewDetailsResponse;
 import org.apache.paimon.rest.responses.ListViewsResponse;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.IntType;
@@ -223,8 +228,38 @@ public class RESTCatalogController {
     })
     @GetMapping("/v1/{prefix}/databases/{database}/tables")
     public ListTablesResponse listTables(
-            @PathVariable String prefix, @PathVariable String database) {
-        return new ListTablesResponse(ImmutableList.of("user"));
+            @PathVariable String prefix, @PathVariable String database, @PathVariable Integer maxResults, @PathVariable String pageToken) {
+        //paged list tables in this database with provided maxResults and pageToken
+        return new ListTablesResponse(ImmutableList.of("user"), null);
+    }
+
+    @Operation(
+            summary = "List table details",
+            tags = {"table"})
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    content = {@Content(schema = @Schema(implementation = ListTableDetailsResponse.class))}),
+            @ApiResponse(
+                    responseCode = "500",
+                    content = {@Content(schema = @Schema())})
+    })
+    @GetMapping("/v1/{prefix}/databases/{database}/table-details")
+    public ListTableDetailsResponse listTableDetails(
+            @PathVariable String prefix, @PathVariable String database, @PathVariable Integer maxResults, @PathVariable String pageToken) {
+        //paged list table details in this database with provided maxResults and pageToken
+        GetTableResponse singleTable = new GetTableResponse(
+                UUID.randomUUID().toString(),
+                "",
+                false,
+                1,
+                new org.apache.paimon.schema.Schema(
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        new HashMap<>(),
+                        "test-comment"));
+        return new ListTableDetailsResponse(ImmutableList.of(singleTable), null);
     }
 
     @Operation(
@@ -432,7 +467,10 @@ public class RESTCatalogController {
     public ListPartitionsResponse listPartitions(
             @PathVariable String prefix,
             @PathVariable String database,
-            @PathVariable String table) {
+            @PathVariable String table,
+            @PathVariable Integer maxResults,
+            @PathVariable String pageToken) {
+        //paged list partitions in this table with provided maxResults and pageToken
         Map<String, String> spec = new HashMap<>();
         spec.put("f1", "1");
         Partition partition = new Partition(spec, 1, 2, 3, 4);
@@ -535,8 +573,42 @@ public class RESTCatalogController {
                 content = {@Content(schema = @Schema())})
     })
     @GetMapping("/v1/{prefix}/databases/{database}/views")
-    public ListViewsResponse listViews(@PathVariable String prefix, @PathVariable String database) {
-        return new ListViewsResponse(ImmutableList.of("view1"));
+    public ListViewsResponse listViews(@PathVariable String prefix, @PathVariable String database, @PathVariable Integer maxResults, @PathVariable String pageToken) {
+        //support paged list views in this database with provided maxResults and pageToken
+        return new ListViewsResponse(ImmutableList.of("view1"), null);
+    }
+
+    @Operation(
+            summary = "List view details",
+            tags = {"view"})
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    content = {@Content(schema = @Schema(implementation = ListViewsResponse.class))}),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Resource not found",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(
+                    responseCode = "500",
+                    content = {@Content(schema = @Schema())})
+    })
+    @GetMapping("/v1/{prefix}/databases/{database}/views")
+    public ListViewDetailsResponse listViewDetails(@PathVariable String prefix, @PathVariable String database, @PathVariable Integer maxResults, @PathVariable String pageToken) {
+        //paged list view details in this database with provided maxResults and pageToken
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "f0", new IntType()),
+                        new DataField(1, "f1", new IntType()));
+        ViewSchema schema =
+                new ViewSchema(
+                        fields,
+                        "select * from t1",
+                        Collections.emptyMap(),
+                        "comment",
+                        Collections.singletonMap("pt", "1"));
+        GetViewResponse singleView = new GetViewResponse("id", "name", schema);
+        return new ListViewDetailsResponse(ImmutableList.of(singleView), null);
     }
 
     @Operation(

--- a/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
+++ b/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
@@ -18,9 +18,6 @@
 
 package org.apache.paimon.open.api;
 
-import org.apache.paimon.catalog.CatalogContext;
-import org.apache.paimon.catalog.Identifier;
-import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.rest.requests.AlterDatabaseRequest;
 import org.apache.paimon.rest.requests.AlterPartitionsRequest;
@@ -228,8 +225,11 @@ public class RESTCatalogController {
     })
     @GetMapping("/v1/{prefix}/databases/{database}/tables")
     public ListTablesResponse listTables(
-            @PathVariable String prefix, @PathVariable String database, @PathVariable Integer maxResults, @PathVariable String pageToken) {
-        //paged list tables in this database with provided maxResults and pageToken
+            @PathVariable String prefix,
+            @PathVariable String database,
+            @PathVariable Integer maxResults,
+            @PathVariable String pageToken) {
+        // paged list tables in this database with provided maxResults and pageToken
         return new ListTablesResponse(ImmutableList.of("user"), null);
     }
 
@@ -237,28 +237,34 @@ public class RESTCatalogController {
             summary = "List table details",
             tags = {"table"})
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    content = {@Content(schema = @Schema(implementation = ListTableDetailsResponse.class))}),
-            @ApiResponse(
-                    responseCode = "500",
-                    content = {@Content(schema = @Schema())})
+        @ApiResponse(
+                responseCode = "200",
+                content = {
+                    @Content(schema = @Schema(implementation = ListTableDetailsResponse.class))
+                }),
+        @ApiResponse(
+                responseCode = "500",
+                content = {@Content(schema = @Schema())})
     })
     @GetMapping("/v1/{prefix}/databases/{database}/table-details")
     public ListTableDetailsResponse listTableDetails(
-            @PathVariable String prefix, @PathVariable String database, @PathVariable Integer maxResults, @PathVariable String pageToken) {
-        //paged list table details in this database with provided maxResults and pageToken
-        GetTableResponse singleTable = new GetTableResponse(
-                UUID.randomUUID().toString(),
-                "",
-                false,
-                1,
-                new org.apache.paimon.schema.Schema(
-                        ImmutableList.of(),
-                        ImmutableList.of(),
-                        ImmutableList.of(),
-                        new HashMap<>(),
-                        "test-comment"));
+            @PathVariable String prefix,
+            @PathVariable String database,
+            @PathVariable Integer maxResults,
+            @PathVariable String pageToken) {
+        // paged list table details in this database with provided maxResults and pageToken
+        GetTableResponse singleTable =
+                new GetTableResponse(
+                        UUID.randomUUID().toString(),
+                        "",
+                        false,
+                        1,
+                        new org.apache.paimon.schema.Schema(
+                                ImmutableList.of(),
+                                ImmutableList.of(),
+                                ImmutableList.of(),
+                                new HashMap<>(),
+                                "test-comment"));
         return new ListTableDetailsResponse(ImmutableList.of(singleTable), null);
     }
 
@@ -470,7 +476,7 @@ public class RESTCatalogController {
             @PathVariable String table,
             @PathVariable Integer maxResults,
             @PathVariable String pageToken) {
-        //paged list partitions in this table with provided maxResults and pageToken
+        // paged list partitions in this table with provided maxResults and pageToken
         Map<String, String> spec = new HashMap<>();
         spec.put("f1", "1");
         Partition partition = new Partition(spec, 1, 2, 3, 4);
@@ -573,8 +579,12 @@ public class RESTCatalogController {
                 content = {@Content(schema = @Schema())})
     })
     @GetMapping("/v1/{prefix}/databases/{database}/views")
-    public ListViewsResponse listViews(@PathVariable String prefix, @PathVariable String database, @PathVariable Integer maxResults, @PathVariable String pageToken) {
-        //support paged list views in this database with provided maxResults and pageToken
+    public ListViewsResponse listViews(
+            @PathVariable String prefix,
+            @PathVariable String database,
+            @PathVariable Integer maxResults,
+            @PathVariable String pageToken) {
+        // support paged list views in this database with provided maxResults and pageToken
         return new ListViewsResponse(ImmutableList.of("view1"), null);
     }
 
@@ -582,20 +592,24 @@ public class RESTCatalogController {
             summary = "List view details",
             tags = {"view"})
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    content = {@Content(schema = @Schema(implementation = ListViewsResponse.class))}),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "Resource not found",
-                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
-            @ApiResponse(
-                    responseCode = "500",
-                    content = {@Content(schema = @Schema())})
+        @ApiResponse(
+                responseCode = "200",
+                content = {@Content(schema = @Schema(implementation = ListViewsResponse.class))}),
+        @ApiResponse(
+                responseCode = "404",
+                description = "Resource not found",
+                content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+        @ApiResponse(
+                responseCode = "500",
+                content = {@Content(schema = @Schema())})
     })
     @GetMapping("/v1/{prefix}/databases/{database}/views")
-    public ListViewDetailsResponse listViewDetails(@PathVariable String prefix, @PathVariable String database, @PathVariable Integer maxResults, @PathVariable String pageToken) {
-        //paged list view details in this database with provided maxResults and pageToken
+    public ListViewDetailsResponse listViewDetails(
+            @PathVariable String prefix,
+            @PathVariable String database,
+            @PathVariable Integer maxResults,
+            @PathVariable String pageToken) {
+        // paged list view details in this database with provided maxResults and pageToken
         List<DataField> fields =
                 Arrays.asList(
                         new DataField(0, "f0", new IntType()),


### PR DESCRIPTION
0. 命名：方法名(动词)： ListTablesPaged, 对象名：名词：PagedTables
1. Catalog接口增加： ListTablesPaged/ListTableDetailsPaged/ListViewsPaged/ListViewDetailsPaged/ListPartitionsPaged
2. 引入数据结构PagedList
3. 新增分页接口均未做缓存处理
4. 原RestCatalog listTables/listViews/listPartitions接口均改为客户端分页逻辑，分页逻辑模仿uc & oss, 基于name排序，默认每次返回100条数据，catalog级别配置
4. listTablesPaged/listPartitionsPaged 和listTables/listPartitions保持一致，在AbstractCatalog中，默认回退到listPartitions方法
5. listTableDetailsPaged逻辑： listTablesPaged -> forEach getTable, 逻辑在在AbstractCatalog中(和listTables一致)
6. listViewDeatilsPaged逻辑： listViewsPaged -> forEach getView, 逻辑在子类Catalog中(和listViews一致，如HiveCatalog)
7. 在原有ListTablesResponse/ListViewsResponse/ListPartitionsResponse基础上增加nextPageToken字段
8. 引入ListTableDetailsResponse/ListViewDetailsResponse数据结构, 引入table-details & view-datails api path
9. 关注listTablesPaged 传入maxResults & pageToken为null时返回值，rest catalog根据服务端会截断，其它catalog全部返回