### PR TITLE
[python/hotfix] fix pypaimon manifest entry incomplete identifier issue

### DIFF
--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
@@ -85,17 +85,7 @@ public class LanceUtils {
             }
         }
 
-        // TraceableFileIO is a test utility that wraps LocalFileIO
-        // Convert traceable:// to file:// for Lance compatibility
-        if ("traceable".equals(schema)) {
-            String uriString = uri.toString();
-            uriString = uriString.replace("traceable://", "file://");
-            uri = URI.create(uriString);
-            schema = uri.getScheme();
-            path = new Path(uri);
-        }
-
-        Options originOptions;
+       Options originOptions;
         if (ossFileIOKlass != null && ossFileIOKlass.isInstance(fileIO)) {
             originOptions = ((OSSFileIO) fileIO).hadoopOptions();
         } else if (jindoFileIOKlass != null && jindoFileIOKlass.isInstance(fileIO)) {

--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
@@ -85,6 +85,16 @@ public class LanceUtils {
             }
         }
 
+        // TraceableFileIO is a test utility that wraps LocalFileIO
+        // Convert traceable:// to file:// for Lance compatibility
+        if ("traceable".equals(schema)) {
+            String uriString = uri.toString();
+            uriString = uriString.replace("traceable://", "file://");
+            uri = URI.create(uriString);
+            schema = uri.getScheme();
+            path = new Path(uri);
+        }
+
         Options originOptions;
         if (ossFileIOKlass != null && ossFileIOKlass.isInstance(fileIO)) {
             originOptions = ((OSSFileIO) fileIO).hadoopOptions();

--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
@@ -85,7 +85,7 @@ public class LanceUtils {
             }
         }
 
