### PR TITLE
support target file size in pypaimon

### DIFF
--- a/paimon-python/pypaimon/common/core_options.py
+++ b/paimon-python/pypaimon/common/core_options.py
@@ -47,6 +47,8 @@ class CoreOptions(str, Enum):
     FILE_FORMAT_PER_LEVEL = "file.format.per.level"
     FILE_BLOCK_SIZE = "file.block-size"
     FILE_BLOB_AS_DESCRIPTOR = "blob-as-descriptor"
+    TARGET_FILE_SIZE = "target-file-size"
+    BLOB_TARGET_FILE_SIZE = "blob.target-file-size"
     # Scan options
     SCAN_FALLBACK_BRANCH = "scan.fallback-branch"
     INCREMENTAL_BETWEEN_TIMESTAMP = "incremental-between-timestamp"
@@ -76,3 +78,19 @@ class CoreOptions(str, Enum):
             cost_str = options[CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST]
             return MemorySize.parse(cost_str).get_bytes()
         return MemorySize.of_mebi_bytes(4).get_bytes()
+
+    @staticmethod
+    def get_target_file_size(options: dict, has_primary_key: bool = False) -> int:
+        """Get target file size from options, default to 128MB for primary key table, 256MB for append-only table."""
+        if CoreOptions.TARGET_FILE_SIZE in options:
+            size_str = options[CoreOptions.TARGET_FILE_SIZE]
+            return MemorySize.parse(size_str).get_bytes()
+        return MemorySize.of_mebi_bytes(128 if has_primary_key else 256).get_bytes()
+
+    @staticmethod
+    def get_blob_target_file_size(options: dict) -> int:
+        """Get blob target file size from options, default to target-file-size (256MB for append-only table)."""
+        if CoreOptions.BLOB_TARGET_FILE_SIZE in options:
+            size_str = options[CoreOptions.BLOB_TARGET_FILE_SIZE]
+            return MemorySize.parse(size_str).get_bytes()
+        return CoreOptions.get_target_file_size(options, has_primary_key=False)

--- a/paimon-python/pypaimon/write/writer/blob_file_writer.py
+++ b/paimon-python/pypaimon/write/writer/blob_file_writer.py
@@ -1,0 +1,111 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+
+import pyarrow as pa
+from pathlib import Path
+
+from pypaimon.write.blob_format_writer import BlobFormatWriter
+from pypaimon.table.row.generic_row import GenericRow, RowKind
+from pypaimon.table.row.blob import Blob, BlobData, BlobDescriptor
+from pypaimon.schema.data_types import DataField, PyarrowFieldParser
+
+
+class BlobFileWriter:
+    """
+    Single blob file writer
+    Writes rows one by one and tracks file size.
+    """
+
+    def __init__(self, file_io, file_path: Path, blob_as_descriptor: bool):
+        self.file_io = file_io
+        self.file_path = file_path
+        self.blob_as_descriptor = blob_as_descriptor
+        self.output_stream = file_io.new_output_stream(file_path)
+        self.writer = BlobFormatWriter(self.output_stream)
+        self.row_count = 0
+        self.closed = False
+
+    def write_row(self, row_data: pa.Table):
+        """Write a single row to the blob file."""
+        if row_data.num_rows != 1:
+            raise ValueError(f"Expected 1 row, got {row_data.num_rows}")
+
+        # Convert PyArrow row to GenericRow
+        records_dict = row_data.to_pydict()
+        field_name = row_data.schema[0].name
+        col_data = records_dict[field_name][0]
+
+        # Convert to Blob
+        if self.blob_as_descriptor:
+            # In blob-as-descriptor mode, we need to read external file data
+            # for rolling size calculation (based on external file size)
+            if isinstance(col_data, bytes):
+                blob_descriptor = BlobDescriptor.deserialize(col_data)
+            else:
+                # Handle PyArrow types
+                if hasattr(col_data, 'as_py'):
+                    col_data = col_data.as_py()
+                if isinstance(col_data, str):
+                    col_data = col_data.encode('utf-8')
+                blob_descriptor = BlobDescriptor.deserialize(col_data)
+            # Read external file data for rolling size calculation
+            uri_reader = self.file_io.uri_reader_factory.create(blob_descriptor.uri)
+            blob_data = Blob.from_descriptor(uri_reader, blob_descriptor)
+        elif isinstance(col_data, bytes):
+            blob_data = BlobData(col_data)
+        else:
+            if hasattr(col_data, 'as_py'):
+                col_data = col_data.as_py()
+            if isinstance(col_data, str):
+                col_data = col_data.encode('utf-8')
+            blob_data = BlobData(col_data)
+
+        # Create GenericRow
+        fields = [DataField(0, field_name, PyarrowFieldParser.to_paimon_type(row_data.schema[0].type, False))]
+        row = GenericRow([blob_data], fields, RowKind.INSERT)
+
+        # Write to blob format writer
+        self.writer.add_element(row)
+        self.row_count += 1
+
+    def reach_target_size(self, suggested_check: bool, target_size: int) -> bool:
+        return self.writer.reach_target_size(suggested_check, target_size)
+
+    def close(self) -> int:
+        if self.closed:
+            return self.file_io.get_file_size(self.file_path)
+
+        self.writer.close()
+        self.closed = True
+
+        # Get actual file size
+        file_size = self.file_io.get_file_size(self.file_path)
+        return file_size
+
+    def abort(self):
+        """Abort the writer and delete the file."""
+        if not self.closed:
+            try:
+                if hasattr(self.output_stream, 'close'):
+                    self.output_stream.close()
+            except Exception:
+                pass
+            self.closed = True
+
+        # Delete the file
+        self.file_io.delete_quietly(self.file_path)

