### PR TITLE
Read blob as descriptor dev

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.OutputStream;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -90,6 +91,8 @@ public class BlobTableITCase extends CatalogITCaseBase {
                 Blob.fromDescriptor(
                         uriReaderFactory.create(newBlobDescriptor.uri()), blobDescriptor);
         assertThat(blob.toData()).isEqualTo(blobData);
+        URI blobUri = URI.create(blob.toDescriptor().uri());
+        assertThat(blobUri.getScheme()).isNotNull();
         batchSql("ALTER TABLE blob_table_descriptor SET ('blob-as-descriptor'='false')");
         assertThat(batchSql("SELECT * FROM blob_table_descriptor"))
                 .containsExactlyInAnyOrder(Row.of(1, "paimon", blobData));

--- a/paimon-python/pypaimon/catalog/filesystem_catalog.py
+++ b/paimon-python/pypaimon/catalog/filesystem_catalog.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 #################################################################################
 
-import os
 from typing import List, Optional, Union
 
 from pypaimon.catalog.catalog import Catalog
@@ -108,11 +107,12 @@ class FileSystemCatalog(Catalog):
         return table_schema
 
     def get_database_path(self, name) -> str:
-        return os.path.join(self.warehouse, f"{name}{Catalog.DB_SUFFIX}")
+        warehouse = self.warehouse.rstrip('/')
+        return f"{warehouse}/{name}{Catalog.DB_SUFFIX}"
 
     def get_table_path(self, identifier: Identifier) -> str:
         db_path = self.get_database_path(identifier.get_database_name())
-        return os.path.join(db_path, identifier.get_table_name())
+        return f"{db_path}/{identifier.get_table_name()}"
 
     def commit_snapshot(
             self,

--- a/paimon-python/pypaimon/catalog/filesystem_catalog.py
+++ b/paimon-python/pypaimon/catalog/filesystem_catalog.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #################################################################################
 
+import os
 from typing import List, Optional, Union
 
 from pypaimon.catalog.catalog import Catalog
@@ -107,12 +108,11 @@ class FileSystemCatalog(Catalog):
         return table_schema
 
     def get_database_path(self, name) -> str:
-        warehouse = self.warehouse.rstrip('/')
-        return f"{warehouse}/{name}{Catalog.DB_SUFFIX}"
+        return os.path.join(self.warehouse, f"{name}{Catalog.DB_SUFFIX}")
 
     def get_table_path(self, identifier: Identifier) -> str:
         db_path = self.get_database_path(identifier.get_database_name())
-        return f"{db_path}/{identifier.get_table_name()}"
+        return os.path.join(db_path, identifier.get_table_name())
 
     def commit_snapshot(
             self,

--- a/paimon-python/pypaimon/catalog/filesystem_catalog.py
+++ b/paimon-python/pypaimon/catalog/filesystem_catalog.py
@@ -16,9 +16,7 @@
 # limitations under the License.
 #################################################################################
 
-from pathlib import Path
 from typing import List, Optional, Union
-from urllib.parse import urlparse
 
 from pypaimon.catalog.catalog import Catalog
 from pypaimon.catalog.catalog_environment import CatalogEnvironment
@@ -108,18 +106,13 @@ class FileSystemCatalog(Catalog):
             raise TableNotExistException(identifier)
         return table_schema
 
-    def get_database_path(self, name) -> Path:
-        return self._trim_schema(self.warehouse) / f"{name}{Catalog.DB_SUFFIX}"
+    def get_database_path(self, name) -> str:
+        warehouse = self.warehouse.rstrip('/')
+        return f"{warehouse}/{name}{Catalog.DB_SUFFIX}"
 
-    def get_table_path(self, identifier: Identifier) -> Path:
-        return self.get_database_path(identifier.get_database_name()) / identifier.get_table_name()
-
-    @staticmethod
-    def _trim_schema(warehouse_url: str) -> Path:
-        parsed = urlparse(warehouse_url)
-        bucket = parsed.netloc
-        warehouse_dir = parsed.path.lstrip('/')
-        return Path(f"{bucket}/{warehouse_dir}" if warehouse_dir else bucket)
+    def get_table_path(self, identifier: Identifier) -> str:
+        db_path = self.get_database_path(identifier.get_database_name())
+        return f"{db_path}/{identifier.get_table_name()}"
 
     def commit_snapshot(
             self,

--- a/paimon-python/pypaimon/catalog/rest/rest_token_file_io.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_token_file_io.py
@@ -18,7 +18,6 @@ limitations under the License.
 import logging
 import threading
 import time
-from pathlib import Path
 from typing import Optional
 
 from pyarrow._fs import FileSystem
@@ -46,8 +45,8 @@ class RESTTokenFileIO(FileIO):
         self.properties.update(self.token.token)
         return super()._initialize_oss_fs(path)
 
-    def new_output_stream(self, path: Path):
-        return self.filesystem.open_output_stream(str(path))
+    def new_output_stream(self, path: str):
+        return self.filesystem.open_output_stream(path)
 
     def try_to_refresh_token(self):
         if self.should_refresh():

--- a/paimon-python/pypaimon/catalog/rest/rest_token_file_io.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_token_file_io.py
@@ -46,7 +46,8 @@ class RESTTokenFileIO(FileIO):
         return super()._initialize_oss_fs(path)
 
     def new_output_stream(self, path: str):
-        return self.filesystem.open_output_stream(path)
+        # Call parent class method to ensure path conversion and parent directory creation
+        return super().new_output_stream(path)
 
     def try_to_refresh_token(self):
         if self.should_refresh():

--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -127,11 +127,11 @@ class FileIO:
             raise RuntimeError("HADOOP_CONF_DIR environment variable is not set.")
 
         hadoop_home = os.environ.get("HADOOP_HOME")
-        native_lib_path = os.path.join(hadoop_home, "lib", "native")
+        native_lib_path = f"{hadoop_home}/lib/native"
         os.environ['LD_LIBRARY_PATH'] = f"{native_lib_path}:{os.environ.get('LD_LIBRARY_PATH', '')}"
 
         class_paths = subprocess.run(
-            [os.path.join(hadoop_home, 'bin', 'hadoop'), 'classpath', '--glob'],
+            [f'{hadoop_home}/bin/hadoop', 'classpath', '--glob'],
             capture_output=True,
             text=True,
             check=True
@@ -302,7 +302,7 @@ class FileIO:
             if file_info.type == pyarrow.fs.FileType.File:
                 source_file = file_info.path
                 file_name = source_file.split('/')[-1]
-                target_file = os.path.join(target_directory, file_name) if target_directory else file_name
+                target_file = f"{target_directory.rstrip('/')}/{file_name}" if target_directory else file_name
                 self.copy_file(source_file, target_file, overwrite)
 
     def read_overwritten_file_utf8(self, path: str) -> Optional[str]:

--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -150,71 +150,81 @@ class FileIO:
 
         return LocalFileSystem()
 
-    def new_input_stream(self, path: Path):
-        return self.filesystem.open_input_file(str(path))
+    def new_input_stream(self, path: str):
+        path_str = self.to_filesystem_path(path)
+        return self.filesystem.open_input_file(path_str)
 
-    def new_output_stream(self, path: Path):
-        parent_dir = path.parent
-        if str(parent_dir) and not self.exists(parent_dir):
-            self.mkdirs(parent_dir)
+    def new_output_stream(self, path: str):
+        path_str = self.to_filesystem_path(path)
+        parent_dir = Path(path_str).parent
+        if str(parent_dir) and not self.exists(str(parent_dir)):
+            self.mkdirs(str(parent_dir))
 
-        return self.filesystem.open_output_stream(str(path))
+        return self.filesystem.open_output_stream(path_str)
 
-    def get_file_status(self, path: Path):
-        file_infos = self.filesystem.get_file_info([str(path)])
+    def get_file_status(self, path: str):
+        path_str = self.to_filesystem_path(path)
+        file_infos = self.filesystem.get_file_info([path_str])
         return file_infos[0]
 
-    def list_status(self, path: Path):
-        selector = pyarrow.fs.FileSelector(str(path), recursive=False, allow_not_found=True)
+    def list_status(self, path: str):
+        path_str = self.to_filesystem_path(path)
+        selector = pyarrow.fs.FileSelector(path_str, recursive=False, allow_not_found=True)
         return self.filesystem.get_file_info(selector)
 
-    def list_directories(self, path: Path):
+    def list_directories(self, path: str):
         file_infos = self.list_status(path)
         return [info for info in file_infos if info.type == pyarrow.fs.FileType.Directory]
 
-    def exists(self, path: Path) -> bool:
+    def exists(self, path: str) -> bool:
         try:
-            file_info = self.filesystem.get_file_info([str(path)])[0]
-            return file_info.type != pyarrow.fs.FileType.NotFound
+            path_str = self.to_filesystem_path(path)
+            file_info = self.filesystem.get_file_info([path_str])[0]
+            result = file_info.type != pyarrow.fs.FileType.NotFound
+            return result
         except Exception:
             return False
 
-    def delete(self, path: Path, recursive: bool = False) -> bool:
+    def delete(self, path: str, recursive: bool = False) -> bool:
         try:
-            file_info = self.filesystem.get_file_info([str(path)])[0]
+            path_str = self.to_filesystem_path(path)
+            file_info = self.filesystem.get_file_info([path_str])[0]
             if file_info.type == pyarrow.fs.FileType.Directory:
                 if recursive:
-                    self.filesystem.delete_dir_contents(str(path))
+                    self.filesystem.delete_dir_contents(path_str)
                 else:
-                    self.filesystem.delete_dir(str(path))
+                    self.filesystem.delete_dir(path_str)
             else:
-                self.filesystem.delete_file(str(path))
+                self.filesystem.delete_file(path_str)
             return True
         except Exception as e:
             self.logger.warning(f"Failed to delete {path}: {e}")
             return False
 
-    def mkdirs(self, path: Path) -> bool:
+    def mkdirs(self, path: str) -> bool:
         try:
-            self.filesystem.create_dir(str(path), recursive=True)
+            path_str = self.to_filesystem_path(path)
+            self.filesystem.create_dir(path_str, recursive=True)
             return True
         except Exception as e:
             self.logger.warning(f"Failed to create directory {path}: {e}")
             return False
 
-    def rename(self, src: Path, dst: Path) -> bool:
+    def rename(self, src: str, dst: str) -> bool:
         try:
-            dst_parent = dst.parent
-            if str(dst_parent) and not self.exists(dst_parent):
-                self.mkdirs(dst_parent)
+            dst_str = self.to_filesystem_path(dst)
+            dst_parent = Path(dst_str).parent
+            if str(dst_parent) and not self.exists(str(dst_parent)):
+                self.mkdirs(str(dst_parent))
 
-            self.filesystem.move(str(src), str(dst))
+            src_str = self.to_filesystem_path(src)
+            self.filesystem.move(src_str, dst_str)
             return True
         except Exception as e:
             self.logger.warning(f"Failed to rename {src} to {dst}: {e}")
             return False
 
-    def delete_quietly(self, path: Path):
+    def delete_quietly(self, path: str):
         if self.logger.isEnabledFor(logging.DEBUG):
             self.logger.debug(f"Ready to delete {path}")
 
@@ -224,11 +234,11 @@ class FileIO:
         except Exception:
             self.logger.warning(f"Exception occurs when deleting file {path}", exc_info=True)
 
-    def delete_files_quietly(self, files: List[Path]):
+    def delete_files_quietly(self, files: List[str]):
         for file_path in files:
             self.delete_quietly(file_path)
 
-    def delete_directory_quietly(self, directory: Path):
+    def delete_directory_quietly(self, directory: str):
         if self.logger.isEnabledFor(logging.DEBUG):
             self.logger.debug(f"Ready to delete {directory}")
 
@@ -238,29 +248,29 @@ class FileIO:
         except Exception:
             self.logger.warning(f"Exception occurs when deleting directory {directory}", exc_info=True)
 
-    def get_file_size(self, path: Path) -> int:
+    def get_file_size(self, path: str) -> int:
         file_info = self.get_file_status(path)
         if file_info.size is None:
             raise ValueError(f"File size not available for {path}")
         return file_info.size
 
-    def is_dir(self, path: Path) -> bool:
+    def is_dir(self, path: str) -> bool:
         file_info = self.get_file_status(path)
         return file_info.type == pyarrow.fs.FileType.Directory
 
-    def check_or_mkdirs(self, path: Path):
+    def check_or_mkdirs(self, path: str):
         if self.exists(path):
             if not self.is_dir(path):
                 raise ValueError(f"The path '{path}' should be a directory.")
         else:
             self.mkdirs(path)
 
-    def read_file_utf8(self, path: Path) -> str:
+    def read_file_utf8(self, path: str) -> str:
         with self.new_input_stream(path) as input_stream:
             return input_stream.read().decode('utf-8')
 
-    def try_to_write_atomic(self, path: Path, content: str) -> bool:
-        temp_path = path.with_suffix(path.suffix + ".tmp") if path.suffix else Path(str(path) + ".tmp")
+    def try_to_write_atomic(self, path: str, content: str) -> bool:
+        temp_path = path + ".tmp"
         success = False
         try:
             self.write_file(temp_path, content, False)
@@ -270,29 +280,32 @@ class FileIO:
                 self.delete_quietly(temp_path)
             return success
 
-    def write_file(self, path: Path, content: str, overwrite: bool = False):
+    def write_file(self, path: str, content: str, overwrite: bool = False):
         with self.new_output_stream(path) as output_stream:
             output_stream.write(content.encode('utf-8'))
 
-    def overwrite_file_utf8(self, path: Path, content: str):
+    def overwrite_file_utf8(self, path: str, content: str):
         with self.new_output_stream(path) as output_stream:
             output_stream.write(content.encode('utf-8'))
 
-    def copy_file(self, source_path: Path, target_path: Path, overwrite: bool = False):
+    def copy_file(self, source_path: str, target_path: str, overwrite: bool = False):
         if not overwrite and self.exists(target_path):
             raise FileExistsError(f"Target file {target_path} already exists and overwrite=False")
 
-        self.filesystem.copy_file(str(source_path), str(target_path))
+        source_str = self.to_filesystem_path(source_path)
+        target_str = self.to_filesystem_path(target_path)
+        self.filesystem.copy_file(source_str, target_str)
 
-    def copy_files(self, source_directory: Path, target_directory: Path, overwrite: bool = False):
+    def copy_files(self, source_directory: str, target_directory: str, overwrite: bool = False):
         file_infos = self.list_status(source_directory)
         for file_info in file_infos:
             if file_info.type == pyarrow.fs.FileType.File:
-                source_file = Path(file_info.path)
-                target_file = target_directory / source_file.name
+                source_file = file_info.path
+                file_name = source_file.split('/')[-1]
+                target_file = f"{target_directory.rstrip('/')}/{file_name}" if target_directory else file_name
                 self.copy_file(source_file, target_file, overwrite)
 
-    def read_overwritten_file_utf8(self, path: Path) -> Optional[str]:
+    def read_overwritten_file_utf8(self, path: str) -> Optional[str]:
         retry_number = 0
         exception = None
         while retry_number < 5:
@@ -319,7 +332,7 @@ class FileIO:
 
         return None
 
-    def write_parquet(self, path: Path, data: pyarrow.Table, compression: str = 'snappy', **kwargs):
+    def write_parquet(self, path: str, data: pyarrow.Table, compression: str = 'snappy', **kwargs):
         try:
             import pyarrow.parquet as pq
 
@@ -330,7 +343,7 @@ class FileIO:
             self.delete_quietly(path)
             raise RuntimeError(f"Failed to write Parquet file {path}: {e}") from e
 
-    def write_orc(self, path: Path, data: pyarrow.Table, compression: str = 'zstd', **kwargs):
+    def write_orc(self, path: str, data: pyarrow.Table, compression: str = 'zstd', **kwargs):
         try:
             """Write ORC file using PyArrow ORC writer."""
             import sys
@@ -352,7 +365,7 @@ class FileIO:
             self.delete_quietly(path)
             raise RuntimeError(f"Failed to write ORC file {path}: {e}") from e
 
-    def write_avro(self, path: Path, data: pyarrow.Table, avro_schema: Optional[Dict[str, Any]] = None, **kwargs):
+    def write_avro(self, path: str, data: pyarrow.Table, avro_schema: Optional[Dict[str, Any]] = None, **kwargs):
         import fastavro
         if avro_schema is None:
             from pypaimon.schema.data_types import PyarrowFieldParser
@@ -370,7 +383,7 @@ class FileIO:
         with self.new_output_stream(path) as output_stream:
             fastavro.writer(output_stream, avro_schema, records, **kwargs)
 
-    def write_blob(self, path: Path, data: pyarrow.Table, blob_as_descriptor: bool, **kwargs):
+    def write_blob(self, path: str, data: pyarrow.Table, blob_as_descriptor: bool, **kwargs):
         try:
             # Validate input constraints
             if data.num_columns != 1:
@@ -423,3 +436,41 @@ class FileIO:
         except Exception as e:
             self.delete_quietly(path)
             raise RuntimeError(f"Failed to write blob file {path}: {e}") from e
+
+    def to_filesystem_path(self, path: str) -> str:
+        from pyarrow.fs import S3FileSystem
+        import re
+
+        parsed = urlparse(path)
+        normalized_path = re.sub(r'/+', '/', parsed.path) if parsed.path else ''
+
+        if parsed.scheme and len(parsed.scheme) == 1 and not parsed.netloc:
+            # This is likely a Windows drive letter, not a URI scheme
+            return str(path)
+
+        if parsed.scheme == 'file' and parsed.netloc and parsed.netloc.endswith(':'):
+            # file://C:/path format - netloc is 'C:', need to reconstruct path with drive letter
+            drive_letter = parsed.netloc.rstrip(':')
+            path_part = normalized_path.lstrip('/')
+            return f"{drive_letter}:/{path_part}" if path_part else f"{drive_letter}:"
+
+        if isinstance(self.filesystem, S3FileSystem):
+            # For S3, return "bucket/path" format
+            if parsed.scheme:
+                if parsed.netloc:
+                    # Has netloc (bucket): return "bucket/path" format
+                    path_part = normalized_path.lstrip('/')
+                    return f"{parsed.netloc}/{path_part}" if path_part else parsed.netloc
+                else:
+                    # Has scheme but no netloc: return path without scheme
+                    result = normalized_path.lstrip('/')
+                    return result if result else '.'
+            return str(path)
+
+        if parsed.scheme:
+            # Handle empty path: return '.' for current directory
+            if not normalized_path:
+                return '.'
+            return normalized_path
+
+        return str(path)

--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -127,11 +127,11 @@ class FileIO:
             raise RuntimeError("HADOOP_CONF_DIR environment variable is not set.")
 
         hadoop_home = os.environ.get("HADOOP_HOME")
-        native_lib_path = f"{hadoop_home}/lib/native"
+        native_lib_path = os.path.join(hadoop_home, "lib", "native")
         os.environ['LD_LIBRARY_PATH'] = f"{native_lib_path}:{os.environ.get('LD_LIBRARY_PATH', '')}"
 
         class_paths = subprocess.run(
-            [f'{hadoop_home}/bin/hadoop', 'classpath', '--glob'],
+            [os.path.join(hadoop_home, 'bin', 'hadoop'), 'classpath', '--glob'],
             capture_output=True,
             text=True,
             check=True
@@ -302,7 +302,7 @@ class FileIO:
             if file_info.type == pyarrow.fs.FileType.File:
                 source_file = file_info.path
                 file_name = source_file.split('/')[-1]
-                target_file = f"{target_directory.rstrip('/')}/{file_name}" if target_directory else file_name
+                target_file = os.path.join(target_directory, file_name) if target_directory else file_name
                 self.copy_file(source_file, target_file, overwrite)
 
     def read_overwritten_file_utf8(self, path: str) -> Optional[str]:

--- a/paimon-python/pypaimon/common/uri_reader.py
+++ b/paimon-python/pypaimon/common/uri_reader.py
@@ -18,7 +18,6 @@
 
 import io
 from abc import ABC, abstractmethod
-from pathlib import Path
 from typing import Any, Optional
 from urllib.parse import urlparse, ParseResult
 
@@ -42,12 +41,11 @@ class UriReader(ABC):
     def get_file_path(cls, uri: str):
         parsed_uri = urlparse(uri)
         if parsed_uri.scheme == 'file':
-            path = Path(parsed_uri.path)
+            return parsed_uri.path
         elif parsed_uri.scheme and parsed_uri.scheme != '':
-            path = Path(parsed_uri.netloc + parsed_uri.path)
+            return f"{parsed_uri.netloc}{parsed_uri.path}"
         else:
-            path = Path(uri)
-        return path
+            return uri
 
     @abstractmethod
     def new_input_stream(self, uri: str):
@@ -61,8 +59,7 @@ class FileUriReader(UriReader):
 
     def new_input_stream(self, uri: str):
         try:
-            path = self.get_file_path(uri)
-            return self._file_io.new_input_stream(path)
+            return self._file_io.new_input_stream(uri)
         except Exception as e:
             raise IOError(f"Failed to read file {uri}: {e}")
 

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import os
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from typing import List
@@ -39,7 +38,8 @@ class ManifestFileManager:
         from pypaimon.table.file_store_table import FileStoreTable
 
         self.table: FileStoreTable = table
-        self.manifest_path = os.path.join(table.table_path, "manifest")
+        manifest_path = table.table_path.rstrip('/')
+        self.manifest_path = f"{manifest_path}/manifest"
         self.file_io = table.file_io
         self.partition_keys_fields = self.table.partition_keys_fields
         self.primary_keys_fields = self.table.primary_keys_fields
@@ -70,7 +70,7 @@ class ManifestFileManager:
         return final_entries
 
     def read(self, manifest_file_name: str, manifest_entry_filter=None, drop_stats=True) -> List[ManifestEntry]:
-        manifest_file_path = os.path.join(self.manifest_path, manifest_file_name)
+        manifest_file_path = f"{self.manifest_path}/{manifest_file_name}"
 
         entries = []
         with self.file_io.new_input_stream(manifest_file_path) as input_stream:
@@ -189,7 +189,7 @@ class ManifestFileManager:
             }
             avro_records.append(avro_record)
 
-        manifest_path = os.path.join(self.manifest_path, file_name)
+        manifest_path = f"{self.manifest_path}/{file_name}"
         try:
             buffer = BytesIO()
             fastavro.writer(buffer, MANIFEST_ENTRY_SCHEMA, avro_records)

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import os
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from typing import List
@@ -38,8 +39,7 @@ class ManifestFileManager:
         from pypaimon.table.file_store_table import FileStoreTable
 
         self.table: FileStoreTable = table
-        manifest_path = table.table_path.rstrip('/')
-        self.manifest_path = f"{manifest_path}/manifest"
+        self.manifest_path = os.path.join(table.table_path, "manifest")
         self.file_io = table.file_io
         self.partition_keys_fields = self.table.partition_keys_fields
         self.primary_keys_fields = self.table.primary_keys_fields
@@ -70,7 +70,7 @@ class ManifestFileManager:
         return final_entries
 
     def read(self, manifest_file_name: str, manifest_entry_filter=None, drop_stats=True) -> List[ManifestEntry]:
-        manifest_file_path = f"{self.manifest_path}/{manifest_file_name}"
+        manifest_file_path = os.path.join(self.manifest_path, manifest_file_name)
 
         entries = []
         with self.file_io.new_input_stream(manifest_file_path) as input_stream:
@@ -189,7 +189,7 @@ class ManifestFileManager:
             }
             avro_records.append(avro_record)
 
-        manifest_path = f"{self.manifest_path}/{file_name}"
+        manifest_path = os.path.join(self.manifest_path, file_name)
         try:
             buffer = BytesIO()
             fastavro.writer(buffer, MANIFEST_ENTRY_SCHEMA, avro_records)

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -38,7 +38,8 @@ class ManifestFileManager:
         from pypaimon.table.file_store_table import FileStoreTable
 
         self.table: FileStoreTable = table
-        self.manifest_path = table.table_path / "manifest"
+        manifest_path = table.table_path.rstrip('/')
+        self.manifest_path = f"{manifest_path}/manifest"
         self.file_io = table.file_io
         self.partition_keys_fields = self.table.partition_keys_fields
         self.primary_keys_fields = self.table.primary_keys_fields
@@ -69,7 +70,7 @@ class ManifestFileManager:
         return final_entries
 
     def read(self, manifest_file_name: str, manifest_entry_filter=None, drop_stats=True) -> List[ManifestEntry]:
-        manifest_file_path = self.manifest_path / manifest_file_name
+        manifest_file_path = f"{self.manifest_path}/{manifest_file_name}"
 
         entries = []
         with self.file_io.new_input_stream(manifest_file_path) as input_stream:
@@ -188,7 +189,7 @@ class ManifestFileManager:
             }
             avro_records.append(avro_record)
 
-        manifest_path = self.manifest_path / file_name
+        manifest_path = f"{self.manifest_path}/{file_name}"
         try:
             buffer = BytesIO()
             fastavro.writer(buffer, MANIFEST_ENTRY_SCHEMA, avro_records)

--- a/paimon-python/pypaimon/manifest/manifest_list_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_list_manager.py
@@ -36,7 +36,8 @@ class ManifestListManager:
         from pypaimon.table.file_store_table import FileStoreTable
 
         self.table: FileStoreTable = table
-        self.manifest_path = self.table.table_path / "manifest"
+        manifest_path = table.table_path.rstrip('/')
+        self.manifest_path = f"{manifest_path}/manifest"
         self.file_io = self.table.file_io
 
     def read_all(self, snapshot: Snapshot) -> List[ManifestFileMeta]:
@@ -53,7 +54,7 @@ class ManifestListManager:
     def read(self, manifest_list_name: str) -> List[ManifestFileMeta]:
         manifest_files = []
 
-        manifest_list_path = self.manifest_path / manifest_list_name
+        manifest_list_path = f"{self.manifest_path}/{manifest_list_name}"
         with self.file_io.new_input_stream(manifest_list_path) as input_stream:
             avro_bytes = input_stream.read()
         buffer = BytesIO(avro_bytes)
@@ -101,7 +102,7 @@ class ManifestListManager:
             }
             avro_records.append(avro_record)
 
-        list_path = self.manifest_path / file_name
+        list_path = f"{self.manifest_path}/{file_name}"
         try:
             buffer = BytesIO()
             fastavro.writer(buffer, MANIFEST_FILE_META_SCHEMA, avro_records)

--- a/paimon-python/pypaimon/manifest/manifest_list_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_list_manager.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import os
 
 from io import BytesIO
 from typing import List
@@ -37,7 +36,8 @@ class ManifestListManager:
         from pypaimon.table.file_store_table import FileStoreTable
 
         self.table: FileStoreTable = table
-        self.manifest_path = os.path.join(table.table_path, "manifest")
+        manifest_path = table.table_path.rstrip('/')
+        self.manifest_path = f"{manifest_path}/manifest"
         self.file_io = self.table.file_io
 
     def read_all(self, snapshot: Snapshot) -> List[ManifestFileMeta]:
@@ -54,7 +54,7 @@ class ManifestListManager:
     def read(self, manifest_list_name: str) -> List[ManifestFileMeta]:
         manifest_files = []
 
-        manifest_list_path = os.path.join(self.manifest_path, manifest_list_name)
+        manifest_list_path = f"{self.manifest_path}/{manifest_list_name}"
         with self.file_io.new_input_stream(manifest_list_path) as input_stream:
             avro_bytes = input_stream.read()
         buffer = BytesIO(avro_bytes)
@@ -102,7 +102,7 @@ class ManifestListManager:
             }
             avro_records.append(avro_record)
 
-        list_path = os.path.join(self.manifest_path, file_name)
+        list_path = f"{self.manifest_path}/{file_name}"
         try:
             buffer = BytesIO()
             fastavro.writer(buffer, MANIFEST_FILE_META_SCHEMA, avro_records)

--- a/paimon-python/pypaimon/manifest/manifest_list_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_list_manager.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import os
 
 from io import BytesIO
 from typing import List
@@ -36,8 +37,7 @@ class ManifestListManager:
         from pypaimon.table.file_store_table import FileStoreTable
 
         self.table: FileStoreTable = table
-        manifest_path = table.table_path.rstrip('/')
-        self.manifest_path = f"{manifest_path}/manifest"
+        self.manifest_path = os.path.join(table.table_path, "manifest")
         self.file_io = self.table.file_io
 
     def read_all(self, snapshot: Snapshot) -> List[ManifestFileMeta]:
@@ -54,7 +54,7 @@ class ManifestListManager:
     def read(self, manifest_list_name: str) -> List[ManifestFileMeta]:
         manifest_files = []
 
-        manifest_list_path = f"{self.manifest_path}/{manifest_list_name}"
+        manifest_list_path = os.path.join(self.manifest_path, manifest_list_name)
         with self.file_io.new_input_stream(manifest_list_path) as input_stream:
             avro_bytes = input_stream.read()
         buffer = BytesIO(avro_bytes)
@@ -102,7 +102,7 @@ class ManifestListManager:
             }
             avro_records.append(avro_record)
 
