### PR TITLE
[python] update data type of _VALUE_KIND to int8

### DIFF
--- a/paimon-python/pypaimon/tests/reader_primary_key_test.py
+++ b/paimon-python/pypaimon/tests/reader_primary_key_test.py
@@ -68,7 +68,7 @@ class PkReaderTest(unittest.TestCase):
         read_builder = table.new_read_builder()
         actual = self._read_test_table(read_builder).sort_by('user_id')
         self.assertEqual(actual, self.expected)
-        
+
         # Verify _VALUE_KIND field type is int8 in the written parquet file
         table_scan = read_builder.new_scan()
         splits = table_scan.plan().splits()
@@ -87,15 +87,17 @@ class PkReaderTest(unittest.TestCase):
                         field = file_schema.field(i)
                         if field.name == '_VALUE_KIND':
                             value_kind_field_found = True
-                            self.assertEqual(field.type, pa.int8(), 
-                                           f"_VALUE_KIND field type should be int8, got {field.type}")
+                            self.assertEqual(
+                                field.type, pa.int8(),
+                                f"_VALUE_KIND field type should be int8, got {field.type}")
                             break
                     if value_kind_field_found:
                         break
             if value_kind_field_found:
                 break
-        self.assertTrue(value_kind_field_found, 
-                       "_VALUE_KIND field should exist in the written parquet file")
+        self.assertTrue(
+            value_kind_field_found,
+            "_VALUE_KIND field should exist in the written parquet file")
 
     def test_pk_orc_reader(self):
         schema = Schema.from_pyarrow_schema(self.pa_schema,

--- a/paimon-python/pypaimon/write/writer/key_value_data_writer.py
+++ b/paimon-python/pypaimon/write/writer/key_value_data_writer.py
@@ -47,7 +47,7 @@ class KeyValueDataWriter(DataWriter):
         enhanced_table = enhanced_table.add_column(len(self.trimmed_primary_keys), '_SEQUENCE_NUMBER', sequence_column)
 
         # TODO: support real row kind here
-        value_kind_column = pa.array([0] * num_rows, type=pa.int32())
+        value_kind_column = pa.array([0] * num_rows, type=pa.int8())
         enhanced_table = enhanced_table.add_column(len(self.trimmed_primary_keys) + 1, '_VALUE_KIND',
                                                    value_kind_column)
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Changes `_VALUE_KIND` from int32 to int8 in writer and adds a test validating parquet files store `_VALUE_KIND` as int8.
> 
> - **Storage/Writer**:
>   - Update `_VALUE_KIND` column type from `int32` to `int8` in `pypaimon/write/writer/key_value_data_writer.py`.
> - **Tests**:
>   - Extend `pypaimon/tests/reader_primary_key_test.py` to assert parquet files contain `_VALUE_KIND` with Arrow type `int8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 665d5c4fbbd7e6b566b2d87df78adbb15c72563b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->