--- a/paimon-python/pypaimon/write/writer/blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/blob_writer.py
@@ -172,17 +172,11 @@ class BlobWriter(AppendOnlyDataWriter):
         else:
             # row_count only (from BlobFileWriter)
             row_count = data_or_row_count
-            # For blob files, we don't have stats
-            # Use the actual blob column name instead of hardcoded 'blob_data'
-            # This ensures the stats schema matches the actual table schema
             data_fields = [PyarrowFieldParser.to_paimon_schema(pa.schema([(self.blob_column, pa.large_binary())]))[0]]
             min_value_stats = [None]
             max_value_stats = [None]
             value_null_counts = [0]
 
-        # min_seq = seqNumCounter.getValue() - super.recordCount()
-        # max_seq = seqNumCounter.getValue() - 1
-        # This ensures max_seq - min_seq + 1 == row_count
         min_seq = self.sequence_generator.current - row_count
         max_seq = self.sequence_generator.current - 1
         self.sequence_generator.start = self.sequence_generator.current
@@ -205,7 +199,7 @@ class BlobWriter(AppendOnlyDataWriter):
             extra_files=[],
             creation_time=datetime.now(),
             delete_row_count=0,
-            file_source="APPEND",
+            file_source=0,  # FileSource.APPEND = 0
             value_stats_cols=None,
             external_path=None,
             first_row_id=None,

--- a/paimon-python/pypaimon/write/writer/blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/blob_writer.py
@@ -17,12 +17,18 @@
 ################################################################################
 
 import logging
-from typing import Tuple
+import uuid
+import pyarrow as pa
+from pathlib import Path
+from typing import Optional, Tuple
 
 from pypaimon.common.core_options import CoreOptions
 from pypaimon.write.writer.append_only_data_writer import AppendOnlyDataWriter
+from pypaimon.write.writer.blob_file_writer import BlobFileWriter
 
 logger = logging.getLogger(__name__)
+
+CHECK_ROLLING_RECORD_CNT = 1000
 
 
 class BlobWriter(AppendOnlyDataWriter):
@@ -33,11 +39,219 @@ class BlobWriter(AppendOnlyDataWriter):
         # Override file format to "blob"
         self.file_format = CoreOptions.FILE_FORMAT_BLOB
 