-        list_path = f"{self.manifest_path}/{file_name}"
+        list_path = os.path.join(self.manifest_path, file_name)
         try:
             buffer = BytesIO()
             fastavro.writer(buffer, MANIFEST_FILE_META_SCHEMA, avro_records)

--- a/paimon-python/pypaimon/manifest/schema/data_file_meta.py
+++ b/paimon-python/pypaimon/manifest/schema/data_file_meta.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import os
 
 from dataclasses import dataclass
 from datetime import datetime
@@ -50,15 +51,16 @@ class DataFileMeta:
     write_cols: Optional[List[str]] = None
 
     # not a schema field, just for internal usage
-    file_path: str = None
+    file_path: Optional[str] = None
 
     def set_file_path(self, table_path: str, partition: GenericRow, bucket: int):
-        path_builder = table_path.rstrip('/')
+        path_components = [table_path]
         partition_dict = partition.to_dict()
         for field_name, field_value in partition_dict.items():
-            path_builder = f"{path_builder}/{field_name}={str(field_value)}"
-        path_builder = f"{path_builder}/bucket-{str(bucket)}/{self.file_name}"
-        self.file_path = path_builder
+            path_components.append(f"{field_name}={str(field_value)}")
+        path_components.append(f"bucket-{str(bucket)}")
+        path_components.append(self.file_name)
+        self.file_path = str(os.path.join(*path_components))
 
     def copy_without_stats(self) -> 'DataFileMeta':
         """Create a new DataFileMeta without value statistics."""

