### PR TITLE
Ray data dev

### DIFF
--- a/docs/content/program-api/python-api.md
+++ b/docs/content/program-api/python-api.md
@@ -376,16 +376,7 @@ print(ray_dataset.to_pandas())
 # ...
 ```
 
-#### Parallelism Control
-
-The `to_ray()` method supports a `parallelism` parameter to control distributed reading:
-
-- `parallelism=1` (default): Single-task read (simple mode), suitable for small datasets
-- `parallelism > 1`: Distributed read with specified parallelism, enabling parallel processing across multiple Ray workers
-
-{{< hint info >}}
-**Note**: For PrimaryKey tables, merge-on-read is performed within each split. Since Paimon's split planning ensures that files with overlapping key ranges (same primary keys) are grouped into the same split, merge-on-read works correctly for PrimaryKey tables in both single-task and distributed modes.
-{{< /hint >}}
+The `to_ray()` method supports a `parallelism` parameter to control distributed reading. Use `parallelism=1` for single-task read (default) or `parallelism > 1` for distributed read with multiple Ray workers:
 
 ```python
 # Simple mode (single task)
@@ -393,65 +384,11 @@ ray_dataset = table_read.to_ray(splits, parallelism=1)
 
 # Distributed mode with 4 parallel tasks
 ray_dataset = table_read.to_ray(splits, parallelism=4)
-```
-
-#### Ray Data Operations
-
-Once converted to a Ray Dataset, you can use all Ray Data operations:
-
-```python
-# Map operation (transform data)
-def process_row(row):
-    row['value'] = row['value'] * 2
-    return row
-
-mapped_dataset = ray_dataset.map(process_row)
-
-# Filter operation
-filtered_dataset = ray_dataset.filter(lambda row: row['score'] > 80)
-
-# Group by and aggregate
-grouped = ray_dataset.groupby("category").sum("amount")
-
-# Convert to Pandas
-df = ray_dataset.to_pandas()
-```
-
-
-#### Complete Example
-
-```python
-from pypaimon import CatalogFactory
-
-# Create catalog and get table
-catalog = CatalogFactory.create({'warehouse': '/path/to/warehouse'})
-table = catalog.get_table('database_name.table_name')
-
-# Build read with predicate and projection
-read_builder = table.new_read_builder()
-predicate_builder = read_builder.new_predicate_builder()
-predicate = predicate_builder.equal('status', 'active')
-read_builder = read_builder.with_filter(predicate)
-read_builder = read_builder.with_projection(['id', 'name', 'value'])
-
-# Get splits and read to Ray Dataset
-table_read = read_builder.new_read()
-table_scan = read_builder.new_scan()
-splits = table_scan.plan().splits()
-
-# Convert to Ray Dataset with distributed reading
-ray_dataset = table_read.to_ray(splits, parallelism=4)
 
 # Use Ray Data operations