-        logger.info("Initialized BlobWriter with blob file format")
+        # Store blob column name for use in metadata creation
+        self.blob_column = blob_column
+
+        options = self.table.options
+        self.blob_target_file_size = CoreOptions.get_blob_target_file_size(options)
+
+        self.current_writer: Optional[BlobFileWriter] = None
+        self.current_file_path: Optional[Path] = None
+        self.record_count = 0
+
+        self.file_uuid = str(uuid.uuid4())
+        self.file_count = 0
+
+        logger.info(f"Initialized BlobWriter with blob file format, blob_target_file_size={self.blob_target_file_size}")
+
+    def _check_and_roll_if_needed(self):
+        if self.pending_data is None:
+            return
+
+        if self.blob_as_descriptor:
+            # blob-as-descriptor=true: Write row by row and check actual file size
+            for i in range(self.pending_data.num_rows):
+                row_data = self.pending_data.slice(i, 1)
+                self._write_row_to_file(row_data)
+                self.record_count += 1
+
+                if self.rolling_file(False):
+                    self.close_current_writer()
+
+            # All data has been written
+            self.pending_data = None
+        else:
+            # blob-as-descriptor=false: Use blob_target_file_size instead of target_file_size
+            current_size = self.pending_data.nbytes
+            if current_size > self.blob_target_file_size:
+                split_row = self._find_optimal_split_point(self.pending_data, self.blob_target_file_size)
+                if split_row > 0:
+                    data_to_write = self.pending_data.slice(0, split_row)
+                    remaining_data = self.pending_data.slice(split_row)
+
+                    self._write_data_to_file(data_to_write)
+                    self.pending_data = remaining_data
+                    self._check_and_roll_if_needed()
+
+    def _write_row_to_file(self, row_data: pa.Table):
+        """Write a single row to the current blob file. Opens a new file if needed."""
+        if row_data.num_rows == 0:
+            return
+
+        if self.current_writer is None:
+            self.open_current_writer()
+
+        self.current_writer.write_row(row_data)
+        # This ensures each row has a unique sequence number for data versioning and consistency
+        self.sequence_generator.next()
+
+    def open_current_writer(self):
+        file_name = f"data-{self.file_uuid}-{self.file_count}.{self.file_format}"
+        self.file_count += 1  # Increment counter for next file
+        file_path = self._generate_file_path(file_name)
+        self.current_file_path = file_path
+        self.current_writer = BlobFileWriter(self.file_io, file_path, self.blob_as_descriptor)
+
+    def rolling_file(self, force_check: bool = False) -> bool:
+        if self.current_writer is None:
+            return False
+
+        should_check = force_check or (self.record_count % CHECK_ROLLING_RECORD_CNT == 0)
+        return self.current_writer.reach_target_size(should_check, self.blob_target_file_size)
+
+    def close_current_writer(self):
+        """Close current writer and create metadata."""
+        if self.current_writer is None:
+            return
+
+        file_size = self.current_writer.close()
+        file_name = self.current_file_path.name
+        row_count = self.current_writer.row_count
+
+        self._add_file_metadata(file_name, self.current_file_path, row_count, file_size)
+
+        self.current_writer = None
+        self.current_file_path = None
+
+    def _write_data_to_file(self, data):
+        """
+        Override for blob format in normal mode (blob-as-descriptor=false).
+        Only difference from parent: use shared UUID + counter for file naming.
+        """
+        if data.num_rows == 0:
+            return
+
+        # This ensures each row gets a unique sequence number, matching the behavior expected
+        for _ in range(data.num_rows):
+            self.sequence_generator.next()
+
+        file_name = f"data-{self.file_uuid}-{self.file_count}.{self.file_format}"
+        self.file_count += 1
+        file_path = self._generate_file_path(file_name)
+
+        # Write blob file (parent class already supports blob format)
+        self.file_io.write_blob(file_path, data, self.blob_as_descriptor)
+
+        file_size = self.file_io.get_file_size(file_path)
+
+        # Reuse _add_file_metadata for consistency (blob table is append-only, no primary keys)
+        self._add_file_metadata(file_name, file_path, data, file_size)
+
+    def _add_file_metadata(self, file_name: str, file_path: Path, data_or_row_count, file_size: int):
+        """Add file metadata to committed_files."""
+        from datetime import datetime
+        from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+        from pypaimon.manifest.schema.simple_stats import SimpleStats
+        from pypaimon.table.row.generic_row import GenericRow
+        from pypaimon.schema.data_types import PyarrowFieldParser
+
+        # Handle both Table and row_count
+        if isinstance(data_or_row_count, pa.Table):
+            data = data_or_row_count
+            row_count = data.num_rows
+            data_fields = PyarrowFieldParser.to_paimon_schema(data.schema)
+            # Compute statistics across all batches, not just the first one
+            # This ensures correct min/max/null_counts when data has multiple batches
+            column_stats = {
+                field.name: self._get_column_stats(data, field.name)
+                for field in data_fields
+            }
+            min_value_stats = [column_stats[field.name]['min_values'] for field in data_fields]
+            max_value_stats = [column_stats[field.name]['max_values'] for field in data_fields]
+            value_null_counts = [column_stats[field.name]['null_counts'] for field in data_fields]
+        else:
+            # row_count only (from BlobFileWriter)
+            row_count = data_or_row_count
+            # For blob files, we don't have stats
+            # Use the actual blob column name instead of hardcoded 'blob_data'
+            # This ensures the stats schema matches the actual table schema
+            data_fields = [PyarrowFieldParser.to_paimon_schema(pa.schema([(self.blob_column, pa.large_binary())]))[0]]
+            min_value_stats = [None]
+            max_value_stats = [None]
+            value_null_counts = [0]
+
+        # min_seq = seqNumCounter.getValue() - super.recordCount()
+        # max_seq = seqNumCounter.getValue() - 1
+        # This ensures max_seq - min_seq + 1 == row_count
+        min_seq = self.sequence_generator.current - row_count
+        max_seq = self.sequence_generator.current - 1
+        self.sequence_generator.start = self.sequence_generator.current
+
+        self.committed_files.append(DataFileMeta(
+            file_name=file_name,
+            file_size=file_size,
+            row_count=row_count,
+            min_key=GenericRow([], []),
+            max_key=GenericRow([], []),
+            key_stats=SimpleStats(GenericRow([], []), GenericRow([], []), []),
+            value_stats=SimpleStats(
+                GenericRow(min_value_stats, data_fields),
+                GenericRow(max_value_stats, data_fields),
+                value_null_counts),
+            min_sequence_number=min_seq,
+            max_sequence_number=max_seq,
+            schema_id=self.table.table_schema.id,
+            level=0,
+            extra_files=[],
+            creation_time=datetime.now(),
+            delete_row_count=0,
+            file_source="APPEND",
+            value_stats_cols=None,
+            external_path=None,
+            first_row_id=None,
+            write_cols=self.write_cols,
+            file_path=str(file_path),
+        ))
+
+    def prepare_commit(self):
+        """Prepare commit, ensuring all data is written."""
+        # Close current file if open (blob-as-descriptor=true mode)
+        if self.current_writer is not None:
+            self.close_current_writer()
+
+        # Call parent to handle pending_data (blob-as-descriptor=false mode)
+        return super().prepare_commit()
+
+    def close(self):
+        """Close current writer if open."""
+        # Close current file if open (blob-as-descriptor=true mode)
+        if self.current_writer is not None:
+            self.close_current_writer()
+
+        # Call parent to handle pending_data (blob-as-descriptor=false mode)
+        super().close()
+
+    def abort(self):
+        if self.current_writer is not None:
+            try:
+                self.current_writer.abort()
+            except Exception as e:
+                logger.warning(f"Error aborting blob writer: {e}", exc_info=e)
+            self.current_writer = None
+            self.current_file_path = None
+        super().abort()
 
     @staticmethod