--- a/paimon-python/pypaimon/manifest/schema/data_file_meta.py
+++ b/paimon-python/pypaimon/manifest/schema/data_file_meta.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import os
 
 from dataclasses import dataclass
 from datetime import datetime
@@ -51,16 +50,15 @@ class DataFileMeta:
     write_cols: Optional[List[str]] = None
 
     # not a schema field, just for internal usage
-    file_path: Optional[str] = None
+    file_path: str = None
 
     def set_file_path(self, table_path: str, partition: GenericRow, bucket: int):
-        path_components = [table_path]
+        path_builder = table_path.rstrip('/')
         partition_dict = partition.to_dict()
         for field_name, field_value in partition_dict.items():
-            path_components.append(f"{field_name}={str(field_value)}")
-        path_components.append(f"bucket-{str(bucket)}")
-        path_components.append(self.file_name)
-        self.file_path = str(os.path.join(*path_components))
+            path_builder = f"{path_builder}/{field_name}={str(field_value)}"
+        path_builder = f"{path_builder}/bucket-{str(bucket)}/{self.file_name}"
+        self.file_path = path_builder
 
     def copy_without_stats(self) -> 'DataFileMeta':
         """Create a new DataFileMeta without value statistics."""

--- a/paimon-python/pypaimon/manifest/schema/data_file_meta.py
+++ b/paimon-python/pypaimon/manifest/schema/data_file_meta.py
@@ -18,7 +18,6 @@
 
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
 from typing import List, Optional
 
 from pypaimon.manifest.schema.simple_stats import (KEY_STATS_SCHEMA, VALUE_STATS_SCHEMA,
@@ -53,13 +52,13 @@ class DataFileMeta:
     # not a schema field, just for internal usage
     file_path: str = None
 
-    def set_file_path(self, table_path: Path, partition: GenericRow, bucket: int):
-        path_builder = table_path
+    def set_file_path(self, table_path: str, partition: GenericRow, bucket: int):
+        path_builder = table_path.rstrip('/')
         partition_dict = partition.to_dict()
         for field_name, field_value in partition_dict.items():
-            path_builder = path_builder / (field_name + "=" + str(field_value))
-        path_builder = path_builder / ("bucket-" + str(bucket)) / self.file_name
-        self.file_path = str(path_builder)
+            path_builder = f"{path_builder}/{field_name}={str(field_value)}"
+        path_builder = f"{path_builder}/bucket-{str(bucket)}/{self.file_name}"
+        self.file_path = path_builder
 
     def copy_without_stats(self) -> 'DataFileMeta':
         """Create a new DataFileMeta without value statistics."""

--- a/paimon-python/pypaimon/read/reader/format_avro_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_avro_reader.py
@@ -36,7 +36,8 @@ class FormatAvroReader(RecordBatchReader):
 
     def __init__(self, file_io: FileIO, file_path: str, read_fields: List[str], full_fields: List[DataField],
                  push_down_predicate: Any, batch_size: int = 4096):
-        self._file = file_io.filesystem.open_input_file(file_path)
+        file_path_for_io = file_io.to_filesystem_path(file_path)
+        self._file = file_io.filesystem.open_input_file(file_path_for_io)
         self._avro_reader = fastavro.reader(self._file)
         self._batch_size = batch_size
         self._push_down_predicate = push_down_predicate

--- a/paimon-python/pypaimon/read/reader/format_blob_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_blob_reader.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 ################################################################################
 import struct
-from pathlib import Path
 from typing import List, Optional, Any, Iterator
 
 import pyarrow as pa
@@ -42,7 +41,7 @@ class FormatBlobReader(RecordBatchReader):
         self._blob_as_descriptor = blob_as_descriptor
 
         # Get file size
-        self._file_size = file_io.get_file_size(Path(file_path))
+        self._file_size = file_io.get_file_size(file_path)
 
         # Initialize the low-level blob format reader
         self.file_path = file_path
@@ -124,7 +123,7 @@ class FormatBlobReader(RecordBatchReader):
         self._blob_iterator = None
 
     def _read_index(self) -> None:
-        with self._file_io.new_input_stream(Path(self.file_path)) as f:
+        with self._file_io.new_input_stream(self.file_path) as f:
             # Seek to header: last 5 bytes
             f.seek(self._file_size - 5)
             header = f.read(5)

--- a/paimon-python/pypaimon/read/reader/format_pyarrow_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_pyarrow_reader.py
@@ -33,7 +33,8 @@ class FormatPyArrowReader(RecordBatchReader):
 
     def __init__(self, file_io: FileIO, file_format: str, file_path: str, read_fields: List[str],
                  push_down_predicate: Any, batch_size: int = 4096):
-        self.dataset = ds.dataset(file_path, format=file_format, filesystem=file_io.filesystem)
+        file_path_for_pyarrow = file_io.to_filesystem_path(file_path)
+        self.dataset = ds.dataset(file_path_for_pyarrow, format=file_format, filesystem=file_io.filesystem)
         self.reader = self.dataset.scanner(
             columns=read_fields,
             filter=push_down_predicate,

--- a/paimon-python/pypaimon/sample/oss_blob_as_descriptor.py
+++ b/paimon-python/pypaimon/sample/oss_blob_as_descriptor.py
@@ -1,0 +1,111 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+
+import logging
+import pyarrow as pa
+
+from pypaimon.catalog.catalog_factory import CatalogFactory
+
+# Enable debug logging for catalog operations
+logging.basicConfig(level=logging.DEBUG, format='%(levelname)s: %(name)s: %(message)s')
+from pypaimon.schema.schema import Schema
+from pypaimon.table.row.blob import BlobDescriptor, Blob
+
+
+def oss_blob_as_descriptor():
+    warehouse = 'oss://<your-bucket>/<warehouse-path>'
+    catalog = CatalogFactory.create({
+        'warehouse': warehouse,
+        'fs.oss.endpoint': 'oss-<your-region>.aliyuncs.com',
+        'fs.oss.accessKeyId': '<your-ak>',
+        'fs.oss.accessKeySecret': '<your-sk>',
+        'fs.oss.region': '<your-region>'
+    })
+
+    pa_schema = pa.schema([
+        ('id', pa.int32()),
+        ('blob_data', pa.large_binary()),
+    ])
+
+    schema = Schema.from_pyarrow_schema(
+        pa_schema,
+        options={
+            'row-tracking.enabled': 'true',
+            'data-evolution.enabled': 'true',
+            'blob-as-descriptor': 'true',
+            'target-file-size': '100MB'
+        }
+    )
+
+    catalog.create_database("test_db", True)
+    catalog.create_table("test_db.blob_uri_scheme_test", schema, True)
+    table = catalog.get_table("test_db.blob_uri_scheme_test")
+
+    # Create external blob file in OSS
+    external_blob_uri = f"{warehouse.rstrip('/')}/external_blob_scheme_test.bin"
+    blob_content = b'This is external blob data'
+
+    with table.file_io.new_output_stream(external_blob_uri) as out_stream:
+        out_stream.write(blob_content)
+
+    # Create BlobDescriptor with OSS scheme
+    blob_descriptor = BlobDescriptor(external_blob_uri, 0, len(blob_content))
+    descriptor_bytes = blob_descriptor.serialize()
+
+    # Write the descriptor bytes to the table
+    test_data = pa.Table.from_pydict({
+        'id': [1],
+        'blob_data': [descriptor_bytes]
+    }, schema=pa_schema)
+
+    write_builder = table.new_batch_write_builder()
+    writer = write_builder.new_write()
+    writer.write_arrow(test_data)
+    commit_messages = writer.prepare_commit()
+    commit = write_builder.new_commit()
+    commit.commit(commit_messages)
+    writer.close()
+
+    read_builder = table.new_read_builder()
+    table_scan = read_builder.new_scan()
+    table_read = read_builder.new_read()
+    result = table_read.to_arrow(table_scan.plan().splits())
+
+    picture_bytes = result.column('blob_data').to_pylist()[0]
+    new_blob_descriptor = BlobDescriptor.deserialize(picture_bytes)
+
+    print(f"Original URI: {external_blob_uri}")
+    print(f"Read URI: {new_blob_descriptor.uri}")
+    assert new_blob_descriptor.uri.startswith('oss://'), \
+        f"URI scheme should be preserved. Got: {new_blob_descriptor.uri}"
+
+    from pypaimon.common.uri_reader import FileUriReader
+    uri_reader = FileUriReader(table.file_io)
+    blob = Blob.from_descriptor(uri_reader, new_blob_descriptor)
+
+    blob_descriptor_from_blob = blob.to_descriptor()
+    print(f"Blob descriptor URI from Blob.from_descriptor: {blob_descriptor_from_blob.uri}")
+
+    read_data = blob.to_data()
+    assert read_data == blob_content, "Blob data should match original content"
+
+    print("✅ All assertions passed!")
+
+
+if __name__ == '__main__':
+    oss_blob_as_descriptor()

--- a/paimon-python/pypaimon/sample/oss_blob_as_descriptor.py
+++ b/paimon-python/pypaimon/sample/oss_blob_as_descriptor.py
@@ -17,7 +17,6 @@
 ################################################################################
 
 import logging
-import os
 import pyarrow as pa
 
 from pypaimon.catalog.catalog_factory import CatalogFactory
@@ -58,7 +57,7 @@ def oss_blob_as_descriptor():
     table = catalog.get_table("test_db.blob_uri_scheme_test")
 
     # Create external blob file in OSS
-    external_blob_uri = os.path.join(warehouse, "external_blob_scheme_test.bin")
+    external_blob_uri = f"{warehouse.rstrip('/')}/external_blob_scheme_test.bin"
     blob_content = b'This is external blob data'
 
     with table.file_io.new_output_stream(external_blob_uri) as out_stream:

--- a/paimon-python/pypaimon/sample/oss_blob_as_descriptor.py
+++ b/paimon-python/pypaimon/sample/oss_blob_as_descriptor.py
@@ -17,6 +17,7 @@
 ################################################################################
 
 import logging
+import os
 import pyarrow as pa
 
 from pypaimon.catalog.catalog_factory import CatalogFactory
@@ -57,7 +58,7 @@ def oss_blob_as_descriptor():
     table = catalog.get_table("test_db.blob_uri_scheme_test")
 
     # Create external blob file in OSS
-    external_blob_uri = f"{warehouse.rstrip('/')}/external_blob_scheme_test.bin"
+    external_blob_uri = os.path.join(warehouse, "external_blob_scheme_test.bin")
     blob_content = b'This is external blob data'
 
     with table.file_io.new_output_stream(external_blob_uri) as out_stream:

--- a/paimon-python/pypaimon/sample/rest_catalog_read_write_sample.py
+++ b/paimon-python/pypaimon/sample/rest_catalog_read_write_sample.py
@@ -106,4 +106,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/paimon-python/pypaimon/sample/rest_catalog_read_write_sample.py
+++ b/paimon-python/pypaimon/sample/rest_catalog_read_write_sample.py
@@ -1,0 +1,109 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+"""
+Example: REST Catalog Read and Write
+
+Demonstrates:
+1. REST catalog basic read/write operations
+2. Table paths include URI schemes (file://, oss://, s3://)
+3. Paths with schemes can be used directly with FileIO
+"""
+
+import tempfile
+import uuid
+
+import pandas as pd
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.tests.rest.rest_server import RESTCatalogServer
+from pypaimon.api.api_response import ConfigResponse
+from pypaimon.api.auth import BearTokenAuthProvider
+
+
+def main():
+    """REST catalog read/write example with path scheme demonstration."""
+
+    # Setup mock REST server
+    temp_dir = tempfile.mkdtemp()
+    token = str(uuid.uuid4())
+    server = RESTCatalogServer(
+        data_path=temp_dir,
+        auth_provider=BearTokenAuthProvider(token),
+        config=ConfigResponse(defaults={"prefix": "mock-test"}),
+        warehouse="warehouse"
+    )
+    server.start()
+    print(f"REST server started at: {server.get_url()}")
+
+    try:
+        # Note: warehouse must match server's warehouse parameter for config endpoint
+        catalog = CatalogFactory.create({
+            'metastore': 'rest',
+            'uri': f"http://localhost:{server.port}",
+            'warehouse': "warehouse",  # Must match server's warehouse parameter
+            'token.provider': 'bear',
+            'token': token,
+        })
+        catalog.create_database("default", False)
+
+        schema = Schema.from_pyarrow_schema(pa.schema([
+            ('id', pa.int64()),
+            ('name', pa.string()),
+            ('value', pa.float64()),
+        ]))
+        table_name = 'default.example_table'
+        catalog.create_table(table_name, schema, False)
+        table = catalog.get_table(table_name)
+
+        table_path = table.table_path
+        print(f"\nTable path: {table_path}")
+
+        print("\nWriting data...")
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+
+        data = pd.DataFrame({
+            'id': [1, 2, 3],
+            'name': ['Alice', 'Bob', 'Charlie'],
+            'value': [10.5, 20.3, 30.7]
+        })
+        table_write.write_pandas(data)
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+        print("Data written successfully!")
+
+        # Read data
+        print("\nReading data...")
+        read_builder = table.new_read_builder()
+        table_scan = read_builder.new_scan()
+        table_read = read_builder.new_read()
+        splits = table_scan.plan().splits()
+        result = table_read.to_pandas(splits)
+        print(result)
+
+    finally:
+        server.shutdown()
+        print("\nServer stopped")
+
+
+if __name__ == '__main__':
+    main()
+

--- a/paimon-python/pypaimon/schema/schema_manager.py
+++ b/paimon-python/pypaimon/schema/schema_manager.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from pathlib import Path
 from typing import Optional, List
 
 from pypaimon.common.file_io import FileIO
@@ -26,11 +25,11 @@ from pypaimon.schema.table_schema import TableSchema
 
 class SchemaManager:
 
-    def __init__(self, file_io: FileIO, table_path: Path):
+    def __init__(self, file_io: FileIO, table_path: str):
         self.schema_prefix = "schema-"
         self.file_io = file_io
         self.table_path = table_path
-        self.schema_path = table_path / "schema"
+        self.schema_path = f"{table_path.rstrip('/')}/schema"
         self.schema_cache = {}
 
     def latest(self) -> Optional['TableSchema']:
@@ -65,8 +64,8 @@ class SchemaManager:
         except Exception as e:
             raise RuntimeError(f"Failed to commit schema: {e}") from e
 
-    def _to_schema_path(self, schema_id: int) -> Path:
-        return self.schema_path / f"{self.schema_prefix}{schema_id}"
+    def _to_schema_path(self, schema_id: int) -> str:
+        return f"{self.schema_path.rstrip('/')}/{self.schema_prefix}{schema_id}"
 
     def get_schema(self, schema_id: int) -> Optional[TableSchema]:
         if schema_id not in self.schema_cache:
@@ -87,7 +86,7 @@ class SchemaManager:
 
         versions = []
         for status in statuses:
-            name = Path(status.path).name
+            name = status.path.split('/')[-1]
             if name.startswith(self.schema_prefix):
                 try:
                     version = int(name[len(self.schema_prefix):])

--- a/paimon-python/pypaimon/schema/schema_manager.py
+++ b/paimon-python/pypaimon/schema/schema_manager.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import os
 from typing import Optional, List
 
 from pypaimon.common.file_io import FileIO
@@ -29,7 +30,7 @@ class SchemaManager:
         self.schema_prefix = "schema-"
         self.file_io = file_io
         self.table_path = table_path
-        self.schema_path = f"{table_path.rstrip('/')}/schema"
+        self.schema_path = os.path.join(table_path, "schema")
         self.schema_cache = {}
 
     def latest(self) -> Optional['TableSchema']:
@@ -65,7 +66,7 @@ class SchemaManager:
             raise RuntimeError(f"Failed to commit schema: {e}") from e
 
     def _to_schema_path(self, schema_id: int) -> str:
-        return f"{self.schema_path.rstrip('/')}/{self.schema_prefix}{schema_id}"
+        return os.path.join(self.schema_path, f"{self.schema_prefix}{schema_id}")
 
     def get_schema(self, schema_id: int) -> Optional[TableSchema]:
         if schema_id not in self.schema_cache:

--- a/paimon-python/pypaimon/schema/schema_manager.py
+++ b/paimon-python/pypaimon/schema/schema_manager.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import os
 from typing import Optional, List
 
 from pypaimon.common.file_io import FileIO
@@ -30,7 +29,7 @@ class SchemaManager:
         self.schema_prefix = "schema-"
         self.file_io = file_io
         self.table_path = table_path
-        self.schema_path = os.path.join(table_path, "schema")
+        self.schema_path = f"{table_path.rstrip('/')}/schema"
         self.schema_cache = {}
 
     def latest(self) -> Optional['TableSchema']:
@@ -66,7 +65,7 @@ class SchemaManager:
             raise RuntimeError(f"Failed to commit schema: {e}") from e
 
     def _to_schema_path(self, schema_id: int) -> str:
-        return os.path.join(self.schema_path, f"{self.schema_prefix}{schema_id}")
+        return f"{self.schema_path.rstrip('/')}/{self.schema_prefix}{schema_id}"
 
     def get_schema(self, schema_id: int) -> Optional[TableSchema]:
         if schema_id not in self.schema_cache:

--- a/paimon-python/pypaimon/snapshot/snapshot_manager.py
+++ b/paimon-python/pypaimon/snapshot/snapshot_manager.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import os
 from typing import Optional
 
 from pypaimon.common.file_io import FileIO
@@ -31,8 +30,9 @@ class SnapshotManager:
 
         self.table: FileStoreTable = table
         self.file_io: FileIO = self.table.file_io
-        self.snapshot_dir = os.path.join(self.table.table_path, "snapshot")
-        self.latest_file = os.path.join(self.snapshot_dir, "LATEST")
+        snapshot_path = self.table.table_path.rstrip('/')
+        self.snapshot_dir = f"{snapshot_path}/snapshot"
+        self.latest_file = f"{self.snapshot_dir}/LATEST"
 
     def get_latest_snapshot(self) -> Optional[Snapshot]:
         if not self.file_io.exists(self.latest_file):
@@ -41,7 +41,7 @@ class SnapshotManager:
         latest_content = self.file_io.read_file_utf8(self.latest_file)
         latest_snapshot_id = int(latest_content.strip())
 
-        snapshot_file = os.path.join(self.snapshot_dir, f"snapshot-{latest_snapshot_id}")
+        snapshot_file = f"{self.snapshot_dir}/snapshot-{latest_snapshot_id}"
         if not self.file_io.exists(snapshot_file):
             return None
 
@@ -58,10 +58,10 @@ class SnapshotManager:
         Returns:
             Path to the snapshot file
         """
-        return os.path.join(self.snapshot_dir, f"snapshot-{snapshot_id}")
+        return f"{self.snapshot_dir}/snapshot-{snapshot_id}"
 
     def try_get_earliest_snapshot(self) -> Optional[Snapshot]:
-        earliest_file = os.path.join(self.snapshot_dir, "EARLIEST")
+        earliest_file = f"{self.snapshot_dir}/EARLIEST"
         if self.file_io.exists(earliest_file):
             earliest_content = self.file_io.read_file_utf8(earliest_file)
             earliest_snapshot_id = int(earliest_content.strip())

--- a/paimon-python/pypaimon/snapshot/snapshot_manager.py
+++ b/paimon-python/pypaimon/snapshot/snapshot_manager.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import os
 from typing import Optional
 
 from pypaimon.common.file_io import FileIO
@@ -30,9 +31,8 @@ class SnapshotManager:
 
         self.table: FileStoreTable = table
         self.file_io: FileIO = self.table.file_io
-        snapshot_path = self.table.table_path.rstrip('/')
-        self.snapshot_dir = f"{snapshot_path}/snapshot"
-        self.latest_file = f"{self.snapshot_dir}/LATEST"
+        self.snapshot_dir = os.path.join(self.table.table_path, "snapshot")
+        self.latest_file = os.path.join(self.snapshot_dir, "LATEST")
 
     def get_latest_snapshot(self) -> Optional[Snapshot]:
         if not self.file_io.exists(self.latest_file):
@@ -41,7 +41,7 @@ class SnapshotManager:
         latest_content = self.file_io.read_file_utf8(self.latest_file)
         latest_snapshot_id = int(latest_content.strip())
 
-        snapshot_file = f"{self.snapshot_dir}/snapshot-{latest_snapshot_id}"
+        snapshot_file = os.path.join(self.snapshot_dir, f"snapshot-{latest_snapshot_id}")
         if not self.file_io.exists(snapshot_file):
             return None
 
@@ -58,10 +58,10 @@ class SnapshotManager:
         Returns:
             Path to the snapshot file
         """
-        return f"{self.snapshot_dir}/snapshot-{snapshot_id}"
+        return os.path.join(self.snapshot_dir, f"snapshot-{snapshot_id}")
 
     def try_get_earliest_snapshot(self) -> Optional[Snapshot]:
-        earliest_file = f"{self.snapshot_dir}/EARLIEST"
+        earliest_file = os.path.join(self.snapshot_dir, "EARLIEST")
         if self.file_io.exists(earliest_file):
             earliest_content = self.file_io.read_file_utf8(earliest_file)
             earliest_snapshot_id = int(earliest_content.strip())

--- a/paimon-python/pypaimon/table/file_store_table.py
+++ b/paimon-python/pypaimon/table/file_store_table.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 ################################################################################
 
-from pathlib import Path
 from typing import Optional
 
 from pypaimon.catalog.catalog_environment import CatalogEnvironment
@@ -37,7 +36,7 @@ from pypaimon.write.row_key_extractor import (DynamicBucketRowKeyExtractor,
 
 
 class FileStoreTable(Table):
-    def __init__(self, file_io: FileIO, identifier: Identifier, table_path: Path,
+    def __init__(self, file_io: FileIO, identifier: Identifier, table_path: str,
                  table_schema: TableSchema, catalog_environment: Optional[CatalogEnvironment] = None):
         self.file_io = file_io
         self.identifier = identifier

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1059,6 +1059,13 @@ class DataBlobWriterTest(unittest.TestCase):
         uri_reader = uri_reader_factory.create(new_blob_descriptor.uri)
         blob = Blob.from_descriptor(uri_reader, new_blob_descriptor)
 
+        blob_descriptor_from_blob = blob.to_descriptor()
+        self.assertEqual(
+            blob_descriptor_from_blob.uri,
+            new_blob_descriptor.uri,
+            f"URI should be preserved. Expected: {new_blob_descriptor.uri}, Got: {blob_descriptor_from_blob.uri}"
+        )
+
         # Verify the blob data matches the original
         self.assertEqual(blob.to_data(), blob_data, "Blob data should match original")
 

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -40,15 +40,34 @@ class MockFileIO:
 
     def get_file_size(self, path: str) -> int:
         """Get file size."""
-        return self._file_io.get_file_size(Path(path))
+        return self._file_io.get_file_size(path)
 
-    def new_input_stream(self, path: Path):
+    def new_input_stream(self, path):
         """Create new input stream for reading."""
+        if not isinstance(path, (str, type(None))):
+            path = str(path)
         return self._file_io.new_input_stream(path)
 
 
 class BlobTest(unittest.TestCase):
     """Tests for Blob interface following org.apache.paimon.data.BlobTest."""
+
+    @staticmethod
+    def _to_url(path):
+        if isinstance(path, Path):
+            path_str = str(path)
+            is_absolute = os.path.isabs(path_str) or (len(path_str) >= 2 and path_str[1] == ':')
+            if is_absolute:
+                if path_str.startswith('/'):
+                    # Unix absolute path: file:///path (three slashes total)
+                    return f"file://{path_str}"
+                else:
+                    # Windows absolute path: file:///C:/path (three slashes)
+                    return f"file:///{path_str}"
+            else:
+                # Relative path: use file:// (two slashes)
+                return f"file://{path_str}"
+        return str(path) if path else path
 
     def setUp(self):
         """Set up test environment with temporary file."""
@@ -528,6 +547,34 @@ class BlobTest(unittest.TestCase):
 class BlobEndToEndTest(unittest.TestCase):
     """End-to-end tests for blob functionality with schema definition, file writing, and reading."""
 
+    @staticmethod
+    def _to_url(path):
+        """Convert Path to string for FileIO methods.
+        
+        For absolute paths (Unix /path or Windows C:/path), uses file:/// (three slashes)
+        to comply with RFC 8089 file URI specification.
+        For relative paths, uses file:// (two slashes).
+        """
+        if isinstance(path, Path):
+            path_str = str(path)
+            # Check if it's an absolute path
+            # Unix: starts with /, Windows: has drive letter (C:, D:, etc.)
+            is_absolute = os.path.isabs(path_str) or (len(path_str) >= 2 and path_str[1] == ':')
+            if is_absolute:
+                # Absolute path: use file:/// (three slashes per RFC 8089)
+                # For Unix paths starting with /, we get file:////path which is wrong
+                # So we need to handle it differently
+                if path_str.startswith('/'):
+                    # Unix absolute path: file:///path (three slashes total)
+                    return f"file://{path_str}"
+                else:
+                    # Windows absolute path: file:///C:/path (three slashes)
+                    return f"file:///{path_str}"
+            else:
+                # Relative path: use file:// (two slashes)
+                return f"file://{path_str}"
+        return str(path) if path else path
+
     def setUp(self):
         """Set up test environment."""
         self.temp_dir = tempfile.mkdtemp()
@@ -562,9 +609,11 @@ class BlobEndToEndTest(unittest.TestCase):
         blob_data = [test_data[blob_field_name].to_data()]
         schema = pa.schema([pa.field(blob_field_name, pa.large_binary())])
         table = pa.table([blob_data], schema=schema)
-        blob_files[blob_field_name] = Path(self.temp_dir) / (blob_field_name + ".blob")
-        file_io.write_blob(blob_files[blob_field_name], table, False)
-        self.assertTrue(file_io.exists(blob_files[blob_field_name]))
+        blob_file_path = Path(self.temp_dir) / (blob_field_name + ".blob")
+        blob_file_url = self._to_url(blob_file_path)
+        blob_files[blob_field_name] = blob_file_url
+        file_io.write_blob(blob_file_url, table, False)
+        self.assertTrue(file_io.exists(blob_file_url))
 
         # ========== Step 3: Read Data and Check Data ==========
         for field_name, file_path in blob_files.items():
@@ -597,7 +646,6 @@ class BlobEndToEndTest(unittest.TestCase):
         from pypaimon.common.file_io import FileIO
         from pypaimon.table.row.generic_row import GenericRow, GenericRowSerializer
         from pypaimon.table.row.row_kind import RowKind
-        from pathlib import Path
 
         # Set up file I/O
         file_io = FileIO(self.temp_dir, {})
@@ -678,10 +726,11 @@ class BlobEndToEndTest(unittest.TestCase):
         ], schema=multi_column_schema)
 
         multi_column_file = Path(self.temp_dir) / "multi_column.blob"
+        multi_column_url = self._to_url(multi_column_file)
 
         # Should throw RuntimeError for multiple columns
         with self.assertRaises(RuntimeError) as context:
-            file_io.write_blob(multi_column_file, multi_column_table, False)
+            file_io.write_blob(multi_column_url, multi_column_table, False)
         self.assertIn("single column", str(context.exception))
 
         # Test that FileIO.write_blob rejects null values
@@ -689,10 +738,11 @@ class BlobEndToEndTest(unittest.TestCase):
         null_table = pa.table([[b"data", None]], schema=null_schema)
 
         null_file = Path(self.temp_dir) / "null_data.blob"
+        null_file_url = self._to_url(null_file)
 
         # Should throw RuntimeError for null values
         with self.assertRaises(RuntimeError) as context:
-            file_io.write_blob(null_file, null_table, False)
+            file_io.write_blob(null_file_url, null_table, False)
         self.assertIn("null values", str(context.exception))
 
         # ========== Test FormatBlobReader with complex type schema ==========
@@ -702,7 +752,8 @@ class BlobEndToEndTest(unittest.TestCase):
         valid_table = pa.table([valid_blob_data], schema=valid_schema)
 
         valid_blob_file = Path(self.temp_dir) / "valid_blob.blob"
-        file_io.write_blob(valid_blob_file, valid_table, False)
+        valid_blob_url = self._to_url(valid_blob_file)
+        file_io.write_blob(valid_blob_url, valid_table, False)
 
         # Try to read with complex type field definition - this should fail
         # because FormatBlobReader tries to create PyArrow schema with complex types
@@ -737,7 +788,6 @@ class BlobEndToEndTest(unittest.TestCase):
         from pypaimon.schema.data_types import DataField, AtomicType
         from pypaimon.common.file_io import FileIO
         from pypaimon.common.delta_varint_compressor import DeltaVarintCompressor
-        from pathlib import Path
 
         # Set up file I/O
         file_io = FileIO(self.temp_dir, {})
@@ -750,7 +800,8 @@ class BlobEndToEndTest(unittest.TestCase):
         valid_table = pa.table([valid_blob_data], schema=valid_schema)
 
         header_test_file = Path(self.temp_dir) / "header_test.blob"
-        file_io.write_blob(header_test_file, valid_table, False)
+        header_test_url = self._to_url(header_test_file)
+        file_io.write_blob(header_test_url, valid_table, False)
 
         # Read the file and corrupt the header (last 5 bytes: index_length + version)
         with open(header_test_file, 'rb') as f:
@@ -788,7 +839,8 @@ class BlobEndToEndTest(unittest.TestCase):
         large_table = pa.table([large_blob_data], schema=large_schema)
 
         full_blob_file = Path(self.temp_dir) / "full_blob.blob"
-        file_io.write_blob(full_blob_file, large_table, False)
+        full_blob_url = self._to_url(full_blob_file)
+        file_io.write_blob(full_blob_url, large_table, False)
 
         # Read the full file and truncate it in the middle
         with open(full_blob_file, 'rb') as f:
@@ -826,11 +878,12 @@ class BlobEndToEndTest(unittest.TestCase):
         zero_table = pa.table([zero_blob_data], schema=zero_schema)
 
         zero_blob_file = Path(self.temp_dir) / "zero_length.blob"
-        file_io.write_blob(zero_blob_file, zero_table, False)
+        zero_blob_url = self._to_url(zero_blob_file)
+        file_io.write_blob(zero_blob_url, zero_table, False)
 
         # Verify file was created
-        self.assertTrue(file_io.exists(zero_blob_file))
-        file_size = file_io.get_file_size(zero_blob_file)
+        self.assertTrue(file_io.exists(zero_blob_url))
+        file_size = file_io.get_file_size(zero_blob_url)
         self.assertGreater(file_size, 0)  # File should have headers even with empty blob
 
         # Read zero-length blob
@@ -868,10 +921,11 @@ class BlobEndToEndTest(unittest.TestCase):
         large_sim_table = pa.table([simulated_large_data], schema=large_sim_schema)
 
         large_sim_file = Path(self.temp_dir) / "large_simulation.blob"
-        file_io.write_blob(large_sim_file, large_sim_table, False)
+        large_sim_url = self._to_url(large_sim_file)
+        file_io.write_blob(large_sim_url, large_sim_table, False)
 
         # Verify large file was written
-        large_sim_size = file_io.get_file_size(large_sim_file)
+        large_sim_size = file_io.get_file_size(large_sim_url)
         self.assertGreater(large_sim_size, 10 * 1024 * 1024)  # Should be > 10MB
 
         # Read large blob in memory-safe manner
@@ -937,10 +991,11 @@ class BlobEndToEndTest(unittest.TestCase):
         ], schema=multi_field_schema)
 
         multi_field_file = Path(self.temp_dir) / "multi_field.blob"