-processed = ray_dataset.map(lambda row: {
-    'id': row['id'],
-    'name': row['name'].upper(),
-    'value': row['value'] * 2
-})
-
-# Convert to Pandas for further analysis
-df = processed.to_pandas()
-print(df)
+mapped_dataset = ray_dataset.map(lambda row: {'value': row['value'] * 2})
+filtered_dataset = ray_dataset.filter(lambda row: row['score'] > 80)
+df = ray_dataset.to_pandas()
 ```
 
 ### Incremental Read

--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -35,6 +35,7 @@ polars==1.8.0; python_version=="3.8"
 polars==1.32.0; python_version>"3.8"
 pyarrow==6.0.1; python_version < "3.8"
 pyarrow==16; python_version >= "3.8"
+ray==2.48.0
 readerwriterlock==1.0.9
 zstandard==0.19.0; python_version<"3.9"
 zstandard==0.24.0; python_version>="3.9"

--- a/paimon-python/pypaimon/read/ray_datasource.py
+++ b/paimon-python/pypaimon/read/ray_datasource.py
@@ -94,7 +94,7 @@ class PaimonDatasource(Datasource):
 
         return chunks
 
-    def get_read_tasks(self, parallelism: int, per_task_row_limit: Optional[int] = None) -> List:
+    def get_read_tasks(self, parallelism: int) -> List:
         """Return a list of read tasks that can be executed in parallel."""
         from ray.data.datasource import ReadTask
         from ray.data.block import BlockMetadata
@@ -189,13 +189,12 @@ class PaimonDatasource(Datasource):
                 exec_stats=None,  # Will be populated by Ray during execution
             )
 
-            # Create ReadTask with lambda to capture chunk_splits
+            # TODO: per_task_row_limit is not supported in Ray 2.48.0, will be added in future versions
             read_tasks.append(
                 ReadTask(
                     read_fn=lambda splits=chunk_splits: get_read_task(splits),
                     metadata=metadata,
                     schema=schema,
-                    per_task_row_limit=per_task_row_limit,
                 )
             )
 

--- a/paimon-python/pypaimon/read/ray_datasource.py
+++ b/paimon-python/pypaimon/read/ray_datasource.py
@@ -99,6 +99,10 @@ class PaimonDatasource(Datasource):
         from ray.data.datasource import ReadTask
         from ray.data.block import BlockMetadata
 
+        # Validate parallelism parameter
+        if parallelism < 1:
+            raise ValueError(f"parallelism must be at least 1, got {parallelism}")
+
         # Get schema for metadata
         if self._schema is None:
             self._schema = PyarrowFieldParser.from_paimon_schema(self.table_read.read_type)

--- a/paimon-python/pypaimon/read/ray_datasource.py
+++ b/paimon-python/pypaimon/read/ray_datasource.py
@@ -1,0 +1,202 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+"""
+Module to read a Paimon table into a Ray Dataset, by using the Ray Datasource API.
+"""
+import heapq
+import itertools
+import logging
+from functools import partial
+from typing import List, Optional, Iterable
+
+import pyarrow
+
+from pypaimon.read.split import Split
+from pypaimon.read.table_read import TableRead
+from pypaimon.schema.data_types import PyarrowFieldParser
+
+logger = logging.getLogger(__name__)
+
+from ray.data.datasource import Datasource
+
+
+class PaimonDatasource(Datasource):
+    """
+    Ray Data Datasource implementation for reading Paimon tables.
+
+    This datasource enables distributed parallel reading of Paimon table splits,
+    allowing Ray to read multiple splits concurrently across the cluster.
+    """
+
+    def __init__(self, table_read: TableRead, splits: List[Split]):
+        """
+        Initialize PaimonDatasource.
+
+        Args:
+            table_read: TableRead instance for reading data
+            splits: List of splits to read
+        """
+        self.table_read = table_read
+        self.splits = splits
+        self._schema = None
+
+    def get_name(self) -> str:
+        identifier = self.table_read.table.identifier
+        table_name = identifier.get_full_name() if hasattr(identifier, 'get_full_name') else str(identifier)
+        return f"PaimonTable({table_name})"
+
+    def estimate_inmemory_data_size(self) -> Optional[int]:
+        if not self.splits:
+            return 0
+
+        # Sum up file sizes from all splits
+        total_size = sum(split.file_size for split in self.splits)
+        return total_size if total_size > 0 else None
+
+    @staticmethod
+    def _distribute_splits_into_equal_chunks(
+        splits: Iterable[Split], n_chunks: int
+    ) -> List[List[Split]]:
+        """
+        Implement a greedy knapsack algorithm to distribute the splits across tasks,
+        based on their file size, as evenly as possible.
+        """
+        chunks = [list() for _ in range(n_chunks)]
+        chunk_sizes = [(0, chunk_id) for chunk_id in range(n_chunks)]
+        heapq.heapify(chunk_sizes)
+
+        # From largest to smallest, add the splits to the smallest chunk one at a time
+        for split in sorted(
+            splits, key=lambda s: s.file_size if hasattr(s, 'file_size') and s.file_size > 0 else 0, reverse=True
+        ):
+            smallest_chunk = heapq.heappop(chunk_sizes)
+            chunks[smallest_chunk[1]].append(split)
+            split_size = split.file_size if hasattr(split, 'file_size') and split.file_size > 0 else 0
+            heapq.heappush(
+                chunk_sizes,
+                (smallest_chunk[0] + split_size, smallest_chunk[1]),
+            )
+
+        return chunks
+
+    def get_read_tasks(self, parallelism: int, per_task_row_limit: Optional[int] = None) -> List:
+        """Return a list of read tasks that can be executed in parallel."""
+        from ray.data.datasource import ReadTask
+        from ray.data.block import BlockMetadata
+
+        # Get schema for metadata
+        if self._schema is None:
+            self._schema = PyarrowFieldParser.from_paimon_schema(self.table_read.read_type)
+
+        # Adjust parallelism if it exceeds the number of splits
+        if parallelism > len(self.splits):
+            parallelism = len(self.splits)
+            logger.warning(
+                f"Reducing the parallelism to {parallelism}, as that is the number of splits"
+            )
+
+        # Store necessary information for creating readers in Ray workers
+        # Extract these to avoid serializing the entire self object in closures
+        table = self.table_read.table
+        predicate = self.table_read.predicate
+        read_type = self.table_read.read_type
+        schema = self._schema
+
+        # Create a partial function to avoid capturing self in closure
+        # This reduces serialization overhead (see https://github.com/ray-project/ray/issues/49107)
+        def _get_read_task(
+            splits: List[Split],
+            table=table,
+            predicate=predicate,
+            read_type=read_type,
+            schema=schema,
+        ) -> Iterable[pyarrow.Table]:
+            """Read function that will be executed by Ray workers."""
+            from pypaimon.read.table_read import TableRead
+            worker_table_read = TableRead(table, predicate, read_type)
+
+            # Read all splits in this chunk
+            arrow_table = worker_table_read.to_arrow(splits)
+
+            # Return as a list to allow Ray to split into multiple blocks if needed
+            if arrow_table is not None and arrow_table.num_rows > 0:
+                return [arrow_table]
+            else:
+                # Return empty table with correct schema
+                empty_table = pyarrow.Table.from_arrays(
+                    [pyarrow.array([], type=field.type) for field in schema],
+                    schema=schema
+                )
+                return [empty_table]
+
+        # Use partial to create read function without capturing self
+        get_read_task = partial(
+            _get_read_task,
+            table=table,
+            predicate=predicate,
+            read_type=read_type,
+            schema=schema,
+        )
+
+        read_tasks = []
+
+        # Distribute splits across tasks using load balancing algorithm
+        for chunk_splits in self._distribute_splits_into_equal_chunks(self.splits, parallelism):
+            if not chunk_splits:
+                continue
+
+            # Calculate metadata for this chunk
+            total_rows = 0
+            total_size = 0
+
+            for split in chunk_splits:
+                if predicate is None:
+                    # Only estimate rows if no predicate (predicate filtering changes row count)
+                    if hasattr(split, 'row_count') and split.row_count > 0:
+                        total_rows += split.row_count
+                if hasattr(split, 'file_size') and split.file_size > 0:
+                    total_size += split.file_size
+
+            input_files = list(itertools.chain.from_iterable(
+                split.file_paths
+                for split in chunk_splits
+                if hasattr(split, 'file_paths') and split.file_paths
+            ))
+
+            # If predicate exists, we can't accurately estimate num_rows before filtering
+            num_rows = None if predicate is not None else (total_rows if total_rows > 0 else None)
+            size_bytes = total_size if total_size > 0 else None
+
+            metadata = BlockMetadata(
+                num_rows=num_rows,
+                size_bytes=size_bytes,
+                input_files=input_files if input_files else None,
+                exec_stats=None,  # Will be populated by Ray during execution
+            )
+
+            # Create ReadTask with lambda to capture chunk_splits
+            read_tasks.append(
+                ReadTask(
+                    read_fn=lambda splits=chunk_splits: get_read_task(splits),
+                    metadata=metadata,
+                    schema=schema,
+                    per_task_row_limit=per_task_row_limit,
+                )
+            )
+
+        return read_tasks

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -126,10 +126,24 @@ class TableRead:
         con.register(table_name, self.to_arrow(splits))
         return con
 
-    def to_ray(self, splits: List[Split]) -> "ray.data.dataset.Dataset":
+    def to_ray(self, splits: List[Split], use_distributed_read: bool = True) -> "ray.data.dataset.Dataset":
+        """Convert Paimon table data to Ray Dataset."""
         import ray
 
-        return ray.data.from_arrow(self.to_arrow(splits))
+        if not splits:
+            schema = PyarrowFieldParser.from_paimon_schema(self.read_type)
+            empty_table = pyarrow.Table.from_arrays(
+                [pyarrow.array([], type=field.type) for field in schema],
+                schema=schema
+            )
+            return ray.data.from_arrow(empty_table)
+
+        if use_distributed_read:
+            from pypaimon.read.ray_datasource import PaimonDatasource
+            datasource = PaimonDatasource(self, splits)
+            return ray.data.read_datasource(datasource)
+        else:
+            return ray.data.from_arrow(self.to_arrow(splits))
 
     def _create_split_read(self, split: Split) -> SplitRead:
         if self.table.is_primary_key_table and not split.raw_convertible:

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -138,6 +138,10 @@ class TableRead:
             )
             return ray.data.from_arrow(empty_table)
 
+        # Validate parallelism parameter
+        if parallelism < 1:
+            raise ValueError(f"parallelism must be at least 1, got {parallelism}")
+
         if parallelism == 1:
             # Single-task read (simple mode)
             return ray.data.from_arrow(self.to_arrow(splits))

--- a/paimon-python/pypaimon/sample/rest_catalog_ray_data_sample.py
+++ b/paimon-python/pypaimon/sample/rest_catalog_ray_data_sample.py
@@ -122,7 +122,7 @@ def main():
 
         # Convert to Ray Dataset
         ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
-        print(f"✓ Ray Dataset created successfully")
+        print("✓ Ray Dataset created successfully")
         print(f"  - Total rows: {ray_dataset.count()}")
         # Note: num_blocks() requires materialized dataset, so we skip it for simplicity
 
@@ -140,7 +140,7 @@ def main():
 
         print(f"Distributed mode rows: {ray_dataset.count()}")
         print(f"Simple mode rows: {ray_dataset_simple.count()}")
-        print(f"✓ Both modes return the same number of rows")
+        print("✓ Both modes return the same number of rows")
 
         # Verify data consistency (sort by id for comparison)
         df_ray_sorted = df_ray.sort_values(by='id').reset_index(drop=True)
@@ -162,6 +162,7 @@ def main():
 
         # Map operation
         print("\n4.2 Map: Double the value column")
+
         def double_value(row):
             row['value'] = row['value'] * 2
             return row
@@ -209,7 +210,7 @@ def main():
         ray_dataset_projected = table_read_projected.to_ray(splits_projected, use_distributed_read=True)
         df_projected = ray_dataset_projected.to_pandas()
         print(f"✓ Projected columns: {list(df_projected.columns)}")
-        print(f"  - Expected: ['id', 'name', 'value']")
+        print("  - Expected: ['id', 'name', 'value']")
         print(f"  - Match: {set(df_projected.columns) == {'id', 'name', 'value'}}")
 
         # Optional: Blob data example (uncomment to demonstrate blob data handling)
@@ -242,4 +243,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/paimon-python/pypaimon/sample/rest_catalog_ray_data_sample.py
+++ b/paimon-python/pypaimon/sample/rest_catalog_ray_data_sample.py
@@ -121,7 +121,7 @@ def main():
         print(f"Number of splits: {len(splits)}")
 
         # Convert to Ray Dataset
-        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+        ray_dataset = table_read.to_ray(splits, parallelism=2)
         print("✓ Ray Dataset created successfully")
         print(f"  - Total rows: {ray_dataset.count()}")
         # Note: num_blocks() requires materialized dataset, so we skip it for simplicity
@@ -135,7 +135,7 @@ def main():
         print("\n" + "="*60)
         print("Step 3: Comparison with simple read mode")
         print("="*60)
-        ray_dataset_simple = table_read.to_ray(splits, use_distributed_read=False)
+        ray_dataset_simple = table_read.to_ray(splits, parallelism=1)
         df_simple = ray_dataset_simple.to_pandas()
 
         print(f"Distributed mode rows: {ray_dataset.count()}")
@@ -193,7 +193,7 @@ def main():
         table_scan_filtered = read_builder_filtered.new_scan()
         splits_filtered = table_scan_filtered.plan().splits()
 
-        ray_dataset_filtered = table_read_filtered.to_ray(splits_filtered, use_distributed_read=True)
+        ray_dataset_filtered = table_read_filtered.to_ray(splits_filtered, parallelism=2)
         df_filtered_at_read = ray_dataset_filtered.to_pandas()
         print(f"✓ Filtered at read time: {ray_dataset_filtered.count()} rows")
         print(f"  - All categories are 'A': {all(df_filtered_at_read['category'] == 'A')}")
@@ -207,7 +207,7 @@ def main():
         table_scan_projected = read_builder_projected.new_scan()
         splits_projected = table_scan_projected.plan().splits()
 
-        ray_dataset_projected = table_read_projected.to_ray(splits_projected, use_distributed_read=True)
+        ray_dataset_projected = table_read_projected.to_ray(splits_projected, parallelism=2)
         df_projected = ray_dataset_projected.to_pandas()
         print(f"✓ Projected columns: {list(df_projected.columns)}")
         print("  - Expected: ['id', 'name', 'value']")

--- a/paimon-python/pypaimon/sample/rest_catalog_ray_data_sample.py
+++ b/paimon-python/pypaimon/sample/rest_catalog_ray_data_sample.py
@@ -1,0 +1,245 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+"""
+Example: REST Catalog with Ray Data Integration
+
+Demonstrates:
+1. REST catalog basic read/write operations
+2. Reading Paimon tables into Ray Dataset for distributed processing
+3. Using Ray Data operations (map, filter, etc.) on Paimon data
+4. Performance comparison between simple and distributed reads
+
+Prerequisites:
+    pip install pypaimon ray pandas pyarrow
+"""
+
+import tempfile
+import uuid
+
+import pandas as pd
+import pyarrow as pa
+import ray
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.tests.rest.rest_server import RESTCatalogServer
+from pypaimon.api.api_response import ConfigResponse
+from pypaimon.api.auth import BearTokenAuthProvider
+
+
+def main():
+    """REST catalog with Ray Data integration example."""
+
+    # Initialize Ray
+    if not ray.is_initialized():
+        ray.init(ignore_reinit_error=True, num_cpus=2)
+        print("Ray initialized successfully")
+
+    # Setup mock REST server
+    temp_dir = tempfile.mkdtemp()
+    token = str(uuid.uuid4())
+    server = RESTCatalogServer(
+        data_path=temp_dir,
+        auth_provider=BearTokenAuthProvider(token),
+        config=ConfigResponse(defaults={"prefix": "mock-test"}),
+        warehouse="warehouse"
+    )
+    server.start()
+    print(f"REST server started at: {server.get_url()}")
+
+    try:
+        # Create REST catalog
+        catalog = CatalogFactory.create({
+            'metastore': 'rest',
+            'uri': f"http://localhost:{server.port}",
+            'warehouse': "warehouse",  # Must match server's warehouse parameter
+            'token.provider': 'bear',
+            'token': token,
+        })
+        catalog.create_database("default", True)
+
+        # Create table schema
+        schema = Schema.from_pyarrow_schema(pa.schema([
+            ('id', pa.int64()),
+            ('name', pa.string()),
+            ('category', pa.string()),
+            ('value', pa.float64()),
+            ('score', pa.int32()),
+        ]))
+        table_name = 'default.ray_example_table'
+        catalog.create_table(table_name, schema, True)
+        table = catalog.get_table(table_name)
+
+        print(f"\nTable created: {table_name}")
+        print(f"Table path: {table.table_path}")
+
+        # Write data
+        print("\n" + "="*60)
+        print("Step 1: Writing data to Paimon table")
+        print("="*60)
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+
+        # Generate sample data
+        data = pd.DataFrame({
+            'id': list(range(1, 21)),  # 20 rows
+            'name': [f'Item_{i}' for i in range(1, 21)],
+            'category': ['A', 'B', 'C'] * 6 + ['A', 'B'],
+            'value': [10.5 + i * 2.3 for i in range(20)],
+            'score': [50 + i * 5 for i in range(20)],
+        })
+        table_write.write_pandas(data)
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+        print(f"✓ Successfully wrote {len(data)} rows to table")
+
+        # Read with Ray Data (distributed mode)
+        print("\n" + "="*60)
+        print("Step 2: Reading data with Ray Data (distributed mode)")
+        print("="*60)
+        read_builder = table.new_read_builder()
+        table_read = read_builder.new_read()
+        table_scan = read_builder.new_scan()
+        splits = table_scan.plan().splits()
+
+        print(f"Number of splits: {len(splits)}")
+
+        # Convert to Ray Dataset
+        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+        print(f"✓ Ray Dataset created successfully")
+        print(f"  - Total rows: {ray_dataset.count()}")
+        # Note: num_blocks() requires materialized dataset, so we skip it for simplicity
+
+        # Convert to pandas for display
+        df_ray = ray_dataset.to_pandas()
+        print("\nFirst 5 rows from Ray Dataset:")
+        print(df_ray.head().to_string())
+
+        # Compare with simple read
+        print("\n" + "="*60)
+        print("Step 3: Comparison with simple read mode")
+        print("="*60)
+        ray_dataset_simple = table_read.to_ray(splits, use_distributed_read=False)
+        df_simple = ray_dataset_simple.to_pandas()
+
+        print(f"Distributed mode rows: {ray_dataset.count()}")
+        print(f"Simple mode rows: {ray_dataset_simple.count()}")
+        print(f"✓ Both modes return the same number of rows")
+
+        # Verify data consistency (sort by id for comparison)
+        df_ray_sorted = df_ray.sort_values(by='id').reset_index(drop=True)
+        df_simple_sorted = df_simple.sort_values(by='id').reset_index(drop=True)
+        pd.testing.assert_frame_equal(df_ray_sorted, df_simple_sorted)
+        print("✓ Data content matches between distributed and simple modes")
+
+        # Ray Data operations
+        print("\n" + "="*60)
+        print("Step 4: Ray Data operations on Paimon data")
+        print("="*60)
+
+        # Filter operation
+        print("\n4.1 Filter: Get items with score >= 80")
+        filtered_dataset = ray_dataset.filter(lambda row: row['score'] >= 80)
+        df_filtered = filtered_dataset.to_pandas()
+        print(f"  - Filtered rows: {len(df_filtered)}")
+        print(f"  - IDs: {sorted(df_filtered['id'].tolist())}")
+
+        # Map operation
+        print("\n4.2 Map: Double the value column")
+        def double_value(row):
+            row['value'] = row['value'] * 2
+            return row
+
+        mapped_dataset = ray_dataset.map(double_value)
+        df_mapped = mapped_dataset.to_pandas()
+        print(f"  - Original first value: {df_ray.iloc[0]['value']:.2f}")
+        print(f"  - Mapped first value: {df_mapped.iloc[0]['value']:.2f}")
+
+        # Group by operation (using pandas after conversion)
+        print("\n4.3 Group by: Aggregate by category")
+        df_grouped = df_ray.groupby('category').agg({
+            'value': 'sum',
+            'score': 'mean',
+            'id': 'count'
+        }).round(2)
+        print(df_grouped.to_string())
+
+        # Predicate filtering at read time
+        print("\n" + "="*60)
+        print("Step 5: Predicate filtering at read time")
+        print("="*60)
+        predicate_builder = read_builder.new_predicate_builder()
+        predicate = predicate_builder.equal('category', 'A')
+        read_builder_filtered = read_builder.with_filter(predicate)
+
+        table_read_filtered = read_builder_filtered.new_read()
+        table_scan_filtered = read_builder_filtered.new_scan()
+        splits_filtered = table_scan_filtered.plan().splits()
+
+        ray_dataset_filtered = table_read_filtered.to_ray(splits_filtered, use_distributed_read=True)
+        df_filtered_at_read = ray_dataset_filtered.to_pandas()
+        print(f"✓ Filtered at read time: {ray_dataset_filtered.count()} rows")
+        print(f"  - All categories are 'A': {all(df_filtered_at_read['category'] == 'A')}")
+
+        # Projection (select specific columns)
+        print("\n" + "="*60)
+        print("Step 6: Column projection")
+        print("="*60)
+        read_builder_projected = read_builder.with_projection(['id', 'name', 'value'])
+        table_read_projected = read_builder_projected.new_read()
+        table_scan_projected = read_builder_projected.new_scan()
+        splits_projected = table_scan_projected.plan().splits()
+
+        ray_dataset_projected = table_read_projected.to_ray(splits_projected, use_distributed_read=True)
+        df_projected = ray_dataset_projected.to_pandas()
+        print(f"✓ Projected columns: {list(df_projected.columns)}")
+        print(f"  - Expected: ['id', 'name', 'value']")
+        print(f"  - Match: {set(df_projected.columns) == {'id', 'name', 'value'}}")
+
+        # Optional: Blob data example (uncomment to demonstrate blob data handling)
+        # print("\n" + "="*60)
+        # print("Step 7: Blob data handling (Optional)")
+        # print("="*60)
+        # print("Paimon supports storing blob data (images, audio, etc.)")
+        # print("For blob data examples, see: pypaimon/sample/oss_blob_as_descriptor.py")
+
+        print("\n" + "="*60)
+        print("Summary")
+        print("="*60)
+        print("✓ Successfully demonstrated Ray Data integration with REST catalog")
+        print("✓ Distributed reading works correctly")
+        print("✓ Ray Data operations (filter, map, group by) work on Paimon data")
+        print("✓ Predicate filtering and projection work at read time")
+        print("\nRay Data enables:")
+        print("  - Distributed parallel reading from Paimon tables")
+        print("  - Scalable data processing with Ray operations")
+        print("  - Integration with Ray ecosystem (Ray Train, Ray Serve, etc.)")
+        print("\nFor blob data (images, audio) examples, see:")
+        print("  - pypaimon/sample/oss_blob_as_descriptor.py")
+
+    finally:
+        server.shutdown()
+        if ray.is_initialized():
+            ray.shutdown()
+        print("\n✓ Server stopped and Ray shutdown")
+
+
+if __name__ == '__main__':
+    main()
+

--- a/paimon-python/pypaimon/tests/ray_data_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_test.py
@@ -1,0 +1,363 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+
+import os
+import tempfile
+import unittest
+import shutil
+
+import pyarrow as pa
+import ray
+
+from pypaimon import CatalogFactory, Schema
+
+
+class RayDataTest(unittest.TestCase):
+    """Tests for Ray Data integration with PyPaimon."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test environment."""
+        cls.tempdir = tempfile.mkdtemp()
+        cls.warehouse = os.path.join(cls.tempdir, 'warehouse')
+        cls.catalog = CatalogFactory.create({
+            'warehouse': cls.warehouse
+        })
+        cls.catalog.create_database('default', True)
+
+        if not ray.is_initialized():
+            ray.init(ignore_reinit_error=True, num_cpus=2)
+
+        try:
+            from ray.data import DataContext
+            context = DataContext.get_current()
+            if hasattr(context, 'shuffle_strategy'):
+                try:
+                    from ray.data._internal.execution.interfaces.execution_options import ShuffleStrategy
+                    context.shuffle_strategy = ShuffleStrategy.SORT_SHUFFLE_PUSH_BASED
+                except (ImportError, AttributeError):
+                    pass
+            if hasattr(context, 'use_polars_sort'):
+                context.use_polars_sort = True
+        except (ImportError, AttributeError):
+            pass
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up test environment."""
+        try:
+            if ray.is_initialized():
+                ray.shutdown()
+        except Exception:
+            pass
+        try:
+            shutil.rmtree(cls.tempdir)
+        except OSError:
+            pass
+
+    def setUp(self):
+        """Set up test method."""
+        pass
+
+    def test_basic_ray_data_read(self):
+        """Test basic Ray Data read from PyPaimon table."""
+        # Create schema
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('name', pa.string()),
+            ('value', pa.int64()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(pa_schema)
+        self.catalog.create_table('default.test_ray_basic', schema, False)
+        table = self.catalog.get_table('default.test_ray_basic')
+
+        # Write test data
+        test_data = pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'name': ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
+            'value': [100, 200, 300, 400, 500],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(test_data)
+        commit_messages = writer.prepare_commit()
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        writer.close()
+
+        # Read using Ray Data
+        read_builder = table.new_read_builder()
+        table_read = read_builder.new_read()
+        table_scan = read_builder.new_scan()
+        splits = table_scan.plan().splits()
+
+        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+
+        # Verify Ray dataset
+        self.assertIsNotNone(ray_dataset, "Ray dataset should not be None")
+        self.assertEqual(ray_dataset.count(), 5, "Should have 5 rows")
+
+        # Test basic operations
+        sample_data = ray_dataset.take(3)
+        self.assertEqual(len(sample_data), 3, "Should have 3 sample rows")
+
+        # Convert to pandas for verification
+        df = ray_dataset.to_pandas()
+        self.assertEqual(len(df), 5, "DataFrame should have 5 rows")
+        # Sort by id to ensure order-independent comparison
+        df_sorted = df.sort_values(by='id').reset_index(drop=True)
+        self.assertEqual(list(df_sorted['id']), [1, 2, 3, 4, 5], "ID column should match")
+        self.assertEqual(list(df_sorted['name']), ['Alice', 'Bob', 'Charlie', 'David', 'Eve'], "Name column should match")
+
+    def test_ray_data_with_predicate(self):
+        """Test Ray Data read with predicate filtering."""
+        # Create schema
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('category', pa.string()),
+            ('amount', pa.int64()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(pa_schema)
+        self.catalog.create_table('default.test_ray_predicate', schema, False)
+        table = self.catalog.get_table('default.test_ray_predicate')
+
+        # Write test data
+        test_data = pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'category': ['A', 'B', 'A', 'C', 'B'],
+            'amount': [100, 200, 150, 300, 250],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(test_data)
+        commit_messages = writer.prepare_commit()
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        writer.close()
+
+        # Read with predicate
+        read_builder = table.new_read_builder()
+        predicate_builder = read_builder.new_predicate_builder()
+        predicate = predicate_builder.equal('category', 'A')
+        read_builder = read_builder.with_filter(predicate)
+
+        table_read = read_builder.new_read()
+        table_scan = read_builder.new_scan()
+        splits = table_scan.plan().splits()
+
+        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+
+        # Verify filtered results
+        self.assertEqual(ray_dataset.count(), 2, "Should have 2 rows after filtering")
+        df = ray_dataset.to_pandas()
+        self.assertEqual(set(df['category'].tolist()), {'A'}, "All rows should have category='A'")
+        self.assertEqual(set(df['id'].tolist()), {1, 3}, "Should have IDs 1 and 3")
+
+    def test_ray_data_with_projection(self):
+        """Test Ray Data read with column projection."""
+        # Create schema
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('name', pa.string()),
+            ('email', pa.string()),
+            ('age', pa.int32()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(pa_schema)
+        self.catalog.create_table('default.test_ray_projection', schema, False)
+        table = self.catalog.get_table('default.test_ray_projection')
+
+        # Write test data
+        test_data = pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'name': ['Alice', 'Bob', 'Charlie'],
+            'email': ['alice@example.com', 'bob@example.com', 'charlie@example.com'],
+            'age': [25, 30, 35],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(test_data)
+        commit_messages = writer.prepare_commit()
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        writer.close()
+
+        # Read with projection
+        read_builder = table.new_read_builder()
+        read_builder = read_builder.with_projection(['id', 'name'])
+
+        table_read = read_builder.new_read()
+        table_scan = read_builder.new_scan()
+        splits = table_scan.plan().splits()
+
+        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+
+        # Verify projection
+        self.assertEqual(ray_dataset.count(), 3, "Should have 3 rows")
+        df = ray_dataset.to_pandas()
+        self.assertEqual(set(df.columns), {'id', 'name'}, "Should only have id and name columns")
+        self.assertFalse('email' in df.columns, "Should not have email column")
+        self.assertFalse('age' in df.columns, "Should not have age column")
+
+    def test_ray_data_map_operation(self):
+        """Test Ray Data map operations after reading from PyPaimon."""
+        # Create schema
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('value', pa.int64()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(pa_schema)
+        self.catalog.create_table('default.test_ray_map', schema, False)
+        table = self.catalog.get_table('default.test_ray_map')
+
+        # Write test data
+        test_data = pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'value': [10, 20, 30, 40, 50],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(test_data)
+        commit_messages = writer.prepare_commit()
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        writer.close()
+
+        # Read using Ray Data
+        read_builder = table.new_read_builder()
+        table_read = read_builder.new_read()
+        table_scan = read_builder.new_scan()
+        splits = table_scan.plan().splits()
+
+        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+
+        # Apply map operation (double the value)
+        def double_value(row):
+            row['value'] = row['value'] * 2
+            return row
+
+        mapped_dataset = ray_dataset.map(double_value)
+
+        # Verify mapped results
+        df = mapped_dataset.to_pandas()
+        # Sort by id to ensure order-independent comparison
+        df_sorted = df.sort_values(by='id').reset_index(drop=True)
+        self.assertEqual(list(df_sorted['value']), [20, 40, 60, 80, 100], "Values should be doubled")
+
+    def test_ray_data_filter_operation(self):
+        """Test Ray Data filter operations after reading from PyPaimon."""
+        # Create schema
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('score', pa.int64()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(pa_schema)
+        self.catalog.create_table('default.test_ray_filter', schema, False)
+        table = self.catalog.get_table('default.test_ray_filter')
+
+        # Write test data
+        test_data = pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'score': [60, 70, 80, 90, 100],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(test_data)
+        commit_messages = writer.prepare_commit()
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        writer.close()
+
+        # Read using Ray Data
+        read_builder = table.new_read_builder()
+        table_read = read_builder.new_read()
+        table_scan = read_builder.new_scan()
+        splits = table_scan.plan().splits()
+
+        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+
+        # Apply filter operation (score >= 80)
+        filtered_dataset = ray_dataset.filter(lambda row: row['score'] >= 80)
+
+        # Verify filtered results
+        df = filtered_dataset.to_pandas()
+        self.assertEqual(len(df), 3, "Should have 3 rows with score >= 80")
+        self.assertEqual(set(df['id'].tolist()), {3, 4, 5}, "Should have IDs 3, 4, 5")
+        self.assertEqual(set(df['score'].tolist()), {80, 90, 100}, "Should have scores 80, 90, 100")
+
+    def test_ray_data_distributed_vs_simple(self):
+        """Test that both distributed and simple reading modes work correctly."""
+        # Create schema
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('value', pa.int64()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(pa_schema)
+        self.catalog.create_table('default.test_ray_modes', schema, False)
+        table = self.catalog.get_table('default.test_ray_modes')
+
+        # Write test data
+        test_data = pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'value': [10, 20, 30],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(test_data)
+        commit_messages = writer.prepare_commit()
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        writer.close()
+
+        # Read using distributed mode
+        read_builder = table.new_read_builder()
+        table_read = read_builder.new_read()
+        table_scan = read_builder.new_scan()
+        splits = table_scan.plan().splits()
+
+        ray_dataset_distributed = table_read.to_ray(splits, use_distributed_read=True)
+        ray_dataset_simple = table_read.to_ray(splits, use_distributed_read=False)
+
+        # Both should produce the same results
+        self.assertEqual(ray_dataset_distributed.count(), 3, "Distributed mode should have 3 rows")
+        self.assertEqual(ray_dataset_simple.count(), 3, "Simple mode should have 3 rows")
+
+        df_distributed = ray_dataset_distributed.to_pandas()
+        df_simple = ray_dataset_simple.to_pandas()
+
+        # Sort both dataframes by id to ensure order-independent comparison
+        df_distributed_sorted = df_distributed.sort_values(by='id').reset_index(drop=True)
+        df_simple_sorted = df_simple.sort_values(by='id').reset_index(drop=True)
+
+        self.assertEqual(list(df_distributed_sorted['id']), list(df_simple_sorted['id']), "IDs should match")
+        self.assertEqual(list(df_distributed_sorted['value']), list(df_simple_sorted['value']), "Values should match")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/ray_data_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_test.py
@@ -61,8 +61,8 @@ class RayDataTest(unittest.TestCase):
     def tearDownClass(cls):
         """Clean up test environment."""
         try:
-                if ray.is_initialized():
-                    ray.shutdown()
+            if ray.is_initialized():
+                ray.shutdown()
         except Exception:
             pass
         try:
@@ -537,7 +537,7 @@ class RayDataTest(unittest.TestCase):
     def test_ray_data_primary_key_multiple_splits_same_bucket(self):
         """Test Ray Data read from PrimaryKey table with small target_split_size."""
         from pypaimon.common.core_options import CoreOptions
-        
+
         pa_schema = pa.schema([
             ('id', pa.int32()),
             ('name', pa.string()),

--- a/paimon-python/pypaimon/tests/ray_data_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_test.py
@@ -108,7 +108,7 @@ class RayDataTest(unittest.TestCase):
         table_scan = read_builder.new_scan()
         splits = table_scan.plan().splits()
 
-        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+        ray_dataset = table_read.to_ray(splits, parallelism=2)
 
         # Verify Ray dataset
         self.assertIsNotNone(ray_dataset, "Ray dataset should not be None")
@@ -168,7 +168,7 @@ class RayDataTest(unittest.TestCase):
         table_scan = read_builder.new_scan()
         splits = table_scan.plan().splits()
 
-        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+        ray_dataset = table_read.to_ray(splits, parallelism=2)
 
         # Verify filtered results
         self.assertEqual(ray_dataset.count(), 2, "Should have 2 rows after filtering")
@@ -214,7 +214,7 @@ class RayDataTest(unittest.TestCase):
         table_scan = read_builder.new_scan()
         splits = table_scan.plan().splits()
 
-        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+        ray_dataset = table_read.to_ray(splits, parallelism=2)
 
         # Verify projection
         self.assertEqual(ray_dataset.count(), 3, "Should have 3 rows")
@@ -255,7 +255,7 @@ class RayDataTest(unittest.TestCase):
         table_scan = read_builder.new_scan()
         splits = table_scan.plan().splits()
 
-        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+        ray_dataset = table_read.to_ray(splits, parallelism=2)
 
         # Apply map operation (double the value)
         def double_value(row):
@@ -302,7 +302,7 @@ class RayDataTest(unittest.TestCase):
         table_scan = read_builder.new_scan()
         splits = table_scan.plan().splits()
 
-        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+        ray_dataset = table_read.to_ray(splits, parallelism=2)
 
         # Apply filter operation (score >= 80)
         filtered_dataset = ray_dataset.filter(lambda row: row['score'] >= 80)
@@ -345,8 +345,8 @@ class RayDataTest(unittest.TestCase):
         table_scan = read_builder.new_scan()
         splits = table_scan.plan().splits()
 
-        ray_dataset_distributed = table_read.to_ray(splits, use_distributed_read=True)
-        ray_dataset_simple = table_read.to_ray(splits, use_distributed_read=False)
+        ray_dataset_distributed = table_read.to_ray(splits, parallelism=2)
+        ray_dataset_simple = table_read.to_ray(splits, parallelism=1)
 
         # Both should produce the same results
         self.assertEqual(ray_dataset_distributed.count(), 3, "Distributed mode should have 3 rows")
@@ -394,7 +394,7 @@ class RayDataTest(unittest.TestCase):
         splits = table_scan.plan().splits()
 
         # TODO: support pk merge feature in distributed mode
-        ray_dataset = table_read.to_ray(splits, use_distributed_read=False)
+        ray_dataset = table_read.to_ray(splits, parallelism=1)
         self.assertIsNotNone(ray_dataset, "Ray dataset should not be None")
         self.assertEqual(ray_dataset.count(), 5, "Should have 5 rows")
 
@@ -462,7 +462,7 @@ class RayDataTest(unittest.TestCase):
         self.assertEqual(list(simple_df_sorted['id']), [1, 2, 3, 4], "ID column should match")
         
         # TODO: support pk merge feature in distributed mode
-        ray_dataset = table_read.to_ray(splits, use_distributed_read=False)
+        ray_dataset = table_read.to_ray(splits, parallelism=1)
 
         self.assertIsNotNone(ray_dataset, "Ray dataset should not be None")
         self.assertEqual(ray_dataset.count(), 4, "Should have 4 rows after upsert")
@@ -520,7 +520,7 @@ class RayDataTest(unittest.TestCase):
         splits = table_scan.plan().splits()
 
         # TODO: support pk merge feature in distributed mode
-        ray_dataset = table_read.to_ray(splits, use_distributed_read=False)
+        ray_dataset = table_read.to_ray(splits, parallelism=1)
 
         # Verify filtered results
         self.assertEqual(ray_dataset.count(), 2, "Should have 2 rows after filtering")
@@ -539,7 +539,7 @@ class RayDataTest(unittest.TestCase):
         splits = table_scan.plan().splits()
 
         # TODO: support pk merge feature in distributed mode
-        ray_dataset = table_read.to_ray(splits, use_distributed_read=False)
+        ray_dataset = table_read.to_ray(splits, parallelism=1)
 
         # Verify filtered results by partition
         self.assertEqual(ray_dataset.count(), 2, "Should have 2 rows in partition 2024-01-01")

--- a/paimon-python/pypaimon/tests/ray_data_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_test.py
@@ -124,7 +124,11 @@ class RayDataTest(unittest.TestCase):
         # Sort by id to ensure order-independent comparison
         df_sorted = df.sort_values(by='id').reset_index(drop=True)
         self.assertEqual(list(df_sorted['id']), [1, 2, 3, 4, 5], "ID column should match")
-        self.assertEqual(list(df_sorted['name']), ['Alice', 'Bob', 'Charlie', 'David', 'Eve'], "Name column should match")
+        self.assertEqual(
+            list(df_sorted['name']),
+            ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
+            "Name column should match"
+        )
 
     def test_ray_data_with_predicate(self):
         """Test Ray Data read with predicate filtering."""

--- a/paimon-python/pypaimon/tests/ray_data_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_test.py
@@ -61,8 +61,8 @@ class RayDataTest(unittest.TestCase):
     def tearDownClass(cls):
         """Clean up test environment."""
         try:
-                if ray.is_initialized():
-                    ray.shutdown()
+            if ray.is_initialized():
+                ray.shutdown()
         except Exception:
             pass
         try:
@@ -393,14 +393,12 @@ class RayDataTest(unittest.TestCase):
         table_scan = read_builder.new_scan()
         splits = table_scan.plan().splits()
 
-        # TODO: support pk merge feature in distributed mode
         ray_dataset = table_read.to_ray(splits, parallelism=1)
         self.assertIsNotNone(ray_dataset, "Ray dataset should not be None")
         self.assertEqual(ray_dataset.count(), 5, "Should have 5 rows")
 
         df = ray_dataset.to_pandas()
         self.assertEqual(len(df), 5, "DataFrame should have 5 rows")
-        # Sort by id to ensure order-independent comparison
         df_sorted = df.sort_values(by='id').reset_index(drop=True)
         self.assertEqual(list(df_sorted['id']), [1, 2, 3, 4, 5], "ID column should match")
         self.assertEqual(
@@ -454,15 +452,7 @@ class RayDataTest(unittest.TestCase):
         table_scan = read_builder.new_scan()
         splits = table_scan.plan().splits()
 
-        simple_read_result = table_read.to_arrow(splits)
-        simple_df = simple_read_result.to_pandas()
-        simple_df_sorted = simple_df.sort_values(by='id').reset_index(drop=True)
-        
-        self.assertEqual(len(simple_df_sorted), 4, "Simple read should have 4 rows after upsert")
-        self.assertEqual(list(simple_df_sorted['id']), [1, 2, 3, 4], "ID column should match")
-        
-        # TODO: support pk merge feature in distributed mode
-        ray_dataset = table_read.to_ray(splits, parallelism=1)
+        ray_dataset = table_read.to_ray(splits, parallelism=2)
 
         self.assertIsNotNone(ray_dataset, "Ray dataset should not be None")
         self.assertEqual(ray_dataset.count(), 4, "Should have 4 rows after upsert")
@@ -519,7 +509,6 @@ class RayDataTest(unittest.TestCase):
         table_scan = read_builder.new_scan()
         splits = table_scan.plan().splits()
 
-        # TODO: support pk merge feature in distributed mode
         ray_dataset = table_read.to_ray(splits, parallelism=1)
 
         # Verify filtered results
@@ -538,13 +527,81 @@ class RayDataTest(unittest.TestCase):
         table_scan = read_builder.new_scan()
         splits = table_scan.plan().splits()
 
-        # TODO: support pk merge feature in distributed mode
         ray_dataset = table_read.to_ray(splits, parallelism=1)
 
         # Verify filtered results by partition
         self.assertEqual(ray_dataset.count(), 2, "Should have 2 rows in partition 2024-01-01")
         df = ray_dataset.to_pandas()
         self.assertEqual(set(df['dt'].tolist()), {'2024-01-01'}, "All rows should be in partition 2024-01-01")
+
+    def test_ray_data_primary_key_multiple_splits_same_bucket(self):
+        """Test Ray Data read from PrimaryKey table with small target_split_size."""
+        from pypaimon.common.core_options import CoreOptions
+        
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('name', pa.string()),
+            ('value', pa.int64()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            primary_keys=['id'],
+            options={
+                'bucket': '2',
+                CoreOptions.SOURCE_SPLIT_TARGET_SIZE: '1b'
+            }
+        )
+        self.catalog.create_table('default.test_ray_pk_multi_split', schema, False)
+        table = self.catalog.get_table('default.test_ray_pk_multi_split')
+
+        initial_data = pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'name': ['Alice', 'Bob', 'Charlie'],
+            'value': [100, 200, 300],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(initial_data)
+        commit_messages = writer.prepare_commit()
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        writer.close()
+
+        updated_data = pa.Table.from_pydict({
+            'id': [1, 2, 4],
+            'name': ['Alice-Updated', 'Bob-Updated', 'David'],
+            'value': [150, 250, 400],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(updated_data)
+        commit_messages = writer.prepare_commit()
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        writer.close()
+
+        read_builder = table.new_read_builder()
+        table_read = read_builder.new_read()
+        table_scan = read_builder.new_scan()
+        splits = table_scan.plan().splits()
+
+        ray_dataset = table_read.to_ray(splits, parallelism=2)
+
+        self.assertIsNotNone(ray_dataset, "Ray dataset should not be None")
+        self.assertEqual(ray_dataset.count(), 4, "Should have 4 rows after upsert")
+
+        df = ray_dataset.to_pandas()
+        df_sorted = df.sort_values(by='id').reset_index(drop=True)
+        self.assertEqual(list(df_sorted['id']), [1, 2, 3, 4], "ID column should match")
+        self.assertEqual(
+            list(df_sorted['name']),
+            ['Alice-Updated', 'Bob-Updated', 'Charlie', 'David'],
+            "Name column should reflect updates"
+        )
+        self.assertEqual(list(df_sorted['value']), [150, 250, 300, 400], "Value column should reflect updates")
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/rest/rest_read_write_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_read_write_test.py
@@ -372,7 +372,7 @@ class RESTTableReadWriteTest(RESTBaseTest):
         table_read = read_builder.new_read()
         splits = read_builder.new_scan().plan().splits()
 
-        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+        ray_dataset = table_read.to_ray(splits, parallelism=2)
 
         self.assertIsNotNone(ray_dataset, "Ray dataset should not be None")
         self.assertEqual(ray_dataset.count(), 8, "Should have 8 rows")
@@ -413,7 +413,7 @@ class RESTTableReadWriteTest(RESTBaseTest):
         table_read = read_builder.new_read()
         splits = read_builder.new_scan().plan().splits()
 
-        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+        ray_dataset = table_read.to_ray(splits, parallelism=2)
 
         self.assertIsNotNone(ray_dataset, "Ray dataset should not be None")
         self.assertEqual(ray_dataset.count(), 3, "Should have 3 rows")

--- a/paimon-python/pypaimon/tests/rest/rest_read_write_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_read_write_test.py
@@ -29,6 +29,8 @@ from pypaimon.common.identifier import Identifier
 from pypaimon import Schema
 from pypaimon.tests.rest.rest_base_test import RESTBaseTest
 
+import ray
+
 
 class RESTTableReadWriteTest(RESTBaseTest):
 
@@ -361,6 +363,70 @@ class RESTTableReadWriteTest(RESTBaseTest):
         actual = duckdb_con.query("SELECT * FROM duckdb_table").fetchdf()
         expect = pd.DataFrame(self.raw_data)
         pd.testing.assert_frame_equal(actual.reset_index(drop=True), expect.reset_index(drop=True))
+
+    def test_reader_ray_data(self):
+        if not ray.is_initialized():
+            ray.init(ignore_reinit_error=True, num_cpus=2)
+
+        read_builder = self.table.new_read_builder()
+        table_read = read_builder.new_read()
+        splits = read_builder.new_scan().plan().splits()
+
+        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+
+        self.assertIsNotNone(ray_dataset, "Ray dataset should not be None")
+        self.assertEqual(ray_dataset.count(), 8, "Should have 8 rows")
+
+        df = ray_dataset.to_pandas()
+        expect = pd.DataFrame(self.raw_data)
+        pd.testing.assert_frame_equal(df.sort_values(by='user_id').reset_index(drop=True),
+                                      expect.sort_values(by='user_id').reset_index(drop=True))
+
+    def test_ray_data_write_and_read(self):
+        if not ray.is_initialized():
+            ray.init(ignore_reinit_error=True, num_cpus=2)
+
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('name', pa.string()),
+            ('value', pa.int64()),
+        ])
+        schema = Schema.from_pyarrow_schema(pa_schema)
+        self.rest_catalog.create_table('default.test_ray_write_read', schema, False)
+        table = self.rest_catalog.get_table('default.test_ray_write_read')
+
+        test_data = pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'name': ['Alice', 'Bob', 'Charlie'],
+            'value': [100, 200, 300],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        table_write.write_arrow(test_data)
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+
+        read_builder = table.new_read_builder()
+        table_read = read_builder.new_read()
+        splits = read_builder.new_scan().plan().splits()
+
+        ray_dataset = table_read.to_ray(splits, use_distributed_read=True)
+
+        self.assertIsNotNone(ray_dataset, "Ray dataset should not be None")
+        self.assertEqual(ray_dataset.count(), 3, "Should have 3 rows")
+
+        df = ray_dataset.to_pandas()
+        expected_df = pd.DataFrame({
+            'id': [1, 2, 3],
+            'name': ['Alice', 'Bob', 'Charlie'],
+            'value': [100, 200, 300],
+        })
+        expected_df['id'] = expected_df['id'].astype('int32')
+        pd.testing.assert_frame_equal(df.sort_values(by='id').reset_index(drop=True),
+                                      expected_df.sort_values(by='id').reset_index(drop=True))
 
     def test_write_wide_table_large_data(self):
         logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Ray Data Dataset reading with optional parallelism, new Ray datasource, serialization fixes for REST file IO, plus docs, samples, tests, and dependency updates.
> 
> - **Python Read API**:
>   - Add `TableRead.to_ray(splits, parallelism=...)` with empty-split handling and distributed mode via Ray.
>   - Introduce `pypaimon/read/ray_datasource.py` (`PaimonDatasource`) to create balanced Ray read tasks from Paimon splits.
> - **REST IO**:
>   - Enhance `RESTTokenFileIO` with `__getstate__`/`__setstate__` to support safe serialization in worker processes.
> - **Tests**:
>   - Add `pypaimon/tests/ray_data_test.py` covering basic reads, predicates, projections, PK tables, distributed vs. simple modes, and invalid `parallelism`.
>   - Extend REST tests to validate Ray read/write (`test_reader_ray_data`, `test_ray_data_write_and_read`).
> - **Docs**:
>   - Update Python API docs Ray section to use Ray Data and document `parallelism` usage with examples.
> - **Samples**:
>   - Add `pypaimon/sample/rest_catalog_ray_data_sample.py` demonstrating REST catalog with Ray Data operations.
> - **Dependencies**:
>   - Add `ray==2.48.0` to `dev/requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa0bc26e9f797d19806f726e870df1fb35e1a193. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->