### PR TITLE
Fix bug bot disabled repository error

### DIFF
--- a/.github/bugbot.yml
+++ b/.github/bugbot.yml
@@ -1,0 +1,1 @@
+enabled: true


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx

Resolves "Skipping Bugbot: Bugbot is disabled for this repository" by explicitly enabling Bugbot via its configuration file.

### Tests

No unit/integration tests are applicable. Verification can be done by triggering Bugbot or observing workflow logs to confirm the skip message is gone.

### API and Format

No changes to API or storage format.

### Documentation

No new features introduced.

---
<a href="https://cursor.com/background-agent?bcId=bc-b114714d-5e1f-45a0-a2f3-9ff4109cc46f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b114714d-5e1f-45a0-a2f3-9ff4109cc46f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