+        multi_field_url = self._to_url(multi_field_file)
 
         # Should reject multi-field table
         with self.assertRaises(RuntimeError) as context:
-            file_io.write_blob(multi_field_file, multi_field_table, False)
+            file_io.write_blob(multi_field_url, multi_field_table, False)
         self.assertIn("single column", str(context.exception))
 
         # Test that blob format rejects non-binary field types
@@ -948,10 +1003,11 @@ class BlobEndToEndTest(unittest.TestCase):
         non_binary_table = pa.table([["not_binary_data"]], schema=non_binary_schema)
 
         non_binary_file = Path(self.temp_dir) / "non_binary.blob"
+        non_binary_url = self._to_url(non_binary_file)
 
         # Should reject non-binary field
         with self.assertRaises(RuntimeError) as context:
-            file_io.write_blob(non_binary_file, non_binary_table, False)
+            file_io.write_blob(non_binary_url, non_binary_table, False)
         # Should fail due to type conversion issues (non-binary field can't be converted to BLOB)
         self.assertTrue(
             "large_binary" in str(context.exception) or
@@ -965,10 +1021,11 @@ class BlobEndToEndTest(unittest.TestCase):
         null_table = pa.table([[b"data", None, b"more_data"]], schema=null_schema)
 
         null_file = Path(self.temp_dir) / "with_nulls.blob"
+        null_file_url = self._to_url(null_file)
 
         # Should reject null values
         with self.assertRaises(RuntimeError) as context:
-            file_io.write_blob(null_file, null_table, False)
+            file_io.write_blob(null_file_url, null_table, False)
         self.assertIn("null values", str(context.exception))
 
     def test_blob_end_to_end_with_descriptor(self):
@@ -1007,10 +1064,11 @@ class BlobEndToEndTest(unittest.TestCase):
 
         # Write the blob file with blob_as_descriptor=True
         blob_file_path = Path(self.temp_dir) / "descriptor_blob.blob"
-        file_io.write_blob(blob_file_path, table, blob_as_descriptor=True)
+        blob_file_url = self._to_url(blob_file_path)
+        file_io.write_blob(blob_file_url, table, blob_as_descriptor=True)
         # Verify the blob file was created
-        self.assertTrue(file_io.exists(blob_file_path))
-        file_size = file_io.get_file_size(blob_file_path)
+        self.assertTrue(file_io.exists(blob_file_url))
+        file_size = file_io.get_file_size(blob_file_url)
         self.assertGreater(file_size, 0)
 
         # ========== Step 3: Read data and check ==========

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -549,21 +549,12 @@ class BlobEndToEndTest(unittest.TestCase):
 
     @staticmethod
     def _to_url(path):
-        """Convert Path to string for FileIO methods.
-        
-        For absolute paths (Unix /path or Windows C:/path), uses file:/// (three slashes)
-        to comply with RFC 8089 file URI specification.
-        For relative paths, uses file:// (two slashes).
-        """
         if isinstance(path, Path):
             path_str = str(path)
             # Check if it's an absolute path
             # Unix: starts with /, Windows: has drive letter (C:, D:, etc.)
             is_absolute = os.path.isabs(path_str) or (len(path_str) >= 2 and path_str[1] == ':')
             if is_absolute:
-                # Absolute path: use file:/// (three slashes per RFC 8089)
-                # For Unix paths starting with /, we get file:////path which is wrong
-                # So we need to handle it differently
                 if path_str.startswith('/'):
                     # Unix absolute path: file:///path (three slashes total)
                     return f"file://{path_str}"

--- a/paimon-python/pypaimon/tests/file_io_test.py
+++ b/paimon-python/pypaimon/tests/file_io_test.py
@@ -17,7 +17,6 @@
 ################################################################################
 import unittest
 from pathlib import Path
-from unittest.mock import Mock, MagicMock
 
 from pyarrow.fs import S3FileSystem, LocalFileSystem
 
@@ -41,14 +40,14 @@ class FileIOTest(unittest.TestCase):
 
         converted_path = "my-bucket/path/to/file.txt"
         double_converted = file_io.to_filesystem_path(converted_path)
-        self.assertEqual(double_converted, converted_path, 
-                       "to_filesystem_path should be idempotent for already-converted paths")
-        
+        self.assertEqual(double_converted, converted_path,
+                         "to_filesystem_path should be idempotent for already-converted paths")
+
         parent_dir = Path(converted_path).parent
         parent_str = str(parent_dir)
         parent_double_converted = file_io.to_filesystem_path(parent_str)
         self.assertEqual(parent_double_converted, parent_str,
-                        "Double conversion of parent directory should not change the path")
+                         "Double conversion of parent directory should not change the path")
 
     def test_s3_filesystem_with_bucket_only(self):
         """Test S3FileSystem with bucket only (no path)."""
