### PR TITLE
[test] add e2e test case for lance read write with python and java

### DIFF
--- a/paimon-lance/pom.xml
+++ b/paimon-lance/pom.xml
@@ -105,6 +105,42 @@ under the License.
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-format</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs-client</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <!-- If you want to use paimon-lance, you should add following dependencies to your environment. -->

--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
@@ -100,7 +100,13 @@ public class LanceUtils {
 
         Path converted = path;
         Map<String, String> storageOptions = new HashMap<>();
-        if ("oss".equals(schema)) {
+
+        if ("traceable".equals(schema)) {
+            String uriString = uri.toString();
+            if (uriString.startsWith("traceable:/")) {
+                converted = new Path(uriString.replace("traceable:/", "file:/"));
+            }
+        } else if ("oss".equals(schema)) {
             assert originOptions.containsKey("fs.oss.endpoint");
             assert originOptions.containsKey("fs.oss.accessKeyId");
             assert originOptions.containsKey("fs.oss.accessKeySecret");

--- a/paimon-lance/src/test/java/org/apache/paimon/JavaPyLanceE2ETest.java
+++ b/paimon-lance/src/test/java/org/apache/paimon/JavaPyLanceE2ETest.java
@@ -1,0 +1,335 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.DataFormatTestUtil;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.lance.jni.LanceReader;
+import org.apache.paimon.format.lance.jni.LanceWriter;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.sink.InnerTableCommit;
+import org.apache.paimon.table.sink.StreamTableWrite;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.TraceableFileIO;
+
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.apache.paimon.table.SimpleTableTestBase.getResult;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Mixed language e2e test for Java and Python interoperability with Lance format. */
+public class JavaPyLanceE2ETest {
+
+    private static boolean tokioRuntimeInitialized = false;
+    private static final Object TOKIO_INIT_LOCK = new Object();
+
+    static {
+    }
+
+    @BeforeAll
+    public static void initializeTokioRuntime() {
+        synchronized (TOKIO_INIT_LOCK) {
+            if (tokioRuntimeInitialized) {
+                return;
+            }
+            try {
+                // Try to initialize Tokio runtime by creating and reading a minimal Lance file
+                // This is a workaround to ensure Tokio runtime is available before reading
+                // Python-written files
+                java.nio.file.Path tempInitDir =
+                        Files.createTempDirectory("paimon-lance-tokio-init");
+                String testFilePath = tempInitDir.resolve("tokio_init_test.lance").toString();
+
+                // Create a minimal Lance file using Java writer
+                RootAllocator allocator = new RootAllocator();
+                try {
+                    // Create a simple schema
+                    Field intField =
+                            new Field(
+                                    "id", FieldType.nullable(Types.MinorType.INT.getType()), null);
+                    Field strField =
+                            new Field(
+                                    "name",
+                                    FieldType.nullable(Types.MinorType.VARCHAR.getType()),
+                                    null);
+                    org.apache.arrow.vector.types.pojo.Schema schema =
+                            new org.apache.arrow.vector.types.pojo.Schema(
+                                    Arrays.asList(intField, strField));
+
+                    // Create vectors
+                    IntVector intVector = new IntVector("id", allocator);
+                    VarCharVector strVector = new VarCharVector("name", allocator);
+
+                    intVector.allocateNew(1);
+                    strVector.allocateNew(1);
+
+                    intVector.set(0, 1);
+                    strVector.set(0, "test".getBytes());
+
+                    intVector.setValueCount(1);
+                    strVector.setValueCount(1);
+
+                    List<FieldVector> vectors = new ArrayList<>();
+                    vectors.add(intVector);
+                    vectors.add(strVector);
+
+                    VectorSchemaRoot vsr = new VectorSchemaRoot(schema, vectors, 1);
+
+                    // Write using LanceWriter
+                    Map<String, String> storageOptions = new HashMap<>();
+                    LanceWriter writer = new LanceWriter(testFilePath, storageOptions);
+                    try {
+                        writer.writeVsr(vsr);
+                    } finally {
+                        writer.close();
+                        vsr.close();
+                        intVector.close();
+                        strVector.close();
+                    }
+
+                    // Try to read it back - this may initialize Tokio runtime
+                    // Note: This might fail if Tokio is not initialized, but we'll catch and
+                    // ignore
+                    try {
+                        // Use field names matching the written schema ("id" and "name")
+                        org.apache.paimon.types.RowType rowType =
+                                org.apache.paimon.types.RowType.of(
+                                        new org.apache.paimon.types.DataType[] {
+                                            org.apache.paimon.types.DataTypes.INT(),
+                                            org.apache.paimon.types.DataTypes.STRING()
+                                        },
+                                        new String[] {"id", "name"});
+                        LanceReader reader =
+                                new LanceReader(testFilePath, rowType, null, 1024, storageOptions);
+                        try {
+                            // Try to read at least one batch
+                            reader.readBatch();
+                        } finally {
+                            reader.close();
+                        }
+                    } catch (Exception e) {
+                        // Ignore - this is expected if Tokio is not initialized
+                    }
+
+                    // Clean up
+                    Files.deleteIfExists(Paths.get(testFilePath));
+                    Files.deleteIfExists(tempInitDir);
+
+                } finally {
+                    allocator.close();
+                }
+
+                tokioRuntimeInitialized = true;
+            } catch (Exception e) {
+                // Don't fail the test - this is just an attempt to initialize Tokio
+            }
+        }
+    }
+
+    java.nio.file.Path tempDir = Paths.get("../paimon-python/pypaimon/tests/e2e").toAbsolutePath();
+
+    // Fields from TableTestBase that we need
+    protected final String commitUser = UUID.randomUUID().toString();
+    protected Path warehouse;
+    protected Catalog catalog;
+    protected String database;
+
+    @BeforeEach
+    public void before() throws Exception {
+        database = "default";
+
+        // Create warehouse directory if it doesn't exist
+        if (!Files.exists(tempDir.resolve("warehouse"))) {
+            Files.createDirectories(tempDir.resolve("warehouse"));
+        }
+
+        warehouse = new Path(TraceableFileIO.SCHEME + "://" + tempDir.resolve("warehouse"));
+        Options options = new Options();
+        options.set("warehouse", warehouse.toUri().toString());
+        // Use preferIO to avoid FileIO loader conflicts (OSS vs Jindo)
+        CatalogContext context = CatalogContext.create(options, new TraceableFileIO.Loader(), null);
+        catalog = CatalogFactory.createCatalog(context);
+
+        // Create database if it doesn't exist
+        try {
+            catalog.createDatabase(database, false);
+        } catch (Catalog.DatabaseAlreadyExistException e) {
+            // Database already exists, ignore
+        }
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
+    public void testJavaWriteReadPkTableLance() throws Exception {
+        Identifier identifier = identifier("mixed_test_pk_tablej_lance");
+        Schema schema =
+                Schema.newBuilder()
+                        .column("id", DataTypes.INT())
+                        .column("name", DataTypes.STRING())
+                        .column("category", DataTypes.STRING())
+                        .column("value", DataTypes.DOUBLE())
+                        .primaryKey("id")
+                        .partitionKeys("category")
+                        .option("dynamic-partition-overwrite", "false")
+                        .option("bucket", "2")
+                        .option("file.format", "lance")
+                        .build();
+
+        catalog.createTable(identifier, schema, true);
+        Table table = catalog.getTable(identifier);
+        FileStoreTable fileStoreTable = (FileStoreTable) table;
+
+        try (StreamTableWrite write = fileStoreTable.newWrite(commitUser);
+                InnerTableCommit commit = fileStoreTable.newCommit(commitUser)) {
+
+            write.write(createRow(1, "Apple", "Fruit", 1.5));
+            write.write(createRow(2, "Banana", "Fruit", 0.8));
+            write.write(createRow(3, "Carrot", "Vegetable", 0.6));
+            write.write(createRow(4, "Broccoli", "Vegetable", 1.2));
+            write.write(createRow(5, "Chicken", "Meat", 5.0));
+            write.write(createRow(6, "Beef", "Meat", 8.0));
+
+            commit.commit(0, write.prepareCommit(true, 0));
+        }
+
+        List<Split> splits =
+                new ArrayList<>(fileStoreTable.newSnapshotReader().read().dataSplits());
+        TableRead read = fileStoreTable.newRead();
+        List<String> res =
+                getResult(
+                        read,
+                        splits,
+                        row -> DataFormatTestUtil.toStringNoRowKind(row, table.rowType()));
+        assertThat(res)
+                .containsExactlyInAnyOrder(
+                        "1, Apple, Fruit, 1.5",
+                        "2, Banana, Fruit, 0.8",
+                        "3, Carrot, Vegetable, 0.6",
+                        "4, Broccoli, Vegetable, 1.2",
+                        "5, Chicken, Meat, 5.0",
+                        "6, Beef, Meat, 8.0");
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
+    public void testReadPkTableLance() throws Exception {
+        try {
+            // Known issue: Reading Python-written Lance files in Java causes JVM crash due to
+            // missing Tokio runtime. The error is:
+            // "there is no reactor running, must be called from the context of a Tokio 1.x runtime"
+            //
+            // This is a limitation of lance-core Java bindings. The Rust native library requires
+            // Tokio runtime for certain operations when reading files written by Python (which may
+            // use different encoding formats). Java-written files can be read successfully because
+            // they use synchronous APIs that don't require Tokio.
+            //
+            // Workaround: Try to "warm up" Tokio runtime by reading a Java-written file first.
+            // This may initialize the Tokio runtime if it's created on first use.
+            try {
+                Identifier warmupIdentifier = identifier("mixed_test_pk_tablej_lance");
+                try {
+                    Table warmupTable = catalog.getTable(warmupIdentifier);
+                    FileStoreTable warmupFileStoreTable = (FileStoreTable) warmupTable;
+                    List<Split> warmupSplits =
+                            new ArrayList<>(
+                                    warmupFileStoreTable.newSnapshotReader().read().dataSplits());
+                    if (!warmupSplits.isEmpty()) {
+                        TableRead warmupRead = warmupFileStoreTable.newRead();
+                        // Try to read at least one batch to initialize Tokio runtime
+                        getResult(
+                                warmupRead,
+                                warmupSplits.subList(0, Math.min(1, warmupSplits.size())),
+                                row ->
+                                        DataFormatTestUtil.toStringNoRowKind(
+                                                row, warmupTable.rowType()));
+                    }
+                } catch (Catalog.TableNotExistException e) {
+                    // Table doesn't exist, skip warm-up
+                }
+            } catch (Exception e) {
+                // Ignore warm-up errors, continue with the actual test
+            }
+
+            Identifier identifier = identifier("mixed_test_pk_tablep_lance");
+            Table table = catalog.getTable(identifier);
+            FileStoreTable fileStoreTable = (FileStoreTable) table;
+            List<Split> splits =
+                    new ArrayList<>(fileStoreTable.newSnapshotReader().read().dataSplits());
+            TableRead read = fileStoreTable.newRead();
+            List<String> res =
+                    getResult(
+                            read,
+                            splits,
+                            row -> DataFormatTestUtil.toStringNoRowKind(row, table.rowType()));
+            System.out.println("Format: lance, Result: " + res);
+            assertThat(res)
+                    .containsExactlyInAnyOrder(
+                            "1, Apple, Fruit, 1.5",
+                            "2, Banana, Fruit, 0.8",
+                            "3, Carrot, Vegetable, 0.6",
+                            "4, Broccoli, Vegetable, 1.2",
+                            "5, Chicken, Meat, 5.0",
+                            "6, Beef, Meat, 8.0");
+        } catch (Throwable t) {
+            throw t;
+        }
+    }
+
+    // Helper method from TableTestBase
+    protected Identifier identifier(String tableName) {
+        return new Identifier(database, tableName);
+    }
+
+    private static InternalRow createRow(int id, String name, String category, double value) {
+        return GenericRow.of(
+                id, BinaryString.fromString(name), BinaryString.fromString(category), value);
+    }
+}

--- a/paimon-python/dev/run_mixed_tests.sh
+++ b/paimon-python/dev/run_mixed_tests.sh
@@ -60,14 +60,35 @@ cleanup_warehouse() {
 
 # Function to run Java test
 run_java_write_test() {
-    echo -e "${YELLOW}=== Step 1: Running Java Test (JavaPyE2ETest.testJavaWriteRead) ===${NC}"
+    echo -e "${YELLOW}=== Step 1: Running Java Write Tests (Parquet + Lance) ===${NC}"
 
     cd "$PROJECT_ROOT"
 
-    # Run the specific Java test method
-    echo "Running Maven test for JavaPyE2ETest.testJavaWriteRead..."
-    if mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testJavaWriteRead -pl paimon-core -q -Drun.e2e.tests=true; then
-        echo -e "${GREEN}✓ Java test completed successfully${NC}"
+    # Run the Java test method for parquet format
+    echo "Running Maven test for JavaPyE2ETest.testJavaWriteReadPkTable (Parquet)..."
+    echo "Note: Maven may download dependencies on first run, this may take a while..."
+    local parquet_result=0
+    if mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testJavaWriteReadPkTable -pl paimon-core -Drun.e2e.tests=true; then
+        echo -e "${GREEN}✓ Java write parquet test completed successfully${NC}"
+    else
+        echo -e "${RED}✗ Java write parquet test failed${NC}"
+        parquet_result=1
+    fi
+
+    echo ""
+
+    # Run the Java test method for lance format
+    echo "Running Maven test for JavaPyLanceE2ETest.testJavaWriteReadPkTableLance (Lance)..."
+    echo "Note: Maven may download dependencies on first run, this may take a while..."
+    local lance_result=0
+    if mvn test -Dtest=org.apache.paimon.JavaPyLanceE2ETest#testJavaWriteReadPkTableLance -pl paimon-lance -Drun.e2e.tests=true; then
+        echo -e "${GREEN}✓ Java write lance test completed successfully${NC}"
+    else
+        echo -e "${RED}✗ Java write lance test failed${NC}"
+        lance_result=1
+    fi
+
+    if [[ $parquet_result -eq 0 && $lance_result -eq 0 ]]; then
         return 0
     else
         echo -e "${RED}✗ Java test failed${NC}"
@@ -77,13 +98,13 @@ run_java_write_test() {
 
 # Function to run Python test
 run_python_read_test() {
-    echo -e "${YELLOW}=== Step 2: Running Python Test (JavaPyReadWriteTest.testRead) ===${NC}"
+    echo -e "${YELLOW}=== Step 2: Running Python Test (JavaPyReadWriteTest.test_read_pk_table) ===${NC}"
 
     cd "$PAIMON_PYTHON_DIR"
 
-    # Run the specific Python test method
-    echo "Running Python test for JavaPyReadWriteTest.testRead..."
-    if python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest::test_read -v; then
+    # Run the parameterized Python test method (runs for both parquet and lance)
+    echo "Running Python test for JavaPyReadWriteTest.test_read_pk_table..."
+    if python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest -k "test_read_pk_table" -v; then
         echo -e "${GREEN}✓ Python test completed successfully${NC}"
 #        source deactivate
         return 0
@@ -96,13 +117,13 @@ run_python_read_test() {
 
 # Function to run Python Write test for Python-Write-Java-Read scenario
 run_python_write_test() {
-    echo -e "${YELLOW}=== Step 3: Running Python Write Test (JavaPyReadWriteTest.test_py_write_read) ===${NC}"
+    echo -e "${YELLOW}=== Step 3: Running Python Write Test (JavaPyReadWriteTest.test_py_write_read_pk_table) ===${NC}"
 
     cd "$PAIMON_PYTHON_DIR"
 
-    # Run the specific Python test method for writing data
-    echo "Running Python test for JavaPyReadWriteTest.test_py_write_read (Python Write)..."
-    if python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest::test_py_write_read -v; then
+    # Run the parameterized Python test method for writing data (runs for both parquet and lance)
+    echo "Running Python test for JavaPyReadWriteTest.test_py_write_read_pk_table (Python Write)..."
+    if python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest -k "test_py_write_read_pk_table" -v; then
         echo -e "${GREEN}✓ Python write test completed successfully${NC}"
         return 0
     else
@@ -113,17 +134,37 @@ run_python_write_test() {
 
 # Function to run Java Read test for Python-Write-Java-Read scenario
 run_java_read_test() {
-    echo -e "${YELLOW}=== Step 4: Running Java Read Test (JavaPyE2ETest.testRead) ===${NC}"
+    echo -e "${YELLOW}=== Step 4: Running Java Read Test (JavaPyE2ETest.testReadPkTable for parquet, JavaPyLanceE2ETest.testReadPkTableLance for lance) ===${NC}"
 
     cd "$PROJECT_ROOT"
 
-    # Run the specific Java test method for reading Python-written data
-    echo "Running Maven test for JavaPyE2ETest.testRead (Java Read)..."
-    if mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testRead -pl paimon-core -q -Drun.e2e.tests=true; then
-        echo -e "${GREEN}✓ Java read test completed successfully${NC}"
+    # Run Java test for parquet format in paimon-core
+    echo "Running Maven test for JavaPyE2ETest.testReadPkTable (Java Read Parquet)..."
+    echo "Note: Maven may download dependencies on first run, this may take a while..."
+    local parquet_result=0
+    if mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testReadPkTable -pl paimon-core -Drun.e2e.tests=true; then
+        echo -e "${GREEN}✓ Java read parquet test completed successfully${NC}"
+    else
+        echo -e "${RED}✗ Java read parquet test failed${NC}"
+        parquet_result=1
+    fi
+
+    echo ""
+
+    # Run Java test for lance format in paimon-lance
+    echo "Running Maven test for JavaPyLanceE2ETest.testReadPkTableLance (Java Read Lance)..."
+    echo "Note: Maven may download dependencies on first run, this may take a while..."
+    local lance_result=0
+    if mvn test -Dtest=org.apache.paimon.JavaPyLanceE2ETest#testReadPkTableLance -pl paimon-lance -Drun.e2e.tests=true; then
+        echo -e "${GREEN}✓ Java read lance test completed successfully${NC}"
+    else
+        echo -e "${RED}✗ Java read lance test failed${NC}"
+        lance_result=1
+    fi
+
+    if [[ $parquet_result -eq 0 && $lance_result -eq 0 ]]; then
         return 0
     else
-        echo -e "${RED}✗ Java read test failed${NC}"
         return 1
     fi
 }
@@ -167,7 +208,7 @@ main() {
         echo ""
     fi
 
-    # Run Java read test
+    # Run Java read test (handles both parquet and lance)
     if ! run_java_read_test; then
         java_read_result=1
     fi
@@ -176,27 +217,27 @@ main() {
     echo -e "${YELLOW}=== Test Results Summary ===${NC}"
 
     if [[ $java_write_result -eq 0 ]]; then
-        echo -e "${GREEN}✓ Java Write Test (JavaPyE2ETest.testJavaWriteRead): PASSED${NC}"
+        echo -e "${GREEN}✓ Java Write Test (Parquet + Lance): PASSED${NC}"
     else
-        echo -e "${RED}✗ Java Write Test (JavaPyE2ETest.testJavaWriteRead): FAILED${NC}"
+        echo -e "${RED}✗ Java Write Test (Parquet + Lance): FAILED${NC}"
     fi
 
     if [[ $python_read_result -eq 0 ]]; then
-        echo -e "${GREEN}✓ Python Read Test (JavaPyReadWriteTest.testRead): PASSED${NC}"
+        echo -e "${GREEN}✓ Python Read Test (JavaPyReadWriteTest.test_read_pk_table): PASSED${NC}"
     else
-        echo -e "${RED}✗ Python Read Test (JavaPyReadWriteTest.testRead): FAILED${NC}"
+        echo -e "${RED}✗ Python Read Test (JavaPyReadWriteTest.test_read_pk_table): FAILED${NC}"
     fi
 
     if [[ $python_write_result -eq 0 ]]; then
-        echo -e "${GREEN}✓ Python Write Test (JavaPyReadWriteTest.test_py_write_read): PASSED${NC}"
+        echo -e "${GREEN}✓ Python Write Test (JavaPyReadWriteTest.test_py_write_read_pk_table): PASSED${NC}"
     else
-        echo -e "${RED}✗ Python Write Test (JavaPyReadWriteTest.test_py_write_read): FAILED${NC}"
+        echo -e "${RED}✗ Python Write Test (JavaPyReadWriteTest.test_py_write_read_pk_table): FAILED${NC}"
     fi
 
     if [[ $java_read_result -eq 0 ]]; then
-        echo -e "${GREEN}✓ Java Read Test (JavaPyE2ETest.testRead): PASSED${NC}"
+        echo -e "${GREEN}✓ Java Read Test (Parquet + Lance): PASSED${NC}"
     else
-        echo -e "${RED}✗ Java Read Test (JavaPyE2ETest.testRead): FAILED${NC}"
+        echo -e "${RED}✗ Java Read Test (Parquet + Lance): FAILED${NC}"
     fi
 
     echo ""


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds cross-language E2E tests for append and primary-key tables using Parquet and Lance, implements traceable:// path handling in Lance, and updates test dependencies and runner.
> 
> - **Lance**:
>   - **Utils**: `LanceUtils.toLanceSpecified` supports `traceable://` by converting to `file:/`.
>   - **Tests**: Add `JavaPyLanceE2ETest` covering Lance write/read for PK tables with Tokio runtime warm-up.
>   - **Build (test deps)**: Add `paimon-core` (test-jar), `paimon-format`, and `hadoop-hdfs-client` (with exclusions) to `paimon-lance/pom.xml`.
> - **Core Tests**:
>   - Rename/adjust append-table tests: `testJavaWriteReadAppendTable`, `testReadAppendTable` (use `mixed_test_append_*`).
>   - Add PK-table tests: `testJavaWriteReadPkTable`, `testReadPkTable` (Parquet).
> - **Python**:
>   - E2E tests parameterized for `parquet` and `lance`: `test_py_write_read_pk_table`, `test_read_pk_table`; rename append-table tests and compare results order-insensitively.
>   - Script `dev/run_mixed_tests.sh` runs Java (Parquet + Lance) and Python tests, and Java reads for Python-written data; updates output and flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bec522cce11f20321c7ccaa4e30949a3c56749c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->