-    def _get_column_stats(record_batch, column_name: str):
-        column_array = record_batch.column(column_name)
+    def _get_column_stats(data_or_batch, column_name: str):
+        """
+        Compute column statistics for a column in a Table or RecordBatch.
+        """
+        # Handle both Table and RecordBatch
+        if isinstance(data_or_batch, pa.Table):
+            column_array = data_or_batch.column(column_name)
+        else:
+            column_array = data_or_batch.column(column_name)
+
         # For blob data, don't generate min/max values
         return {
             "min_values": None,

--- a/paimon-python/pypaimon/write/writer/data_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_writer.py
@@ -47,7 +47,7 @@ class DataWriter(ABC):
         self.trimmed_primary_keys = self.table.trimmed_primary_keys
 
         options = self.table.options
-        self.target_file_size = 256 * 1024 * 1024
+        self.target_file_size = CoreOptions.get_target_file_size(options, self.table.is_primary_key_table)
         self.file_format = options.get(CoreOptions.FILE_FORMAT,
                                        CoreOptions.FILE_FORMAT_PARQUET
                                        if self.bucket != BucketMode.POSTPONE_BUCKET.value


### PR DESCRIPTION
[python] Support blob.target-file-size (target-file-size) rolling for blob tables

## Purpose

Currently, Python Paimon blob tables did not support file rolling based on `target-file-size` in `blob-as-descriptor=true` mode. 

## This PR

- **Supports `target-file-size` rolling in `blob-as-descriptor=true` mode**: Implements row-by-row writing with actual file size checking, aligned with Java's `RollingBlobFileWriter` architecture
- **Fixes `blob.target-file-size` configuration**: Ensures `blob.target-file-size` is respected in both descriptor and non-descriptor modes instead of being ignored

## Tests

- `blob_table_test.py`
-  `RollingBlobFileWriterTest`, used to check blob rolling in java

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements Python blob file rolling using `target-file-size`/`blob.target-file-size` with new writers, shared-UUID `data-{uuid}-{count}.blob` naming, correct per-row sequence numbers, and adds tests; also aligns Java tests with expected filename prefix.
> 
> - **Python - Blob writing**:
>   - Introduce `BlobFileWriter` and enhance `BlobWriter` to roll files using `blob.target-file-size` (and `target-file-size`), supporting both descriptor and non-descriptor modes.
>   - Use shared-UUID file naming `data-{uuid}-{count}.blob`; increment sequence numbers per row; generate stats using actual blob column name.
>   - Update `DataWriter` to read `target-file-size` via `CoreOptions`; respect `blob-as-descriptor` option.
> - **Options**:
>   - Add `CoreOptions.TARGET_FILE_SIZE` and `BLOB_TARGET_FILE_SIZE` helpers with defaults.
> - **Tests**:
>   - Python: add rolling, filename format, sequence-number, and custom stats tests for both modes.
>   - Java: update `RollingBlobFileWriterTest` to use `data-` prefix and add tests for shared-UUID filenames, sequence numbers, and custom blob column stats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfbb7851c3b60a5f51c4ccbf5e052032a3640646. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->