@@ -104,14 +103,14 @@ class FileIOTest(unittest.TestCase):
         converted_path = "/tmp/path/to/file.txt"
         double_converted = file_io.to_filesystem_path(converted_path)
         self.assertEqual(double_converted, converted_path,
-                       "to_filesystem_path should be idempotent for already-converted paths")
-        
+                         "to_filesystem_path should be idempotent for already-converted paths")
+
         # Test parent directory extraction and double conversion
         parent_dir = Path(converted_path).parent
         parent_str = str(parent_dir)
         parent_double_converted = file_io.to_filesystem_path(parent_str)
         self.assertEqual(parent_double_converted, parent_str,
-                        "Double conversion of parent directory should not change the path")
+                         "Double conversion of parent directory should not change the path")
 
     def test_local_filesystem_empty_path(self):
         """Test LocalFileSystem with empty path."""

--- a/paimon-python/pypaimon/tests/file_io_test.py
+++ b/paimon-python/pypaimon/tests/file_io_test.py
@@ -13,7 +13,7 @@
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
-# limitations under the License.
+#  limitations under the License.
 ################################################################################
 import unittest
 from pathlib import Path
@@ -26,191 +26,101 @@ from pypaimon.common.file_io import FileIO
 class FileIOTest(unittest.TestCase):
     """Test cases for FileIO.to_filesystem_path method."""
 
-    def test_s3_filesystem_with_bucket_and_path(self):
-        """Test S3FileSystem with bucket and path."""
+    def test_s3_filesystem_path_conversion(self):
+        """Test S3FileSystem path conversion with various formats."""
         file_io = FileIO("s3://bucket/warehouse", {})
         self.assertIsInstance(file_io.filesystem, S3FileSystem)
 
-        # Test with bucket and path
-        result = file_io.to_filesystem_path("s3://my-bucket/path/to/file.txt")
-        self.assertEqual(result, "my-bucket/path/to/file.txt")
+        # Test bucket and path
+        self.assertEqual(file_io.to_filesystem_path("s3://my-bucket/path/to/file.txt"),
+                         "my-bucket/path/to/file.txt")
+        self.assertEqual(file_io.to_filesystem_path("oss://my-bucket/path/to/file.txt"),
+                         "my-bucket/path/to/file.txt")
 
-        result = file_io.to_filesystem_path("oss://my-bucket/path/to/file.txt")
-        self.assertEqual(result, "my-bucket/path/to/file.txt")
+        # Test bucket only
+        self.assertEqual(file_io.to_filesystem_path("s3://my-bucket"), "my-bucket")
+        self.assertEqual(file_io.to_filesystem_path("oss://my-bucket"), "my-bucket")
 
+        # Test scheme but no netloc
+        self.assertEqual(file_io.to_filesystem_path("oss:///path/to/file.txt"), "path/to/file.txt")
+        self.assertEqual(file_io.to_filesystem_path("s3:///path/to/file.txt"), "path/to/file.txt")
+
+        # Test empty path
+        self.assertEqual(file_io.to_filesystem_path("oss:///"), ".")
+
+        # Test path without scheme
+        self.assertEqual(file_io.to_filesystem_path("bucket/path/to/file.txt"),
+                         "bucket/path/to/file.txt")
+
+        # Test idempotency
         converted_path = "my-bucket/path/to/file.txt"
-        double_converted = file_io.to_filesystem_path(converted_path)
-        self.assertEqual(double_converted, converted_path,
-                         "to_filesystem_path should be idempotent for already-converted paths")
+        self.assertEqual(file_io.to_filesystem_path(converted_path), converted_path)
+        parent_str = str(Path(converted_path).parent)
+        self.assertEqual(file_io.to_filesystem_path(parent_str), parent_str)
 