-       Options originOptions;
+        Options originOptions;
         if (ossFileIOKlass != null && ossFileIOKlass.isInstance(fileIO)) {
             originOptions = ((OSSFileIO) fileIO).hadoopOptions();
         } else if (jindoFileIOKlass != null && jindoFileIOKlass.isInstance(fileIO)) {

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -51,21 +51,31 @@ class ManifestFileManager:
         def _process_single_manifest(manifest_file: ManifestFileMeta) -> List[ManifestEntry]:
             return self.read(manifest_file.file_name, manifest_entry_filter, drop_stats)
 
+        def _entry_identifier(entry: ManifestEntry) -> tuple:
+            return (
+                tuple(entry.partition.values),
+                entry.bucket,
+                entry.file.level,
+                entry.file.file_name,
+                tuple(entry.file.extra_files) if entry.file.extra_files else (),
+                entry.file.embedded_index,
+                entry.file.external_path,
+            )
+
         deleted_entry_keys = set()
         added_entries = []
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             future_results = executor.map(_process_single_manifest, manifest_files)
             for entries in future_results:
                 for entry in entries:
-                    if entry.kind == 0:
+                    if entry.kind == 0:  # ADD
                         added_entries.append(entry)
-                    else:
-                        key = (tuple(entry.partition.values), entry.bucket, entry.file.file_name)
-                        deleted_entry_keys.add(key)
+                    else:  # DELETE
+                        deleted_entry_keys.add(_entry_identifier(entry))
 
         final_entries = [
             entry for entry in added_entries
-            if (tuple(entry.partition.values), entry.bucket, entry.file.file_name) not in deleted_entry_keys
+            if _entry_identifier(entry) not in deleted_entry_keys
         ]
         return final_entries
 

--- a/paimon-python/pypaimon/tests/manifest/manifest_entry_identifier_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_entry_identifier_test.py
@@ -1,0 +1,509 @@
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import tempfile
+import unittest
+from unittest.mock import Mock
+
+from pypaimon.catalog.filesystem_catalog import FileSystemCatalog
+from pypaimon.manifest.manifest_file_manager import ManifestFileManager
+from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.manifest.schema.manifest_entry import ManifestEntry
+from pypaimon.manifest.schema.manifest_file_meta import ManifestFileMeta
+from pypaimon.schema.schema import Schema
+from pypaimon.table.row.binary_row import BinaryRow
+from pypaimon.table.row.generic_row import GenericRow
+from pypaimon.table.schema.data_field import DataField
+from pypaimon.table.schema.data_types import AtomicType
+from pypaimon.table.schema.simple_stats import SimpleStats
+import pyarrow as pa
+
+
+class ManifestEntryIdentifierTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        cls.catalog = FileSystemCatalog(cls.tempdir)
+
+    def setUp(self):
+        pa_schema = pa.schema([('id', pa.int32()), ('value', pa.string())])
+        schema = Schema.from_pyarrow_schema(pa_schema)
+        self.catalog.create_table('default.test_table', schema, False)
+        self.table = self.catalog.get_table('default.test_table')
+        self.manifest_file_manager = ManifestFileManager(self.table)
+
+    def test_entry_identifier_with_different_levels(self):
+        partition_fields = []
+        partition = GenericRow([], partition_fields)
+
+        # Create ADD entry with level=0
+        add_file_meta = DataFileMeta(
+            file_name="data-1.parquet",
+            file_size=1024,
+            row_count=100,
+            min_key=BinaryRow([], []),
+            max_key=BinaryRow([], []),
+            key_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            value_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            min_sequence_number=1,
+            max_sequence_number=100,
+            schema_id=0,
+            level=0,  # Level 0
+            extra_files=None,
+            creation_time=1234567890,
+            delete_row_count=0,
+            embedded_index=None,
+            file_source=None,
+            value_stats_cols=None,
+            external_path=None,
+            first_row_id=None,
+            write_cols=None
+        )
+
+        add_entry = ManifestEntry(
+            kind=0,  # ADD
+            partition=partition,
+            bucket=0,
+            total_buckets=1,
+            file=add_file_meta
+        )
+
+        # Create DELETE entry with level=1, same file_name
+        delete_file_meta = DataFileMeta(
+            file_name="data-1.parquet",  # Same file name
+            file_size=1024,
+            row_count=100,
+            min_key=BinaryRow([], []),
+            max_key=BinaryRow([], []),
+            key_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            value_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            min_sequence_number=101,
+            max_sequence_number=200,
+            schema_id=0,
+            level=1,  # Different level!
+            extra_files=None,
+            creation_time=1234567891,
+            delete_row_count=0,
+            embedded_index=None,
+            file_source=None,
+            value_stats_cols=None,
+            external_path=None,
+            first_row_id=None,
+            write_cols=None
+        )
+
+        delete_entry = ManifestEntry(
+            kind=1,  # DELETE
+            partition=partition,
+            bucket=0,
+            total_buckets=1,
+            file=delete_file_meta
+        )
+
+        # Simulate reading from two manifest files
+        manifest_file_1 = ManifestFileMeta(
+            version=2,
+            file_name="manifest-1.avro",
+            file_size=1024,
+            num_added_files=1,
+            num_deleted_files=0,
+            partition_stats=None,
+            schema_id=0
+        )
+
+        manifest_file_2 = ManifestFileMeta(
+            version=2,
+            file_name="manifest-2.avro",
+            file_size=1024,
+            num_added_files=0,
+            num_deleted_files=1,
+            partition_stats=None,
+            schema_id=0
+        )
+
+        self.manifest_file_manager.write(manifest_file_1.file_name, [add_entry])
+        self.manifest_file_manager.write(manifest_file_2.file_name, [delete_entry])
+
+        manifest_files = [manifest_file_1, manifest_file_2]
+        final_entries = self.manifest_file_manager.read_entries_parallel(manifest_files)
+
+        self.assertEqual(len(final_entries), 1, "ADD entry should remain after merge")
+        self.assertEqual(final_entries[0].kind, 0, "Remaining entry should be ADD")
+        self.assertEqual(final_entries[0].file.level, 0, "Remaining entry should have level=0")
+
+    def test_entry_identifier_with_different_extra_files(self):
+        partition_fields = []
+        partition = GenericRow([], partition_fields)
+
+        # Create ADD entry with extra_files=["index.idx"]
+        add_file_meta = DataFileMeta(
+            file_name="data-1.parquet",
+            file_size=1024,
+            row_count=100,
+            min_key=BinaryRow([], []),
+            max_key=BinaryRow([], []),
+            key_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            value_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            min_sequence_number=1,
+            max_sequence_number=100,
+            schema_id=0,
+            level=0,
+            extra_files=["index.idx"],  # Has extra file
+            creation_time=1234567890,
+            delete_row_count=0,
+            embedded_index=None,
+            file_source=None,
+            value_stats_cols=None,
+            external_path=None,
+            first_row_id=None,
+            write_cols=None
+        )
+
+        add_entry = ManifestEntry(
+            kind=0,  # ADD
+            partition=partition,
+            bucket=0,
+            total_buckets=1,
+            file=add_file_meta
+        )
+
+        # Create DELETE entry with no extra_files, same file_name
+        delete_file_meta = DataFileMeta(
+            file_name="data-1.parquet",  # Same file name
+            file_size=1024,
+            row_count=100,
+            min_key=BinaryRow([], []),
+            max_key=BinaryRow([], []),
+            key_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            value_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            min_sequence_number=101,
+            max_sequence_number=200,
+            schema_id=0,
+            level=0,
+            extra_files=None,  # No extra files
+            creation_time=1234567891,
+            delete_row_count=0,
+            embedded_index=None,
+            file_source=None,
+            value_stats_cols=None,
+            external_path=None,
+            first_row_id=None,
+            write_cols=None
+        )
+
+        delete_entry = ManifestEntry(
+            kind=1,  # DELETE
+            partition=partition,
+            bucket=0,
+            total_buckets=1,
+            file=delete_file_meta
+        )
+
+        manifest_file_1 = ManifestFileMeta(
+            version=2,
+            file_name="manifest-1.avro",
+            file_size=1024,
+            num_added_files=1,
+            num_deleted_files=0,
+            partition_stats=None,
+            schema_id=0
+        )
+
+        manifest_file_2 = ManifestFileMeta(
+            version=2,
+            file_name="manifest-2.avro",
+            file_size=1024,
+            num_added_files=0,
+            num_deleted_files=1,
+            partition_stats=None,
+            schema_id=0
+        )
+
+        self.manifest_file_manager.write(manifest_file_1.file_name, [add_entry])
+        self.manifest_file_manager.write(manifest_file_2.file_name, [delete_entry])
+
+        manifest_files = [manifest_file_1, manifest_file_2]
+        final_entries = self.manifest_file_manager.read_entries_parallel(manifest_files)
+
+        # With correct identifier (including extra_files), these should be different entries
+        self.assertEqual(len(final_entries), 1, "ADD entry should remain after merge")
+        self.assertEqual(final_entries[0].kind, 0, "Remaining entry should be ADD")
+        self.assertEqual(final_entries[0].file.extra_files, ["index.idx"])
+
+    def test_entry_identifier_with_different_external_paths(self):
+        """Test that entries with same partition/bucket/file_name but different external_paths are correctly distinguished."""
+        partition_fields = []
+        partition = GenericRow([], partition_fields)
+
+        # Create ADD entry with external_path
+        add_file_meta = DataFileMeta(
+            file_name="data-1.parquet",
+            file_size=1024,
+            row_count=100,
+            min_key=BinaryRow([], []),
+            max_key=BinaryRow([], []),
+            key_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            value_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            min_sequence_number=1,
+            max_sequence_number=100,
+            schema_id=0,
+            level=0,
+            extra_files=None,
+            creation_time=1234567890,
+            delete_row_count=0,
+            embedded_index=None,
+            file_source=None,
+            value_stats_cols=None,
+            external_path="s3://bucket/path/data-1.parquet",  # Has external path
+            first_row_id=None,
+            write_cols=None
+        )
+
+        add_entry = ManifestEntry(
+            kind=0,  # ADD
+            partition=partition,
+            bucket=0,
+            total_buckets=1,
+            file=add_file_meta
+        )
+
+        # Create DELETE entry with no external_path, same file_name
+        delete_file_meta = DataFileMeta(
+            file_name="data-1.parquet",  # Same file name
+            file_size=1024,
+            row_count=100,
+            min_key=BinaryRow([], []),
+            max_key=BinaryRow([], []),
+            key_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            value_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            min_sequence_number=101,
+            max_sequence_number=200,
+            schema_id=0,
+            level=0,
+            extra_files=None,
+            creation_time=1234567891,
+            delete_row_count=0,
+            embedded_index=None,
+            file_source=None,
+            value_stats_cols=None,
+            external_path=None,  # No external path
+            first_row_id=None,
+            write_cols=None
+        )
+
+        delete_entry = ManifestEntry(
+            kind=1,  # DELETE
+            partition=partition,
+            bucket=0,
+            total_buckets=1,
+            file=delete_file_meta
+        )
+
+        manifest_file_1 = ManifestFileMeta(
+            version=2,
+            file_name="manifest-1.avro",
+            file_size=1024,
+            num_added_files=1,
+            num_deleted_files=0,
+            partition_stats=None,
+            schema_id=0
+        )
+
+        manifest_file_2 = ManifestFileMeta(
+            version=2,
+            file_name="manifest-2.avro",
+            file_size=1024,
+            num_added_files=0,
+            num_deleted_files=1,
+            partition_stats=None,
+            schema_id=0
+        )
+
+        self.manifest_file_manager.write(manifest_file_1.file_name, [add_entry])
+        self.manifest_file_manager.write(manifest_file_2.file_name, [delete_entry])
+
+        manifest_files = [manifest_file_1, manifest_file_2]
+        final_entries = self.manifest_file_manager.read_entries_parallel(manifest_files)
+
+        self.assertEqual(len(final_entries), 1, "ADD entry should remain after merge")
+        self.assertEqual(final_entries[0].kind, 0, "Remaining entry should be ADD")
+        self.assertEqual(final_entries[0].file.external_path, "s3://bucket/path/data-1.parquet")
+
+    def test_entry_identifier_matching_same_file(self):
+        partition_fields = []
+        partition = GenericRow([], partition_fields)
+
+        # Create ADD entry
+        add_file_meta = DataFileMeta(
+            file_name="data-1.parquet",
+            file_size=1024,
+            row_count=100,
+            min_key=BinaryRow([], []),
+            max_key=BinaryRow([], []),
+            key_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            value_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            min_sequence_number=1,
+            max_sequence_number=100,
+            schema_id=0,
+            level=0,
+            extra_files=None,
+            creation_time=1234567890,
+            delete_row_count=0,
+            embedded_index=None,
+            file_source=None,
+            value_stats_cols=None,
+            external_path=None,
+            first_row_id=None,
+            write_cols=None
+        )
+
+        add_entry = ManifestEntry(
+            kind=0,  # ADD
+            partition=partition,
+            bucket=0,
+            total_buckets=1,
+            file=add_file_meta
+        )
+
+        delete_file_meta = DataFileMeta(
+            file_name="data-1.parquet",  # Same file name
+            file_size=1024,
+            row_count=100,
+            min_key=BinaryRow([], []),
+            max_key=BinaryRow([], []),
+            key_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            value_stats=SimpleStats(
+                min_values=BinaryRow([], []),
+                max_values=BinaryRow([], []),
+                null_counts=[]
+            ),
+            min_sequence_number=101,
+            max_sequence_number=200,
+            schema_id=0,
+            level=0,  # Same level
+            extra_files=None,  # Same extra_files
+            creation_time=1234567891,
+            delete_row_count=0,
+            embedded_index=None,  # Same embedded_index
+            file_source=None,
+            value_stats_cols=None,
+            external_path=None,  # Same external_path
+            first_row_id=None,
+            write_cols=None
+        )
+
+        delete_entry = ManifestEntry(
+            kind=1,  # DELETE
+            partition=partition,
+            bucket=0,
+            total_buckets=1,
+            file=delete_file_meta
+        )
+
+        manifest_file_1 = ManifestFileMeta(
+            version=2,
+            file_name="manifest-1.avro",
+            file_size=1024,
+            num_added_files=1,
+            num_deleted_files=0,
+            partition_stats=None,
+            schema_id=0
+        )
+
+        manifest_file_2 = ManifestFileMeta(
+            version=2,
+            file_name="manifest-2.avro",
+            file_size=1024,
+            num_added_files=0,
+            num_deleted_files=1,
+            partition_stats=None,
+            schema_id=0
+        )
+
+        self.manifest_file_manager.write(manifest_file_1.file_name, [add_entry])
+        self.manifest_file_manager.write(manifest_file_2.file_name, [delete_entry])
+
+        manifest_files = [manifest_file_1, manifest_file_2]
+        final_entries = self.manifest_file_manager.read_entries_parallel(manifest_files)
+
+        self.assertEqual(len(final_entries), 0, "Matching ADD and DELETE entries should both be removed")
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/paimon-python/pypaimon/tests/manifest/manifest_entry_identifier_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_entry_identifier_test.py
@@ -17,493 +17,247 @@ limitations under the License.
 """
 import tempfile
 import unittest
-from unittest.mock import Mock
 
 from pypaimon.catalog.filesystem_catalog import FileSystemCatalog
+from pypaimon.common.identifier import Identifier
 from pypaimon.manifest.manifest_file_manager import ManifestFileManager
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.manifest.schema.manifest_file_meta import ManifestFileMeta
 from pypaimon.schema.schema import Schema
-from pypaimon.table.row.binary_row import BinaryRow
 from pypaimon.table.row.generic_row import GenericRow
-from pypaimon.table.schema.data_field import DataField
-from pypaimon.table.schema.data_types import AtomicType
-from pypaimon.table.schema.simple_stats import SimpleStats
+from pypaimon.manifest.schema.simple_stats import SimpleStats
 import pyarrow as pa
 
 
 class ManifestEntryIdentifierTest(unittest.TestCase):
+    """
+    Test for manifest entry identifier matching in merge logic.
+    
+    Bug: Previously, _entry_identifier was incomplete (missing level, extra_files,
+    embedded_index, external_path), causing ADD and DELETE entries to be incorrectly
+    matched. This led to:
+    - ADD entry not being removed when DELETE entry exists
+    - Result: empty reads because the file was actually deleted but ADD entry remained
+    
+    Fix: _entry_identifier now includes all fields needed for accurate matching:
+    (partition, bucket, level, file_name, extra_files, embedded_index, external_path)
+    """
 
     @classmethod
     def setUpClass(cls):
         cls.tempdir = tempfile.mkdtemp()
-        cls.catalog = FileSystemCatalog(cls.tempdir)
+        cls.catalog = FileSystemCatalog({'warehouse': cls.tempdir})
+        cls.catalog.create_database('default', False)
 
     def setUp(self):
+        try:
+            table_identifier = Identifier.from_string('default.test_table')
+            table_path = self.catalog.get_table_path(table_identifier)
+            if self.catalog.file_io.exists(table_path):
+                self.catalog.file_io.delete(table_path, recursive=True)
+        except Exception:
+            pass
+        
         pa_schema = pa.schema([('id', pa.int32()), ('value', pa.string())])
         schema = Schema.from_pyarrow_schema(pa_schema)
         self.catalog.create_table('default.test_table', schema, False)
         self.table = self.catalog.get_table('default.test_table')
         self.manifest_file_manager = ManifestFileManager(self.table)
 
-    def test_entry_identifier_with_different_levels(self):
-        partition_fields = []
-        partition = GenericRow([], partition_fields)
-
-        # Create ADD entry with level=0
-        add_file_meta = DataFileMeta(
-            file_name="data-1.parquet",
+    def _create_file_meta(self, file_name, level=0, extra_files=None, external_path=None):
+        """Helper to create DataFileMeta with common defaults."""
+        return DataFileMeta(
+            file_name=file_name,
             file_size=1024,
             row_count=100,
-            min_key=BinaryRow([], []),
-            max_key=BinaryRow([], []),
+            min_key=GenericRow([], []),
+            max_key=GenericRow([], []),
             key_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
+                min_values=GenericRow([], []),
+                max_values=GenericRow([], []),
                 null_counts=[]
             ),
             value_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
+                min_values=GenericRow([], []),
+                max_values=GenericRow([], []),
                 null_counts=[]
             ),
             min_sequence_number=1,
             max_sequence_number=100,
             schema_id=0,
-            level=0,  # Level 0
-            extra_files=None,
+            level=level,
+            extra_files=extra_files or [],
             creation_time=1234567890,
             delete_row_count=0,
             embedded_index=None,
             file_source=None,
             value_stats_cols=None,
-            external_path=None,
+            external_path=external_path,
             first_row_id=None,
             write_cols=None
         )
 
+    def test_add_delete_matching_same_file(self):
+        """
+        Core test: ADD -> DELETE should result in empty entries.
+        
+        This is the main scenario that was broken:
+        - Manifest 1: ADD entry for "data-1.parquet"
+        - Manifest 2: DELETE entry for "data-1.parquet" (same identifier)
+        - Expected: Both entries removed, final_entries should be empty
+        - Bug: If identifier was incomplete, DELETE wouldn't match ADD, 
+               ADD would remain, but file is gone -> empty reads
+        """
+        partition = GenericRow([], [])
+        
         add_entry = ManifestEntry(
             kind=0,  # ADD
             partition=partition,
             bucket=0,
             total_buckets=1,
-            file=add_file_meta
+            file=self._create_file_meta("data-1.parquet", level=0)
         )
-
-        # Create DELETE entry with level=1, same file_name
-        delete_file_meta = DataFileMeta(
-            file_name="data-1.parquet",  # Same file name
-            file_size=1024,
-            row_count=100,
-            min_key=BinaryRow([], []),
-            max_key=BinaryRow([], []),
-            key_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            value_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            min_sequence_number=101,
-            max_sequence_number=200,
-            schema_id=0,
-            level=1,  # Different level!
-            extra_files=None,
-            creation_time=1234567891,
-            delete_row_count=0,
-            embedded_index=None,
-            file_source=None,
-            value_stats_cols=None,
-            external_path=None,
-            first_row_id=None,
-            write_cols=None
-        )
-
+        
         delete_entry = ManifestEntry(
             kind=1,  # DELETE
             partition=partition,
             bucket=0,
             total_buckets=1,
-            file=delete_file_meta
+            file=self._create_file_meta("data-1.parquet", level=0)  # Same identifier
         )
-
-        # Simulate reading from two manifest files
+        
         manifest_file_1 = ManifestFileMeta(
-            version=2,
             file_name="manifest-1.avro",
             file_size=1024,
             num_added_files=1,
             num_deleted_files=0,
-            partition_stats=None,
+            partition_stats=SimpleStats.empty_stats(),
             schema_id=0
         )
-
+        
         manifest_file_2 = ManifestFileMeta(
-            version=2,
             file_name="manifest-2.avro",
             file_size=1024,
             num_added_files=0,
             num_deleted_files=1,
-            partition_stats=None,
+            partition_stats=SimpleStats.empty_stats(),
             schema_id=0
         )
-
+        
         self.manifest_file_manager.write(manifest_file_1.file_name, [add_entry])
         self.manifest_file_manager.write(manifest_file_2.file_name, [delete_entry])
+        
+        final_entries = self.manifest_file_manager.read_entries_parallel(
+            [manifest_file_1, manifest_file_2])
+        
+        # With correct identifier matching, ADD and DELETE should cancel out
+        self.assertEqual(
+            len(final_entries), 0,
+            "ADD and DELETE entries with same identifier should both be removed")
 
-        manifest_files = [manifest_file_1, manifest_file_2]
-        final_entries = self.manifest_file_manager.read_entries_parallel(manifest_files)
-
-        self.assertEqual(len(final_entries), 1, "ADD entry should remain after merge")
-        self.assertEqual(final_entries[0].kind, 0, "Remaining entry should be ADD")
-        self.assertEqual(final_entries[0].file.level, 0, "Remaining entry should have level=0")
-
-    def test_entry_identifier_with_different_extra_files(self):
-        partition_fields = []
-        partition = GenericRow([], partition_fields)
-
-        # Create ADD entry with extra_files=["index.idx"]
-        add_file_meta = DataFileMeta(
-            file_name="data-1.parquet",
-            file_size=1024,
-            row_count=100,
-            min_key=BinaryRow([], []),
-            max_key=BinaryRow([], []),
-            key_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            value_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            min_sequence_number=1,
-            max_sequence_number=100,
-            schema_id=0,
-            level=0,
-            extra_files=["index.idx"],  # Has extra file
-            creation_time=1234567890,
-            delete_row_count=0,
-            embedded_index=None,
-            file_source=None,
-            value_stats_cols=None,
-            external_path=None,
-            first_row_id=None,
-            write_cols=None
-        )
-
+    def test_add_delete_different_levels(self):
+        """
+        Test that entries with different levels are NOT matched.
+        
+        Same file_name but different level -> different files -> should NOT cancel out.
+        """
+        partition = GenericRow([], [])
+        
         add_entry = ManifestEntry(
-            kind=0,  # ADD
+            kind=0,
             partition=partition,
             bucket=0,
             total_buckets=1,
-            file=add_file_meta
+            file=self._create_file_meta("data-1.parquet", level=0)
         )
-
-        # Create DELETE entry with no extra_files, same file_name
-        delete_file_meta = DataFileMeta(
-            file_name="data-1.parquet",  # Same file name
-            file_size=1024,
-            row_count=100,
-            min_key=BinaryRow([], []),
-            max_key=BinaryRow([], []),
-            key_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            value_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            min_sequence_number=101,
-            max_sequence_number=200,
-            schema_id=0,
-            level=0,
-            extra_files=None,  # No extra files
-            creation_time=1234567891,
-            delete_row_count=0,
-            embedded_index=None,
-            file_source=None,
-            value_stats_cols=None,
-            external_path=None,
-            first_row_id=None,
-            write_cols=None
-        )
-
+        
         delete_entry = ManifestEntry(
-            kind=1,  # DELETE
+            kind=1,
             partition=partition,
             bucket=0,
             total_buckets=1,
-            file=delete_file_meta
+            file=self._create_file_meta("data-1.parquet", level=1)  # Different level!
         )
-
+        
         manifest_file_1 = ManifestFileMeta(
-            version=2,
             file_name="manifest-1.avro",
             file_size=1024,
             num_added_files=1,
             num_deleted_files=0,
-            partition_stats=None,
+            partition_stats=SimpleStats.empty_stats(),
             schema_id=0
         )
-
+        
         manifest_file_2 = ManifestFileMeta(
-            version=2,
             file_name="manifest-2.avro",
             file_size=1024,
             num_added_files=0,
             num_deleted_files=1,
-            partition_stats=None,
+            partition_stats=SimpleStats.empty_stats(),
             schema_id=0
         )
-
+        
         self.manifest_file_manager.write(manifest_file_1.file_name, [add_entry])
         self.manifest_file_manager.write(manifest_file_2.file_name, [delete_entry])
+        
+        final_entries = self.manifest_file_manager.read_entries_parallel(
+            [manifest_file_1, manifest_file_2])
+        
+        # Different levels -> different identifiers -> should NOT match
+        self.assertEqual(len(final_entries), 1, "Different levels should NOT match")
+        self.assertEqual(final_entries[0].file.level, 0, "ADD entry with level=0 should remain")
 
-        manifest_files = [manifest_file_1, manifest_file_2]
-        final_entries = self.manifest_file_manager.read_entries_parallel(manifest_files)
-
-        # With correct identifier (including extra_files), these should be different entries
-        self.assertEqual(len(final_entries), 1, "ADD entry should remain after merge")
-        self.assertEqual(final_entries[0].kind, 0, "Remaining entry should be ADD")
+    def test_add_delete_different_extra_files(self):
+        """
+        Test that entries with different extra_files are NOT matched.
+        """
+        partition = GenericRow([], [])
+        
+        add_entry = ManifestEntry(
+            kind=0,
+            partition=partition,
+            bucket=0,
+            total_buckets=1,
+            file=self._create_file_meta("data-1.parquet", extra_files=["index.idx"])
+        )
+        
+        delete_entry = ManifestEntry(
+            kind=1,
+            partition=partition,
+            bucket=0,
+            total_buckets=1,
+            file=self._create_file_meta("data-1.parquet", extra_files=[])  # Different!
+        )
+        
+        manifest_file_1 = ManifestFileMeta(
+            file_name="manifest-1.avro",
+            file_size=1024,
+            num_added_files=1,
+            num_deleted_files=0,
+            partition_stats=SimpleStats.empty_stats(),
+            schema_id=0
+        )
+        
+        manifest_file_2 = ManifestFileMeta(
+            file_name="manifest-2.avro",
+            file_size=1024,
+            num_added_files=0,
+            num_deleted_files=1,
+            partition_stats=SimpleStats.empty_stats(),
+            schema_id=0
+        )
+        
+        self.manifest_file_manager.write(manifest_file_1.file_name, [add_entry])
+        self.manifest_file_manager.write(manifest_file_2.file_name, [delete_entry])
+        
+        final_entries = self.manifest_file_manager.read_entries_parallel(
+            [manifest_file_1, manifest_file_2])
+        
+        # Different extra_files -> different identifiers -> should NOT match
+        self.assertEqual(len(final_entries), 1, "Different extra_files should NOT match")
         self.assertEqual(final_entries[0].file.extra_files, ["index.idx"])
-
-    def test_entry_identifier_with_different_external_paths(self):
-        """Test that entries with same partition/bucket/file_name but different external_paths are correctly distinguished."""
-        partition_fields = []
-        partition = GenericRow([], partition_fields)
-
-        # Create ADD entry with external_path
-        add_file_meta = DataFileMeta(
-            file_name="data-1.parquet",
-            file_size=1024,
-            row_count=100,
-            min_key=BinaryRow([], []),
-            max_key=BinaryRow([], []),
-            key_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            value_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            min_sequence_number=1,
-            max_sequence_number=100,
-            schema_id=0,
-            level=0,
-            extra_files=None,
-            creation_time=1234567890,
-            delete_row_count=0,
-            embedded_index=None,
-            file_source=None,
-            value_stats_cols=None,
-            external_path="s3://bucket/path/data-1.parquet",  # Has external path
-            first_row_id=None,
-            write_cols=None
-        )
-
-        add_entry = ManifestEntry(
-            kind=0,  # ADD
-            partition=partition,
-            bucket=0,
-            total_buckets=1,
-            file=add_file_meta
-        )
-
-        # Create DELETE entry with no external_path, same file_name
-        delete_file_meta = DataFileMeta(
-            file_name="data-1.parquet",  # Same file name
-            file_size=1024,
-            row_count=100,
-            min_key=BinaryRow([], []),
-            max_key=BinaryRow([], []),
-            key_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            value_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            min_sequence_number=101,
-            max_sequence_number=200,
-            schema_id=0,
-            level=0,
-            extra_files=None,
-            creation_time=1234567891,
-            delete_row_count=0,
-            embedded_index=None,
-            file_source=None,
-            value_stats_cols=None,
-            external_path=None,  # No external path
-            first_row_id=None,
-            write_cols=None
-        )
-
-        delete_entry = ManifestEntry(
-            kind=1,  # DELETE
-            partition=partition,
-            bucket=0,
-            total_buckets=1,
-            file=delete_file_meta
-        )
-
-        manifest_file_1 = ManifestFileMeta(
-            version=2,
-            file_name="manifest-1.avro",
-            file_size=1024,
-            num_added_files=1,
-            num_deleted_files=0,
-            partition_stats=None,
-            schema_id=0
-        )
-
-        manifest_file_2 = ManifestFileMeta(
-            version=2,
-            file_name="manifest-2.avro",
-            file_size=1024,
-            num_added_files=0,
-            num_deleted_files=1,
-            partition_stats=None,
-            schema_id=0
-        )
-
-        self.manifest_file_manager.write(manifest_file_1.file_name, [add_entry])
-        self.manifest_file_manager.write(manifest_file_2.file_name, [delete_entry])
-
-        manifest_files = [manifest_file_1, manifest_file_2]
-        final_entries = self.manifest_file_manager.read_entries_parallel(manifest_files)
-
-        self.assertEqual(len(final_entries), 1, "ADD entry should remain after merge")
-        self.assertEqual(final_entries[0].kind, 0, "Remaining entry should be ADD")
-        self.assertEqual(final_entries[0].file.external_path, "s3://bucket/path/data-1.parquet")
-
-    def test_entry_identifier_matching_same_file(self):
-        partition_fields = []
-        partition = GenericRow([], partition_fields)
-
-        # Create ADD entry
-        add_file_meta = DataFileMeta(
-            file_name="data-1.parquet",
-            file_size=1024,
-            row_count=100,
-            min_key=BinaryRow([], []),
-            max_key=BinaryRow([], []),
-            key_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            value_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            min_sequence_number=1,
-            max_sequence_number=100,
-            schema_id=0,
-            level=0,
-            extra_files=None,
-            creation_time=1234567890,
-            delete_row_count=0,
-            embedded_index=None,
-            file_source=None,
-            value_stats_cols=None,
-            external_path=None,
-            first_row_id=None,
-            write_cols=None
-        )
-
-        add_entry = ManifestEntry(
-            kind=0,  # ADD
-            partition=partition,
-            bucket=0,
-            total_buckets=1,
-            file=add_file_meta
-        )
-
-        delete_file_meta = DataFileMeta(
-            file_name="data-1.parquet",  # Same file name
-            file_size=1024,
-            row_count=100,
-            min_key=BinaryRow([], []),
-            max_key=BinaryRow([], []),
-            key_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            value_stats=SimpleStats(
-                min_values=BinaryRow([], []),
-                max_values=BinaryRow([], []),
-                null_counts=[]
-            ),
-            min_sequence_number=101,
-            max_sequence_number=200,
-            schema_id=0,
-            level=0,  # Same level
-            extra_files=None,  # Same extra_files
-            creation_time=1234567891,
-            delete_row_count=0,
-            embedded_index=None,  # Same embedded_index
-            file_source=None,
-            value_stats_cols=None,
-            external_path=None,  # Same external_path
-            first_row_id=None,
-            write_cols=None
-        )
-
-        delete_entry = ManifestEntry(
-            kind=1,  # DELETE
-            partition=partition,
-            bucket=0,
-            total_buckets=1,
-            file=delete_file_meta
-        )
-
-        manifest_file_1 = ManifestFileMeta(
-            version=2,
-            file_name="manifest-1.avro",
-            file_size=1024,
-            num_added_files=1,
-            num_deleted_files=0,
-            partition_stats=None,
-            schema_id=0
-        )
-
-        manifest_file_2 = ManifestFileMeta(
-            version=2,
-            file_name="manifest-2.avro",
-            file_size=1024,
-            num_added_files=0,
-            num_deleted_files=1,
-            partition_stats=None,
-            schema_id=0
-        )
-
-        self.manifest_file_manager.write(manifest_file_1.file_name, [add_entry])
-        self.manifest_file_manager.write(manifest_file_2.file_name, [delete_entry])
-
-        manifest_files = [manifest_file_1, manifest_file_2]
-        final_entries = self.manifest_file_manager.read_entries_parallel(manifest_files)
-
-        self.assertEqual(len(final_entries), 0, "Matching ADD and DELETE entries should both be removed")
 
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/paimon-python/pypaimon/tests/manifest/manifest_entry_identifier_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_entry_identifier_test.py
@@ -31,18 +31,6 @@ import pyarrow as pa
 
 
 class ManifestEntryIdentifierTest(unittest.TestCase):
-    """
-    Test for manifest entry identifier matching in merge logic.
-    
-    Bug: Previously, _entry_identifier was incomplete (missing level, extra_files,
-    embedded_index, external_path), causing ADD and DELETE entries to be incorrectly
-    matched. This led to:
-    - ADD entry not being removed when DELETE entry exists
-    - Result: empty reads because the file was actually deleted but ADD entry remained
-    
-    Fix: _entry_identifier now includes all fields needed for accurate matching:
-    (partition, bucket, level, file_name, extra_files, embedded_index, external_path)
-    """
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
### Purpose

Fix pypaimon manifest entry  incomplete identifier issue which causes wrong matching between manifest files with the same name but different level (or other meta data) 
### Linked issue

close #xxx

### Tests

-  `manifest_entry_identifier_test.py` 

### API and Format

### Documentation

N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use a full manifest entry identifier (partition, bucket, level, file name, extra files, embedded index, external path) for matching ADD/DELETE, with tests covering key scenarios.
> 
> - **Manifest**:
>   - Update `ManifestFileManager.read_entries_parallel` to use `_entry_identifier(entry)` comprising `partition.values`, `bucket`, `file.level`, `file.file_name`, `file.extra_files`, `file.embedded_index`, and `file.external_path` for ADD/DELETE matching.
>   - Replace prior partial key with full identifier for both deletion tracking and final filtering.
> - **Tests**:
>   - Add `tests/manifest/manifest_entry_identifier_test.py`:
>     - ADD then DELETE with same identifier cancels out.
>     - Different `level` does not match.
>     - Different `extra_files` does not match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31647d6574253ef896a9729ca541daee81078adc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->