-        parent_dir = Path(converted_path).parent
-        parent_str = str(parent_dir)
-        parent_double_converted = file_io.to_filesystem_path(parent_str)
-        self.assertEqual(parent_double_converted, parent_str,
-                         "Double conversion of parent directory should not change the path")
-
-    def test_s3_filesystem_with_bucket_only(self):
-        """Test S3FileSystem with bucket only (no path)."""
-        file_io = FileIO("s3://bucket/warehouse", {})
-        self.assertIsInstance(file_io.filesystem, S3FileSystem)
-
-        result = file_io.to_filesystem_path("s3://my-bucket")
-        self.assertEqual(result, "my-bucket")
-
-        result = file_io.to_filesystem_path("oss://my-bucket")
-        self.assertEqual(result, "my-bucket")
-
-    def test_s3_filesystem_with_scheme_no_netloc(self):
-        """Test S3FileSystem with scheme but no netloc."""
-        file_io = FileIO("s3://bucket/warehouse", {})
-        self.assertIsInstance(file_io.filesystem, S3FileSystem)
-
-        # oss:///path format
-        result = file_io.to_filesystem_path("oss:///path/to/file.txt")
-        self.assertEqual(result, "path/to/file.txt")
-
-        result = file_io.to_filesystem_path("s3:///path/to/file.txt")
-        self.assertEqual(result, "path/to/file.txt")
-
-    def test_s3_filesystem_empty_path(self):
-        """Test S3FileSystem with empty path."""
-        file_io = FileIO("s3://bucket/warehouse", {})
-        self.assertIsInstance(file_io.filesystem, S3FileSystem)
-
-        result = file_io.to_filesystem_path("oss:///")
-        self.assertEqual(result, ".")
-
-    def test_s3_filesystem_no_scheme(self):
-        """Test S3FileSystem with path without scheme."""
-        file_io = FileIO("s3://bucket/warehouse", {})
-        self.assertIsInstance(file_io.filesystem, S3FileSystem)
-
-        result = file_io.to_filesystem_path("bucket/path/to/file.txt")
-        self.assertEqual(result, "bucket/path/to/file.txt")
-
-    def test_local_filesystem_with_file_scheme(self):
-        """Test LocalFileSystem with file:// scheme."""
+    def test_local_filesystem_path_conversion(self):
+        """Test LocalFileSystem path conversion with various formats."""
         file_io = FileIO("file:///tmp/warehouse", {})
         self.assertIsInstance(file_io.filesystem, LocalFileSystem)
 
-        result = file_io.to_filesystem_path("file:///tmp/path/to/file.txt")
-        self.assertEqual(result, "/tmp/path/to/file.txt")
+        # Test file:// scheme
+        self.assertEqual(file_io.to_filesystem_path("file:///tmp/path/to/file.txt"),
+                         "/tmp/path/to/file.txt")
+        self.assertEqual(file_io.to_filesystem_path("file:///path/to/file.txt"),
+                         "/path/to/file.txt")
 
-        result = file_io.to_filesystem_path("file:///path/to/file.txt")
-        self.assertEqual(result, "/path/to/file.txt")
+        # Test empty paths
+        self.assertEqual(file_io.to_filesystem_path("file://"), ".")
+        self.assertEqual(file_io.to_filesystem_path("file:///"), "/")
 
-        # Test double conversion: to_filesystem_path is idempotent for already-converted paths
+        # Test paths without scheme
+        self.assertEqual(file_io.to_filesystem_path("/tmp/path/to/file.txt"),
+                         "/tmp/path/to/file.txt")
+        self.assertEqual(file_io.to_filesystem_path("relative/path/to/file.txt"),
+                         "relative/path/to/file.txt")
+        self.assertEqual(file_io.to_filesystem_path("./relative/path/to/file.txt"),
+                         "./relative/path/to/file.txt")
+
+        # Test idempotency
         converted_path = "/tmp/path/to/file.txt"
-        double_converted = file_io.to_filesystem_path(converted_path)
-        self.assertEqual(double_converted, converted_path,
-                         "to_filesystem_path should be idempotent for already-converted paths")
+        self.assertEqual(file_io.to_filesystem_path(converted_path), converted_path)
+        parent_str = str(Path(converted_path).parent)
+        self.assertEqual(file_io.to_filesystem_path(parent_str), parent_str)
 
-        # Test parent directory extraction and double conversion
-        parent_dir = Path(converted_path).parent
-        parent_str = str(parent_dir)
-        parent_double_converted = file_io.to_filesystem_path(parent_str)
-        self.assertEqual(parent_double_converted, parent_str,
-                         "Double conversion of parent directory should not change the path")
-
-    def test_local_filesystem_empty_path(self):
-        """Test LocalFileSystem with empty path."""
+    def test_windows_path_handling(self):
+        """Test Windows path handling (drive letters, file:// scheme)."""
         file_io = FileIO("file:///tmp/warehouse", {})
         self.assertIsInstance(file_io.filesystem, LocalFileSystem)
 
-        result = file_io.to_filesystem_path("file://")
-        self.assertEqual(result, ".")
+        # Windows absolute paths
+        self.assertEqual(file_io.to_filesystem_path("C:\\path\\to\\file.txt"),
+                         "C:\\path\\to\\file.txt")
+        self.assertEqual(file_io.to_filesystem_path("C:/path/to/file.txt"),
+                         "C:/path/to/file.txt")
+        self.assertEqual(file_io.to_filesystem_path("C:"), "C:")
 
-        result = file_io.to_filesystem_path("file:///")
-        self.assertEqual(result, "/")
+        # file:// scheme with Windows drive
+        self.assertEqual(file_io.to_filesystem_path("file://C:/path/to/file.txt"),
+                         "C:/path/to/file.txt")
+        self.assertEqual(file_io.to_filesystem_path("file://C:/path"), "C:/path")
+        self.assertEqual(file_io.to_filesystem_path("file://C:"), "C:")
+        self.assertEqual(file_io.to_filesystem_path("file:///C:/path/to/file.txt"),
+                         "/C:/path/to/file.txt")
 
-    def test_local_filesystem_no_scheme(self):
-        """Test LocalFileSystem with path without scheme."""
+        # Windows path with S3FileSystem (should preserve)
+        s3_file_io = FileIO("s3://bucket/warehouse", {})
+        self.assertEqual(s3_file_io.to_filesystem_path("C:\\path\\to\\file.txt"),
+                         "C:\\path\\to\\file.txt")
+
+    def test_path_normalization(self):
+        """Test path normalization (multiple slashes)."""
         file_io = FileIO("file:///tmp/warehouse", {})
-        self.assertIsInstance(file_io.filesystem, LocalFileSystem)
+        self.assertEqual(file_io.to_filesystem_path("file://///tmp///path///file.txt"),
+                         "/tmp/path/file.txt")
 
-        result = file_io.to_filesystem_path("/tmp/path/to/file.txt")
-        self.assertEqual(result, "/tmp/path/to/file.txt")
-
-        result = file_io.to_filesystem_path("relative/path/to/file.txt")
-        self.assertEqual(result, "relative/path/to/file.txt")
-
-    def test_windows_drive_letter(self):
-        """Test Windows drive letter paths (e.g., C:\\path\\file.txt)."""
-        file_io = FileIO("file:///tmp/warehouse", {})
-        self.assertIsInstance(file_io.filesystem, LocalFileSystem)
-
-        # Windows absolute path with backslash
-        result = file_io.to_filesystem_path("C:\\path\\to\\file.txt")
-        self.assertEqual(result, "C:\\path\\to\\file.txt")
-
-        # Windows absolute path with forward slash
-        result = file_io.to_filesystem_path("C:/path/to/file.txt")
-        self.assertEqual(result, "C:/path/to/file.txt")
-
-        # Windows path with drive letter only
-        result = file_io.to_filesystem_path("C:")
-        self.assertEqual(result, "C:")
-
-    def test_file_scheme_with_windows_drive(self):
-        """Test file:// scheme with Windows drive letter (e.g., file://C:/path)."""
-        file_io = FileIO("file:///tmp/warehouse", {})
-        self.assertIsInstance(file_io.filesystem, LocalFileSystem)
-
-        # file://C:/path format - urlparse treats C: as netloc
-        result = file_io.to_filesystem_path("file://C:/path/to/file.txt")
-        # urlparse("file://C:/path/to/file.txt") gives:
-        # scheme='file', netloc='C:', path='/path/to/file.txt'
-        # Should reconstruct as "C:/path/to/file.txt"
-        self.assertEqual(result, "C:/path/to/file.txt")
-
-        result = file_io.to_filesystem_path("file://C:/path")
-        self.assertEqual(result, "C:/path")
-
-        result = file_io.to_filesystem_path("file://C:")
-        self.assertEqual(result, "C:")
-
-        # file:///C:/path format (three slashes) - this is the correct format
-        result = file_io.to_filesystem_path("file:///C:/path/to/file.txt")
-        # urlparse("file:///C:/path/to/file.txt") gives:
-        # scheme='file', netloc='', path='/C:/path/to/file.txt'
-        # So normalized_path = '/C:/path/to/file.txt'
-        self.assertEqual(result, "/C:/path/to/file.txt")
-
-    def test_windows_drive_letter_with_s3_filesystem(self):
-        """Test Windows drive letter with S3FileSystem (should still preserve drive letter)."""
-        file_io = FileIO("s3://bucket/warehouse", {})
-        self.assertIsInstance(file_io.filesystem, S3FileSystem)
-
-        # Windows path should be preserved even with S3FileSystem
-        result = file_io.to_filesystem_path("C:\\path\\to\\file.txt")
-        self.assertEqual(result, "C:\\path\\to\\file.txt")
-
-    def test_path_with_multiple_slashes(self):
-        """Test paths with multiple slashes are normalized."""
-        file_io = FileIO("file:///tmp/warehouse", {})
-        self.assertIsInstance(file_io.filesystem, LocalFileSystem)
-
-        result = file_io.to_filesystem_path("file://///tmp///path///file.txt")
-        self.assertEqual(result, "/tmp/path/file.txt")
-
-    def test_s3_path_with_multiple_slashes(self):
-        """Test S3 paths with multiple slashes are normalized."""
-        file_io = FileIO("s3://bucket/warehouse", {})
-        self.assertIsInstance(file_io.filesystem, S3FileSystem)
-
-        result = file_io.to_filesystem_path("s3://my-bucket///path///to///file.txt")
-        self.assertEqual(result, "my-bucket/path/to/file.txt")
-
-    def test_relative_paths(self):
-        """Test relative paths without scheme."""
-        file_io = FileIO("file:///tmp/warehouse", {})
-        self.assertIsInstance(file_io.filesystem, LocalFileSystem)
-
-        result = file_io.to_filesystem_path("relative/path/to/file.txt")
-        self.assertEqual(result, "relative/path/to/file.txt")
-
-        result = file_io.to_filesystem_path("./relative/path/to/file.txt")
-        self.assertEqual(result, "./relative/path/to/file.txt")
+        s3_file_io = FileIO("s3://bucket/warehouse", {})
+        self.assertEqual(s3_file_io.to_filesystem_path("s3://my-bucket///path///to///file.txt"),
+                         "my-bucket/path/to/file.txt")
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/file_io_test.py
+++ b/paimon-python/pypaimon/tests/file_io_test.py
@@ -215,4 +215,3 @@ class FileIOTest(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/paimon-python/pypaimon/tests/file_io_test.py
+++ b/paimon-python/pypaimon/tests/file_io_test.py
@@ -1,0 +1,208 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import unittest
+from unittest.mock import Mock, MagicMock
+
+from pyarrow.fs import S3FileSystem, LocalFileSystem
+
+from pypaimon.common.file_io import FileIO
+
+
+class FileIOTest(unittest.TestCase):
+    """Test cases for FileIO.to_filesystem_path method."""
+
+    def test_s3_filesystem_with_bucket_and_path(self):
+        """Test S3FileSystem with bucket and path."""
+        file_io = FileIO("s3://bucket/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, S3FileSystem)
+
+        # Test with bucket and path
+        result = file_io.to_filesystem_path("s3://my-bucket/path/to/file.txt")
+        self.assertEqual(result, "my-bucket/path/to/file.txt")
+
+        result = file_io.to_filesystem_path("oss://my-bucket/path/to/file.txt")
+        self.assertEqual(result, "my-bucket/path/to/file.txt")
+
+    def test_s3_filesystem_with_bucket_only(self):
+        """Test S3FileSystem with bucket only (no path)."""
+        file_io = FileIO("s3://bucket/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, S3FileSystem)
+
+        result = file_io.to_filesystem_path("s3://my-bucket")
+        self.assertEqual(result, "my-bucket")
+
+        result = file_io.to_filesystem_path("oss://my-bucket")
+        self.assertEqual(result, "my-bucket")
+
+    def test_s3_filesystem_with_scheme_no_netloc(self):
+        """Test S3FileSystem with scheme but no netloc."""
+        file_io = FileIO("s3://bucket/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, S3FileSystem)
+
+        # oss:///path format
+        result = file_io.to_filesystem_path("oss:///path/to/file.txt")
+        self.assertEqual(result, "path/to/file.txt")
+
+        result = file_io.to_filesystem_path("s3:///path/to/file.txt")
+        self.assertEqual(result, "path/to/file.txt")
+
+    def test_s3_filesystem_empty_path(self):
+        """Test S3FileSystem with empty path."""
+        file_io = FileIO("s3://bucket/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, S3FileSystem)
+
+        result = file_io.to_filesystem_path("oss:///")
+        self.assertEqual(result, ".")
+
+    def test_s3_filesystem_no_scheme(self):
+        """Test S3FileSystem with path without scheme."""
+        file_io = FileIO("s3://bucket/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, S3FileSystem)
+
+        result = file_io.to_filesystem_path("bucket/path/to/file.txt")
+        self.assertEqual(result, "bucket/path/to/file.txt")
+
+    def test_local_filesystem_with_file_scheme(self):
+        """Test LocalFileSystem with file:// scheme."""
+        file_io = FileIO("file:///tmp/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, LocalFileSystem)
+
+        result = file_io.to_filesystem_path("file:///tmp/path/to/file.txt")
+        self.assertEqual(result, "/tmp/path/to/file.txt")
+
+        result = file_io.to_filesystem_path("file:///path/to/file.txt")
+        self.assertEqual(result, "/path/to/file.txt")
+
+    def test_local_filesystem_empty_path(self):
+        """Test LocalFileSystem with empty path."""
+        file_io = FileIO("file:///tmp/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, LocalFileSystem)
+
+        result = file_io.to_filesystem_path("file://")
+        self.assertEqual(result, ".")
+
+        result = file_io.to_filesystem_path("file:///")
+        self.assertEqual(result, "/")
+
+    def test_local_filesystem_no_scheme(self):
+        """Test LocalFileSystem with path without scheme."""
+        file_io = FileIO("file:///tmp/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, LocalFileSystem)
+
+        result = file_io.to_filesystem_path("/tmp/path/to/file.txt")
+        self.assertEqual(result, "/tmp/path/to/file.txt")
+
+        result = file_io.to_filesystem_path("relative/path/to/file.txt")
+        self.assertEqual(result, "relative/path/to/file.txt")
+
+    def test_windows_drive_letter(self):
+        """Test Windows drive letter paths (e.g., C:\\path\\file.txt)."""
+        file_io = FileIO("file:///tmp/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, LocalFileSystem)
+
+        # Windows absolute path with backslash
+        result = file_io.to_filesystem_path("C:\\path\\to\\file.txt")
+        self.assertEqual(result, "C:\\path\\to\\file.txt")
+
+        # Windows absolute path with forward slash
+        result = file_io.to_filesystem_path("C:/path/to/file.txt")
+        self.assertEqual(result, "C:/path/to/file.txt")
+
+        # Windows path with drive letter only
+        result = file_io.to_filesystem_path("C:")
+        self.assertEqual(result, "C:")
+
+    def test_file_scheme_with_windows_drive(self):
+        """Test file:// scheme with Windows drive letter (e.g., file://C:/path)."""
+        file_io = FileIO("file:///tmp/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, LocalFileSystem)
+
+        # file://C:/path format - urlparse treats C: as netloc
+        result = file_io.to_filesystem_path("file://C:/path/to/file.txt")
+        # urlparse("file://C:/path/to/file.txt") gives:
+        # scheme='file', netloc='C:', path='/path/to/file.txt'
+        # Should reconstruct as "C:/path/to/file.txt"
+        self.assertEqual(result, "C:/path/to/file.txt")
+
+        result = file_io.to_filesystem_path("file://C:/path")
+        self.assertEqual(result, "C:/path")
+
+        result = file_io.to_filesystem_path("file://C:")
+        self.assertEqual(result, "C:")
+
+        # file:///C:/path format (three slashes) - this is the correct format
+        result = file_io.to_filesystem_path("file:///C:/path/to/file.txt")
+        # urlparse("file:///C:/path/to/file.txt") gives:
+        # scheme='file', netloc='', path='/C:/path/to/file.txt'
+        # So normalized_path = '/C:/path/to/file.txt'
+        self.assertEqual(result, "/C:/path/to/file.txt")
+
+    def test_windows_drive_letter_with_s3_filesystem(self):
+        """Test Windows drive letter with S3FileSystem (should still preserve drive letter)."""
+        file_io = FileIO("s3://bucket/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, S3FileSystem)
+
+        # Windows path should be preserved even with S3FileSystem
+        result = file_io.to_filesystem_path("C:\\path\\to\\file.txt")
+        self.assertEqual(result, "C:\\path\\to\\file.txt")
+
+    def test_hdfs_filesystem(self):
+        """Test HDFS filesystem paths."""
+        # Note: This test may fail if HADOOP_HOME is not set, but we can test the logic
+        try:
+            file_io = FileIO("hdfs://localhost:9000/warehouse", {})
+            result = file_io.to_filesystem_path("hdfs://localhost:9000/path/to/file.txt")
+            self.assertEqual(result, "/path/to/file.txt")
+
+            result = file_io.to_filesystem_path("hdfs://localhost:9000")
+            self.assertEqual(result, ".")
+        except RuntimeError:
+            # Skip if HADOOP_HOME is not set
+            self.skipTest("HADOOP_HOME not set, skipping HDFS test")
+
+    def test_path_with_multiple_slashes(self):
+        """Test paths with multiple slashes are normalized."""
+        file_io = FileIO("file:///tmp/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, LocalFileSystem)
+
+        result = file_io.to_filesystem_path("file://///tmp///path///file.txt")
+        self.assertEqual(result, "/tmp/path/file.txt")
+
+    def test_s3_path_with_multiple_slashes(self):
+        """Test S3 paths with multiple slashes are normalized."""
+        file_io = FileIO("s3://bucket/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, S3FileSystem)
+
+        result = file_io.to_filesystem_path("s3://my-bucket///path///to///file.txt")
+        self.assertEqual(result, "my-bucket/path/to/file.txt")
+
+    def test_relative_paths(self):
+        """Test relative paths without scheme."""
+        file_io = FileIO("file:///tmp/warehouse", {})
+        self.assertIsInstance(file_io.filesystem, LocalFileSystem)
+
+        result = file_io.to_filesystem_path("relative/path/to/file.txt")
+        self.assertEqual(result, "relative/path/to/file.txt")
+
+        result = file_io.to_filesystem_path("./relative/path/to/file.txt")
+        self.assertEqual(result, "./relative/path/to/file.txt")
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -18,7 +18,6 @@
 
 import unittest
 from datetime import datetime
-from pathlib import Path
 from unittest.mock import Mock, patch
 
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
@@ -41,7 +40,7 @@ class TestFileStoreCommit(unittest.TestCase):
         self.mock_table = Mock()
         self.mock_table.partition_keys = ['dt', 'region']
         self.mock_table.current_branch.return_value = 'main'
-        self.mock_table.table_path = Path('/test/table/path')
+        self.mock_table.table_path = '/test/table/path'
         self.mock_table.file_io = Mock()
 
         # Mock snapshot commit

--- a/paimon-python/pypaimon/tests/rest/rest_token_file_io_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_token_file_io_test.py
@@ -1,0 +1,189 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from pypaimon.catalog.rest.rest_token_file_io import RESTTokenFileIO
+from pypaimon.common.file_io import FileIO
+from pypaimon.common.identifier import Identifier
+
+
+class RESTTokenFileIOTest(unittest.TestCase):
+    """Test cases for RESTTokenFileIO."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp(prefix="rest_token_file_io_test_")
+        self.warehouse_path = f"file://{self.temp_dir}"
+        self.identifier = Identifier.from_string("default.test_table")
+        self.catalog_options = {}
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        import shutil
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def test_new_output_stream_with_file_uri(self):
+        """Test new_output_stream correctly handles file:// URI paths."""
+        # Create RESTTokenFileIO instance
+        # Mock the token refresh to avoid actual API calls
+        with patch.object(RESTTokenFileIO, 'try_to_refresh_token'):
+            file_io = RESTTokenFileIO(
+                self.identifier,
+                self.warehouse_path,
+                self.catalog_options
+            )
+
+            # Test with file:// URI path
+            test_file_path = f"file://{self.temp_dir}/subdir/test.txt"
+            test_content = b"test content"
+
+            # This should work: path should be converted and parent directory created
+            with file_io.new_output_stream(test_file_path) as stream:
+                stream.write(test_content)
+
+            # Verify file was created at the correct location (without scheme)
+            expected_path = f"{self.temp_dir}/subdir/test.txt"
+            self.assertTrue(os.path.exists(expected_path), 
+                          f"File should be created at {expected_path}")
+
+            # Verify content
+            with open(expected_path, 'rb') as f:
+                self.assertEqual(f.read(), test_content)
+
+    def test_new_output_stream_creates_parent_directory(self):
+        """Test new_output_stream creates parent directory if it doesn't exist."""
+        with patch.object(RESTTokenFileIO, 'try_to_refresh_token'):
+            file_io = RESTTokenFileIO(
+                self.identifier,
+                self.warehouse_path,
+                self.catalog_options
+            )
+
+            # Test with nested path that doesn't exist
+            test_file_path = f"file://{self.temp_dir}/level1/level2/level3/test.txt"
+            parent_dir = f"{self.temp_dir}/level1/level2/level3"
+
+            # Parent directory should not exist initially
+            self.assertFalse(os.path.exists(parent_dir))
+
+            # Write file - should create parent directory
+            with file_io.new_output_stream(test_file_path) as stream:
+                stream.write(b"test")
+
+            # Verify parent directory was created
+            self.assertTrue(os.path.exists(parent_dir), 
+                          f"Parent directory should be created at {parent_dir}")
+            self.assertTrue(os.path.exists(f"{parent_dir}/test.txt"))
+
+    def test_new_output_stream_behavior_matches_parent(self):
+        """Test that RESTTokenFileIO.new_output_stream behaves like FileIO.new_output_stream."""
+        with patch.object(RESTTokenFileIO, 'try_to_refresh_token'):
+            rest_file_io = RESTTokenFileIO(
+                self.identifier,
+                self.warehouse_path,
+                self.catalog_options
+            )
+
+            # Create a regular FileIO for comparison
+            regular_file_io = FileIO(self.warehouse_path, self.catalog_options)
+
+            # Test with the same path
+            test_file_path = f"file://{self.temp_dir}/comparison/test.txt"
+            test_content = b"comparison content"
+
+            # Write using RESTTokenFileIO
+            with rest_file_io.new_output_stream(test_file_path) as stream:
+                stream.write(test_content)
+
+            # Verify file exists and content is correct
+            expected_path = f"{self.temp_dir}/comparison/test.txt"
+            self.assertTrue(os.path.exists(expected_path))
+
+            # Read back using regular FileIO
+            with regular_file_io.new_input_stream(test_file_path) as stream:
+                read_content = stream.read()
+                self.assertEqual(read_content, test_content)
+
+    def test_new_output_stream_with_relative_path(self):
+        """Test new_output_stream with relative path."""
+        with patch.object(RESTTokenFileIO, 'try_to_refresh_token'):
+            file_io = RESTTokenFileIO(
+                self.identifier,
+                self.warehouse_path,
+                self.catalog_options
+            )
+
+            # Change to temp directory to test relative path
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(self.temp_dir)
+                test_file_path = "relative_test.txt"
+                test_content = b"relative content"
+
+                # Write using relative path
+                with file_io.new_output_stream(test_file_path) as stream:
+                    stream.write(test_content)
+
+                # Verify file was created
+                expected_path = os.path.join(self.temp_dir, test_file_path)
+                self.assertTrue(os.path.exists(expected_path))
+                with open(expected_path, 'rb') as f:
+                    self.assertEqual(f.read(), test_content)
+            finally:
+                os.chdir(original_cwd)
+
+    def test_new_output_stream_path_conversion(self):
+        """Test that new_output_stream correctly converts URI paths to filesystem paths."""
+        with patch.object(RESTTokenFileIO, 'try_to_refresh_token'):
+            file_io = RESTTokenFileIO(
+                self.identifier,
+                self.warehouse_path,
+                self.catalog_options
+            )
+
+            # Test various path formats
+            test_cases = [
+                (f"file://{self.temp_dir}/test1.txt", f"{self.temp_dir}/test1.txt"),
+                (f"file://{self.temp_dir}/subdir/test2.txt", f"{self.temp_dir}/subdir/test2.txt"),
+            ]
+
+            for uri_path, expected_fs_path in test_cases:
+                with file_io.new_output_stream(uri_path) as stream:
+                    stream.write(b"test")
+
+                # Verify file was created at the expected location (without scheme)
+                self.assertTrue(os.path.exists(expected_fs_path),
+                              f"File should be created at {expected_fs_path} for URI {uri_path}")
+
+                # Clean up for next test
+                os.remove(expected_fs_path)
+                parent = os.path.dirname(expected_fs_path)
+                if parent != self.temp_dir and os.path.exists(parent):
+                    try:
+                        os.rmdir(parent)
+                    except OSError:
+                        pass  # Directory not empty or other error
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/paimon-python/pypaimon/tests/rest/rest_token_file_io_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_token_file_io_test.py
@@ -41,10 +41,8 @@ class RESTTokenFileIOTest(unittest.TestCase):
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
 
-    def test_new_output_stream_with_file_uri(self):
-        """Test new_output_stream correctly handles file:// URI paths."""
-        # Create RESTTokenFileIO instance
-        # Mock the token refresh to avoid actual API calls
+    def test_new_output_stream_path_conversion_and_parent_creation(self):
+        """Test new_output_stream correctly handles URI paths and creates parent directories."""
         with patch.object(RESTTokenFileIO, 'try_to_refresh_token'):
             file_io = RESTTokenFileIO(
                 self.identifier,
@@ -52,47 +50,42 @@ class RESTTokenFileIOTest(unittest.TestCase):
                 self.catalog_options
             )
 
-            # Test with file:// URI path
+            # Test with file:// URI path - should convert and create parent directory
             test_file_path = f"file://{self.temp_dir}/subdir/test.txt"
             test_content = b"test content"
+            expected_path = f"{self.temp_dir}/subdir/test.txt"
 
-            # This should work: path should be converted and parent directory created
             with file_io.new_output_stream(test_file_path) as stream:
                 stream.write(test_content)
 
-            # Verify file was created at the correct location (without scheme)
-            expected_path = f"{self.temp_dir}/subdir/test.txt"
             self.assertTrue(os.path.exists(expected_path),
                             f"File should be created at {expected_path}")
-
-            # Verify content
             with open(expected_path, 'rb') as f:
                 self.assertEqual(f.read(), test_content)
 
-    def test_new_output_stream_creates_parent_directory(self):
-        """Test new_output_stream creates parent directory if it doesn't exist."""
-        with patch.object(RESTTokenFileIO, 'try_to_refresh_token'):
-            file_io = RESTTokenFileIO(
-                self.identifier,
-                self.warehouse_path,
-                self.catalog_options
-            )
-
-            # Test with nested path that doesn't exist
-            test_file_path = f"file://{self.temp_dir}/level1/level2/level3/test.txt"
+            # Test nested path - should create multiple parent directories
+            nested_path = f"file://{self.temp_dir}/level1/level2/level3/nested.txt"
             parent_dir = f"{self.temp_dir}/level1/level2/level3"
-
-            # Parent directory should not exist initially
             self.assertFalse(os.path.exists(parent_dir))
 
-            # Write file - should create parent directory
-            with file_io.new_output_stream(test_file_path) as stream:
-                stream.write(b"test")
+            with file_io.new_output_stream(nested_path) as stream:
+                stream.write(b"nested content")
 
-            # Verify parent directory was created
             self.assertTrue(os.path.exists(parent_dir),
                             f"Parent directory should be created at {parent_dir}")
-            self.assertTrue(os.path.exists(f"{parent_dir}/test.txt"))
+            self.assertTrue(os.path.exists(f"{parent_dir}/nested.txt"))
+
+            # Test relative path
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(self.temp_dir)
+                relative_path = "relative_test.txt"
+                with file_io.new_output_stream(relative_path) as stream:
+                    stream.write(b"relative content")
+                expected_relative = os.path.join(self.temp_dir, relative_path)
+                self.assertTrue(os.path.exists(expected_relative))
+            finally:
+                os.chdir(original_cwd)
 
     def test_new_output_stream_behavior_matches_parent(self):
         """Test that RESTTokenFileIO.new_output_stream behaves like FileIO.new_output_stream."""
@@ -102,86 +95,20 @@ class RESTTokenFileIOTest(unittest.TestCase):
                 self.warehouse_path,
                 self.catalog_options
             )
-
-            # Create a regular FileIO for comparison
             regular_file_io = FileIO(self.warehouse_path, self.catalog_options)
 
-            # Test with the same path
             test_file_path = f"file://{self.temp_dir}/comparison/test.txt"
             test_content = b"comparison content"
 
-            # Write using RESTTokenFileIO
             with rest_file_io.new_output_stream(test_file_path) as stream:
                 stream.write(test_content)
 
-            # Verify file exists and content is correct
             expected_path = f"{self.temp_dir}/comparison/test.txt"
             self.assertTrue(os.path.exists(expected_path))
 
-            # Read back using regular FileIO
             with regular_file_io.new_input_stream(test_file_path) as stream:
                 read_content = stream.read()
                 self.assertEqual(read_content, test_content)
-
-    def test_new_output_stream_with_relative_path(self):
-        """Test new_output_stream with relative path."""
-        with patch.object(RESTTokenFileIO, 'try_to_refresh_token'):
-            file_io = RESTTokenFileIO(
-                self.identifier,
-                self.warehouse_path,
-                self.catalog_options
-            )
-
-            # Change to temp directory to test relative path
-            original_cwd = os.getcwd()
-            try:
-                os.chdir(self.temp_dir)
-                test_file_path = "relative_test.txt"
-                test_content = b"relative content"
-
-                # Write using relative path
-                with file_io.new_output_stream(test_file_path) as stream:
-                    stream.write(test_content)
-
-                # Verify file was created
-                expected_path = os.path.join(self.temp_dir, test_file_path)
-                self.assertTrue(os.path.exists(expected_path))
-                with open(expected_path, 'rb') as f:
-                    self.assertEqual(f.read(), test_content)
-            finally:
-                os.chdir(original_cwd)
-
-    def test_new_output_stream_path_conversion(self):
-        """Test that new_output_stream correctly converts URI paths to filesystem paths."""
-        with patch.object(RESTTokenFileIO, 'try_to_refresh_token'):
-            file_io = RESTTokenFileIO(
-                self.identifier,
-                self.warehouse_path,
-                self.catalog_options
-            )
-
-            # Test various path formats
-            test_cases = [
-                (f"file://{self.temp_dir}/test1.txt", f"{self.temp_dir}/test1.txt"),
-                (f"file://{self.temp_dir}/subdir/test2.txt", f"{self.temp_dir}/subdir/test2.txt"),
-            ]
-
-            for uri_path, expected_fs_path in test_cases:
-                with file_io.new_output_stream(uri_path) as stream:
-                    stream.write(b"test")
-
-                # Verify file was created at the expected location (without scheme)
-                self.assertTrue(os.path.exists(expected_fs_path),
-                                f"File should be created at {expected_fs_path} for URI {uri_path}")
-
-                # Clean up for next test
-                os.remove(expected_fs_path)
-                parent = os.path.dirname(expected_fs_path)
-                if parent != self.temp_dir and os.path.exists(parent):
-                    try:
-                        os.rmdir(parent)
-                    except OSError:
-                        pass  # Directory not empty or other error
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/rest/rest_token_file_io_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_token_file_io_test.py
@@ -62,8 +62,8 @@ class RESTTokenFileIOTest(unittest.TestCase):
 
             # Verify file was created at the correct location (without scheme)
             expected_path = f"{self.temp_dir}/subdir/test.txt"
-            self.assertTrue(os.path.exists(expected_path), 
-                          f"File should be created at {expected_path}")
+            self.assertTrue(os.path.exists(expected_path),
+                            f"File should be created at {expected_path}")
 
             # Verify content
             with open(expected_path, 'rb') as f:
@@ -90,8 +90,8 @@ class RESTTokenFileIOTest(unittest.TestCase):
                 stream.write(b"test")
 
             # Verify parent directory was created
-            self.assertTrue(os.path.exists(parent_dir), 
-                          f"Parent directory should be created at {parent_dir}")
+            self.assertTrue(os.path.exists(parent_dir),
+                            f"Parent directory should be created at {parent_dir}")
             self.assertTrue(os.path.exists(f"{parent_dir}/test.txt"))
 
     def test_new_output_stream_behavior_matches_parent(self):
@@ -172,7 +172,7 @@ class RESTTokenFileIOTest(unittest.TestCase):
 
                 # Verify file was created at the expected location (without scheme)
                 self.assertTrue(os.path.exists(expected_fs_path),
-                              f"File should be created at {expected_fs_path} for URI {uri_path}")
+                                f"File should be created at {expected_fs_path} for URI {uri_path}")
 
                 # Clean up for next test
                 os.remove(expected_fs_path)
@@ -186,4 +186,3 @@ class RESTTokenFileIOTest(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/paimon-python/pypaimon/tests/uri_reader_factory_test.py
+++ b/paimon-python/pypaimon/tests/uri_reader_factory_test.py
@@ -18,7 +18,6 @@ limitations under the License.
 import os
 import tempfile
 import unittest
-from pathlib import Path
 from pypaimon.common.file_io import FileIO
 from pypaimon.common.uri_reader import UriReaderFactory, HttpUriReader, FileUriReader, UriReader
 
@@ -31,10 +30,12 @@ class MockFileIO:
 
     def get_file_size(self, path: str) -> int:
         """Get file size."""
-        return self._file_io.get_file_size(Path(path))
+        return self._file_io.get_file_size(path)
 
-    def new_input_stream(self, path: Path):
+    def new_input_stream(self, path):
         """Create new input stream for reading."""
+        if not isinstance(path, (str, type(None))):
+            path = str(path)
         return self._file_io.new_input_stream(path)
 
 

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 ################################################################################
 
+import os
 import time
 import uuid
 from pathlib import Path
@@ -166,7 +167,7 @@ class FileStoreCommit:
         if not all(count == 0 for count in partition_null_counts):
             raise RuntimeError("Partition value should not be null")
 
-        manifest_file_path = f"{self.manifest_file_manager.manifest_path}/{new_manifest_file}"
+        manifest_file_path = os.path.join(self.manifest_file_manager.manifest_path, new_manifest_file)
         new_manifest_list = ManifestFileMeta(
             file_name=new_manifest_file,
             file_size=self.table.file_io.get_file_size(manifest_file_path),

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -166,9 +166,10 @@ class FileStoreCommit:
         if not all(count == 0 for count in partition_null_counts):
             raise RuntimeError("Partition value should not be null")
 
+        manifest_file_path = f"{self.manifest_file_manager.manifest_path}/{new_manifest_file}"
         new_manifest_list = ManifestFileMeta(
             file_name=new_manifest_file,
-            file_size=self.table.file_io.get_file_size(self.manifest_file_manager.manifest_path / new_manifest_file),
+            file_size=self.table.file_io.get_file_size(manifest_file_path),
             num_added_files=added_file_count,
             num_deleted_files=deleted_file_count,
             partition_stats=SimpleStats(

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 ################################################################################
 
-import os
 import time
 import uuid
 from pathlib import Path
@@ -167,7 +166,7 @@ class FileStoreCommit:
         if not all(count == 0 for count in partition_null_counts):
             raise RuntimeError("Partition value should not be null")
 
-        manifest_file_path = os.path.join(self.manifest_file_manager.manifest_path, new_manifest_file)
+        manifest_file_path = f"{self.manifest_file_manager.manifest_path}/{new_manifest_file}"
         new_manifest_list = ManifestFileMeta(
             file_name=new_manifest_file,
             file_size=self.table.file_io.get_file_size(manifest_file_path),

--- a/paimon-python/pypaimon/write/writer/data_blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_blob_writer.py
@@ -302,7 +302,7 @@ class DataBlobWriter(DataWriter):
             delete_row_count=0,
             file_source=0,
             value_stats_cols=self.normal_column_names,
-            file_path=str(file_path),
+            file_path=file_path,
             write_cols=self.write_cols)
 
     def _validate_consistency(self, normal_meta: DataFileMeta, blob_metas: List[DataFileMeta]):

--- a/paimon-python/pypaimon/write/writer/data_blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_blob_writer.py
@@ -19,7 +19,6 @@
 import logging
 import uuid
 from datetime import datetime
-from pathlib import Path
 from typing import List, Optional, Tuple
 
 import pyarrow as pa
@@ -262,7 +261,7 @@ class DataBlobWriter(DataWriter):
         # Generate metadata
         return self._create_data_file_meta(file_name, file_path, data)
 
-    def _create_data_file_meta(self, file_name: str, file_path: Path, data: pa.Table) -> DataFileMeta:
+    def _create_data_file_meta(self, file_name: str, file_path: str, data: pa.Table) -> DataFileMeta:
         # Column stats (only for normal columns)
         column_stats = {
             field.name: self._get_column_stats(data, field.name)

--- a/paimon-python/pypaimon/write/writer/data_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_writer.py
@@ -20,7 +20,6 @@ import pyarrow.compute as pc
 import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime
-from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from pypaimon.common.core_options import CoreOptions
@@ -216,19 +215,21 @@ class DataWriter(ABC):
             first_row_id=None,
             write_cols=self.write_cols,
             # None means all columns in the table have been written
-            file_path=str(file_path),
+            file_path=file_path,
         ))
 
-    def _generate_file_path(self, file_name: str) -> Path:
-        path_builder = self.table.table_path
+    def _generate_file_path(self, file_name: str) -> str:
+        path_builder = str(self.table.table_path)
 
         for i, field_name in enumerate(self.table.partition_keys):
-            path_builder = path_builder / (field_name + "=" + str(self.partition[i]))
+            path_builder = f"{path_builder.rstrip('/')}/{field_name}={str(self.partition[i])}"
+
         if self.bucket == BucketMode.POSTPONE_BUCKET.value:
             bucket_name = "postpone"
         else:
             bucket_name = str(self.bucket)
-        path_builder = path_builder / ("bucket-" + bucket_name) / file_name
+
+        path_builder = f"{path_builder.rstrip('/')}/bucket-{bucket_name}/{file_name}"
 
         return path_builder
 

--- a/paimon-python/pypaimon/write/writer/data_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_writer.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import os
 import pyarrow as pa
 import pyarrow.compute as pc
 import uuid
@@ -220,20 +219,19 @@ class DataWriter(ABC):
         ))
 
     def _generate_file_path(self, file_name: str) -> str:
-        path_components = [str(self.table.table_path)]
+        path_builder = str(self.table.table_path)
 
         for i, field_name in enumerate(self.table.partition_keys):
-            path_components.append(f"{field_name}={str(self.partition[i])}")
+            path_builder = f"{path_builder.rstrip('/')}/{field_name}={str(self.partition[i])}"
 
         if self.bucket == BucketMode.POSTPONE_BUCKET.value:
             bucket_name = "postpone"
         else:
             bucket_name = str(self.bucket)
 
-        path_components.append(f"bucket-{bucket_name}")
-        path_components.append(file_name)
+        path_builder = f"{path_builder.rstrip('/')}/bucket-{bucket_name}/{file_name}"
 
-        return os.path.join(*path_components)
+        return path_builder
 
     @staticmethod
     def _find_optimal_split_point(data: pa.RecordBatch, target_size: int) -> int:


### PR DESCRIPTION
## Purpose

Fixes URI scheme loss issue in blob-as-descriptor mode by replacing `pathlib.Path` with `urlpath.URL` throughout the codebase. This ensures URI schemes (e.g., `oss://`, `s3://`, `file://`) are preserved when handling blob descriptors and file paths.

## Key Changes

1. **Replaced `pathlib.Path` with `urlpath.URL`**: Unified path handling to preserve URI schemes across all filesystem operations.

3. **Dependency**: Added `urlpath==2.0.0` as a required dependency.

## Impact

- **FileIO**: All methods now accept `URL` type instead of `Path`
- **FileSystemCatalog**: Returns `URL` objects for database and table paths
- **DataFileMeta.set_file_path**: Accepts `URL` type
- **SchemaManager**: Uses `URL` for table paths
- **UriReader.get_file_path**: Returns `URL` instead of `Path`

## Tests

- `test_blob_write_read_end_to_end_with_descriptor`: Verifies URI scheme preservation in blob descriptors
- Sample script `oss_blob_as_descriptor.py`: Demonstrates OSS blob-as-descriptor functionality with scheme preservation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves URI schemes end-to-end by refactoring path handling to string URIs with a new FileIO.to_filesystem_path, updating catalogs/readers/writers/managers accordingly, and adding samples/tests.
> 
> - **Python I/O and Path Handling**:
>   - Introduce `FileIO.to_filesystem_path` and refactor `FileIO` APIs to accept `str` paths; normalize `file://`, `s3://`, `oss://`, Windows paths, and scheme-less inputs.
>   - Update `UriReader`/`FileUriReader` to pass URIs directly; `UriReader.get_file_path` returns string.
> - **Catalogs**:
>   - `FileSystemCatalog`/`RESTCatalog`: use string paths; `RESTCatalog` uses server `CoreOptions.PATH` directly (no scheme trimming); `RESTTokenFileIO.new_output_stream` delegates to parent for path conversion and directory creation.
> - **Readers**:
>   - `FormatPyArrowReader`/`FormatAvroReader` resolve URIs via `to_filesystem_path` before opening files.
>   - `FormatBlobReader` reads using string paths and `FileIO` size APIs.
> - **Table/Metadata**:
>   - `FileStoreTable`, `SchemaManager`, `SnapshotManager`, `ManifestFileManager`, `ManifestListManager`, `DataFileMeta.set_file_path` all switch to string path construction (preserve schemes).
> - **Write/Commit**:
>   - Writers (`DataWriter`, `DataBlobWriter`, `BlobWriter`) and `FileStoreCommit` use string paths; file sizes retrieved via `FileIO` on constructed URIs.
> - **Samples**:
>   - Add `sample/oss_blob_as_descriptor.py` and `sample/rest_catalog_read_write_sample.py` demonstrating scheme-preserving paths.
> - **Tests**:
>   - New/updated tests for path conversion (`file_io_test.py`), REST token I/O, URI reader factory, blob flows, file store commit; Java IT adds assertion that blob descriptor URI retains a non-null scheme.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f78c77c7c93c136cb33b734fbdf3a0fe450575e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->