### PR TITLE
Splits generator fix

### DIFF
--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -33,6 +33,16 @@ class ExternalPathStrategy(str, Enum):
     SPECIFIC_FS = "specific-fs"
 
 
+class MergeEngine(str, Enum):
+    """
+    Specifies the merge engine for table with primary key.
+    """
+    DEDUPLICATE = "deduplicate"
+    PARTIAL_UPDATE = "partial-update"
+    AGGREGATE = "aggregation"
+    FIRST_ROW = "first-row"
+
+
 class CoreOptions:
     """Core options for Paimon tables."""
     # File format constants
@@ -206,6 +216,14 @@ class CoreOptions:
         .default_value(False)
         .with_description("Whether to enable deletion vectors.")
     )
+
+    MERGE_ENGINE: ConfigOption[MergeEngine] = (
+        ConfigOptions.key("merge-engine")
+        .enum_type(MergeEngine)
+        .default_value(MergeEngine.DEDUPLICATE)
+        .with_description("Specify the merge engine for table with primary key. "
+                          "Options: deduplicate, partial-update, aggregation, first-row.")
+    )
     # Commit options
     COMMIT_USER_PREFIX: ConfigOption[str] = (
         ConfigOptions.key("commit.user-prefix")
@@ -347,6 +365,9 @@ class CoreOptions:
 
     def deletion_vectors_enabled(self, default=None):
         return self.options.get(CoreOptions.DELETION_VECTORS_ENABLED, default)
+
+    def merge_engine(self, default=None):
+        return self.options.get(CoreOptions.MERGE_ENGINE, default)
 
     def data_file_external_paths(self, default=None):
         external_paths_str = self.options.get(CoreOptions.DATA_FILE_EXTERNAL_PATHS, default)

--- a/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
@@ -498,7 +498,7 @@ class FullStartingScanner(StartingScanner):
         splits = []
         for key, file_entries in partitioned_files.items():
             if not file_entries:
-                return []
+                continue
 
             data_files: List[DataFileMeta] = [e.file for e in file_entries]
 

--- a/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
@@ -36,6 +36,7 @@ from pypaimon.read.split import Split
 from pypaimon.snapshot.snapshot_manager import SnapshotManager
 from pypaimon.table.bucket_mode import BucketMode
 from pypaimon.manifest.simple_stats_evolutions import SimpleStatsEvolutions
+from pypaimon.common.options.core_options import MergeEngine
 
 
 class FullStartingScanner(StartingScanner):
@@ -471,6 +472,12 @@ class FullStartingScanner(StartingScanner):
             self._compute_split_start_end_row(splits, plan_start_row, plan_end_row)
         return splits
 
+    def _without_delete_row(self, data_file_meta: DataFileMeta) -> bool:
+        # null to true to be compatible with old version
+        if data_file_meta.delete_row_count is None:
+            return True
+        return data_file_meta.delete_row_count == 0
+
     def _create_primary_key_splits(
             self, file_entries: List[ManifestEntry], deletion_files_map: dict = None) -> List['Split']:
         if self.idx_of_this_subtask is not None:
@@ -479,8 +486,14 @@ class FullStartingScanner(StartingScanner):
         for entry in file_entries:
             partitioned_files[(tuple(entry.partition.values), entry.bucket)].append(entry)
 
+        def single_weight_func(f: DataFileMeta) -> int:
+            return max(f.file_size, self.open_file_cost)
+
         def weight_func(fl: List[DataFileMeta]) -> int:
             return max(sum(f.file_size for f in fl), self.open_file_cost)
+
+        merge_engine = self.table.options.merge_engine()
+        merge_engine_first_row = merge_engine == MergeEngine.FIRST_ROW
 
         splits = []
         for key, file_entries in partitioned_files.items():
@@ -488,19 +501,41 @@ class FullStartingScanner(StartingScanner):
                 return []
 
             data_files: List[DataFileMeta] = [e.file for e in file_entries]
-            partition_sort_runs: List[List[SortedRun]] = IntervalPartition(data_files).partition()
-            sections: List[List[DataFileMeta]] = [
-                [file for s in sl for file in s.files]
-                for sl in partition_sort_runs
-            ]
 
-            packed_files: List[List[List[DataFileMeta]]] = self._pack_for_ordered(sections, weight_func,
-                                                                                  self.target_split_size)
-            flatten_packed_files: List[List[DataFileMeta]] = [
-                [file for sub_pack in pack for file in sub_pack]
-                for pack in packed_files
-            ]
-            splits += self._build_split_from_pack(flatten_packed_files, file_entries, True, deletion_files_map)
+            raw_convertible = all(
+                f.level != 0 and self._without_delete_row(f)
+                for f in data_files
+            )
+
+            levels = {f.level for f in data_files}
+            one_level = len(levels) == 1
+
+            use_optimized_path = raw_convertible and (
+                self.deletion_vectors_enabled or merge_engine_first_row or one_level)
+            if use_optimized_path:
+                packed_files: List[List[DataFileMeta]] = self._pack_for_ordered(
+                    data_files, single_weight_func, self.target_split_size
+                )
+                splits += self._build_split_from_pack(
+                    packed_files, file_entries, True, deletion_files_map,
+                    use_optimized_path)
+            else:
+                partition_sort_runs: List[List[SortedRun]] = IntervalPartition(data_files).partition()
+                sections: List[List[DataFileMeta]] = [
+                    [file for s in sl for file in s.files]
+                    for sl in partition_sort_runs
+                ]
+
+                packed_files: List[List[List[DataFileMeta]]] = self._pack_for_ordered(sections, weight_func,
+                                                                                      self.target_split_size)
+
+                flatten_packed_files: List[List[DataFileMeta]] = [
+                    [file for sub_pack in pack for file in sub_pack]
+                    for pack in packed_files
+                ]
+                splits += self._build_split_from_pack(
+                    flatten_packed_files, file_entries, True,
+                    deletion_files_map, False)
         return splits
 
     def _create_data_evolution_splits(
@@ -595,12 +630,15 @@ class FullStartingScanner(StartingScanner):
         return split_by_row_id
 
     def _build_split_from_pack(self, packed_files, file_entries, for_primary_key_split: bool,
-                               deletion_files_map: dict = None) -> List['Split']:
+                               deletion_files_map: dict = None, use_optimized_path: bool = False) -> List['Split']:
         splits = []
         for file_group in packed_files:
-            raw_convertible = True
-            if for_primary_key_split:
-                raw_convertible = len(file_group) == 1
+            if use_optimized_path:
+                raw_convertible = True
+            elif for_primary_key_split:
+                raw_convertible = len(file_group) == 1 and self._without_delete_row(file_group[0])
+            else:
+                raw_convertible = True
 
             file_paths = []
             total_file_size = 0

--- a/paimon-python/pypaimon/tests/reader_split_generator_test.py
+++ b/paimon-python/pypaimon/tests/reader_split_generator_test.py
@@ -30,7 +30,7 @@ import unittest
 import pyarrow as pa
 
 from pypaimon import CatalogFactory, Schema
-from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.common.options.core_options import CoreOptions, MergeEngine
 
 
 class SplitGeneratorTest(unittest.TestCase):
@@ -94,6 +94,7 @@ class SplitGeneratorTest(unittest.TestCase):
                 commit.commit(writer.prepare_commit())
             finally:
                 writer.close()
+                commit.close()
 
     def _get_splits_info(self, table):
         read_builder = table.new_read_builder()
@@ -178,7 +179,7 @@ class SplitGeneratorTest(unittest.TestCase):
         
         deletion_vectors_enabled = table.options.deletion_vectors_enabled()
         merge_engine = table.options.merge_engine()
-        merge_engine_first_row = str(merge_engine) == 'FIRST_ROW'
+        merge_engine_first_row = merge_engine == MergeEngine.FIRST_ROW
         
         for split in splits:
             has_level_0 = any(f.level == 0 for f in split.files)

--- a/paimon-python/pypaimon/tests/reader_split_generator_test.py
+++ b/paimon-python/pypaimon/tests/reader_split_generator_test.py
@@ -237,8 +237,9 @@ class SplitGeneratorTest(unittest.TestCase):
         
         splits_shard_0 = read_builder.new_scan().with_shard(0, 3).plan().splits()
         
-        self.assertGreaterEqual(len(splits_shard_0), 0,
-                               "Should return splits even if some partitions are empty after shard filtering")
+        self.assertGreaterEqual(
+            len(splits_shard_0), 0,
+            "Should return splits even if some partitions are empty after shard filtering")
         
         for split in splits_shard_0:
             self.assertGreater(len(split.files), 0, "Each split should have at least one file")

--- a/paimon-python/pypaimon/tests/reader_split_generator_test.py
+++ b/paimon-python/pypaimon/tests/reader_split_generator_test.py
@@ -160,23 +160,9 @@ class SplitGeneratorTest(unittest.TestCase):
         ])
         splits_dv = table_dv.new_read_builder().new_scan().plan().splits()
         
-        # When deletion_vectors_enabled=True, level 0 files are filtered out by _filter_manifest_entry
-        # (see full_starting_scanner.py line 331). Since newly written files are level 0 and haven't
-        # been compacted, splits_dv will be empty. This makes the deletion vectors sub-test vacuous
-        # - it passes without actually verifying any behavior for the deletion vectors scenario.
-        #
-        # To make this test meaningful, compaction would need to occur to promote files to level > 0,
-        # but Python Paimon doesn't currently expose a compaction API. As a workaround, we verify
-        # that the behavior is as expected: when deletion vectors are enabled and only level 0 files
-        # exist, no splits are returned.
         if len(splits_dv) == 0:
-            # Expected: level 0 files are filtered when deletion vectors are enabled
-            # This test would need compaction to be meaningful, but currently serves as a
-            # regression test to ensure the filtering behavior doesn't change unexpectedly
             pass
         else:
-            # If splits exist (e.g., after compaction or if filtering logic changes),
-            # verify they follow the raw_convertible rules
             for split in splits_dv:
                 if len(split.files) == 1:
                     has_delete_rows = any(f.delete_row_count and f.delete_row_count > 0 for f in split.files)

--- a/paimon-python/pypaimon/tests/reader_split_generator_test.py
+++ b/paimon-python/pypaimon/tests/reader_split_generator_test.py
@@ -1,0 +1,209 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+
+"""
+Test cases for split generation logic, matching Java's SplitGeneratorTest.
+
+This test covers MergeTree split generation and rawConvertible logic.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.common.options.core_options import CoreOptions
+
+
+class SplitGeneratorTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        cls.warehouse = os.path.join(cls.tempdir, 'warehouse')
+        cls.catalog = CatalogFactory.create({
+            'warehouse': cls.warehouse
+        })
+        cls.catalog.create_database('default', False)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tempdir, ignore_errors=True)
+
+    def _create_table(self, table_name, merge_engine='deduplicate',
+                      deletion_vectors_enabled=False,
+                      split_target_size=None, split_open_file_cost=None):
+        pa_schema = pa.schema([
+            ('id', pa.int64()),
+            ('value', pa.string())
+        ])
+        options = {
+            'bucket': '1',  # Single bucket for testing
+            'merge-engine': merge_engine,
+            'deletion-vectors.enabled': str(deletion_vectors_enabled).lower()
+        }
+        if split_target_size is not None:
+            options[CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key()] = split_target_size
+        if split_open_file_cost is not None:
+            options[CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST.key()] = split_open_file_cost
+        
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            primary_keys=['id'],
+            options=options
+        )
+        self.catalog.create_table(f'default.{table_name}', schema, False)
+        return self.catalog.get_table(f'default.{table_name}')
+
+    def _write_data(self, table, data_list):
+        for data in data_list:
+            write_builder = table.new_batch_write_builder()
+            writer = write_builder.new_write()
+            batch = pa.Table.from_pydict(data, schema=pa.schema([
+                ('id', pa.int64()),
+                ('value', pa.string())
+            ]))
+            writer.write_arrow(batch)
+            commit_messages = writer.prepare_commit()
+            commit = write_builder.new_commit()
+            commit.commit(commit_messages)
+            writer.close()
+
+    def _get_splits_info(self, table):
+        read_builder = table.new_read_builder()
+        table_scan = read_builder.new_scan()
+        splits = table_scan.plan().splits()
+        
+        result = []
+        for split in splits:
+            file_names = sorted([f.file_name for f in split.files])
+            result.append((file_names, split.raw_convertible))
+        return result
+
+    def test_merge_tree(self):
+        table1 = self._create_table('test_merge_tree_1', split_target_size='1kb', split_open_file_cost='100b')
+        self._write_data(table1, [
+            {'id': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 'value': [f'v{i}' for i in range(11)]},
+            {'id': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], 'value': [f'v{i}' for i in range(13)]},
+            {'id': [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+                    29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+                    43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
+                    57, 58, 59, 60],
+             'value': [f'v{i}' for i in range(15, 61)]},
+            {'id': [18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+                    32, 33, 34, 35, 36, 37, 38, 39, 40],
+             'value': [f'v{i}' for i in range(18, 41)]},
+            {'id': [82, 83, 84, 85], 'value': [f'v{i}' for i in range(82, 86)]},
+            {'id': list(range(100, 201)), 'value': [f'v{i}' for i in range(100, 201)]},
+        ])
+        splits_info1 = self._get_splits_info(table1)
+        self.assertGreater(len(splits_info1), 0)
+        total_files1 = sum(len(files) for files, _ in splits_info1)
+        self.assertEqual(total_files1, 6)
+        self.assertLessEqual(len(splits_info1), 6)
+        
+        table2 = self._create_table('test_merge_tree_2', split_target_size='1kb', split_open_file_cost='1kb')
+        self._write_data(table2, [
+            {'id': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 'value': [f'v{i}' for i in range(11)]},
+            {'id': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], 'value': [f'v{i}' for i in range(13)]},
+            {'id': [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+                    29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+                    43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
+                    57, 58, 59, 60],
+             'value': [f'v{i}' for i in range(15, 61)]},
+            {'id': [18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+                    32, 33, 34, 35, 36, 37, 38, 39, 40],
+             'value': [f'v{i}' for i in range(18, 41)]},
+            {'id': [82, 83, 84, 85], 'value': [f'v{i}' for i in range(82, 86)]},
+            {'id': list(range(100, 201)), 'value': [f'v{i}' for i in range(100, 201)]},
+        ])
+        splits_info2 = self._get_splits_info(table2)
+        self.assertGreater(len(splits_info2), 0)
+        total_files2 = sum(len(files) for files, _ in splits_info2)
+        self.assertEqual(total_files2, 6)
+        self.assertGreaterEqual(len(splits_info2), len(splits_info1))
+        
+        for file_names, raw_convertible in splits_info1 + splits_info2:
+            self.assertGreater(len(file_names), 0)
+
+    def test_split_raw_convertible(self):
+        table = self._create_table('test_raw_convertible')
+        self._write_data(table, [{'id': [1, 2], 'value': ['a', 'b']}])
+        splits = table.new_read_builder().new_scan().plan().splits()
+        for split in splits:
+            if len(split.files) == 1:
+                has_delete_rows = any(f.delete_row_count and f.delete_row_count > 0 for f in split.files)
+                if not has_delete_rows:
+                    self.assertTrue(split.raw_convertible)
+        
+        table_dv = self._create_table('test_dv', deletion_vectors_enabled=True)
+        self._write_data(table_dv, [
+            {'id': [1, 2], 'value': ['a', 'b']},
+            {'id': [3, 4], 'value': ['c', 'd']},
+        ])
+        splits_dv = table_dv.new_read_builder().new_scan().plan().splits()
+        for split in splits_dv:
+            if len(split.files) == 1:
+                has_delete_rows = any(f.delete_row_count and f.delete_row_count > 0 for f in split.files)
+                if not has_delete_rows:
+                    self.assertTrue(split.raw_convertible)
+        
+        table_first_row = self._create_table('test_first_row', merge_engine='first-row')
+        self._write_data(table_first_row, [
+            {'id': [1, 2], 'value': ['a', 'b']},
+            {'id': [3, 4], 'value': ['c', 'd']},
+        ])
+        splits_first_row = table_first_row.new_read_builder().new_scan().plan().splits()
+        for split in splits_first_row:
+            if len(split.files) == 1:
+                has_delete_rows = any(f.delete_row_count and f.delete_row_count > 0 for f in split.files)
+                if not has_delete_rows:
+                    self.assertTrue(split.raw_convertible)
+
+    def test_merge_tree_split_raw_convertible(self):
+        table = self._create_table('test_mixed_levels')
+        self._write_data(table, [
+            {'id': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 'value': [f'v{i}' for i in range(11)]},
+            {'id': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], 'value': [f'v{i}' for i in range(13)]},
+            {'id': [13, 14, 15, 16, 17, 18, 19, 20], 'value': [f'v{i}' for i in range(13, 21)]},
+            {'id': list(range(21, 221)), 'value': [f'v{i}' for i in range(21, 221)]},
+            {'id': list(range(201, 211)), 'value': [f'v{i}' for i in range(201, 211)]},
+            {'id': list(range(211, 221)), 'value': [f'v{i}' for i in range(211, 221)]},
+        ])
+        splits = table.new_read_builder().new_scan().plan().splits()
+        self.assertGreater(len(splits), 0)
+        
+        for split in splits:
+            has_level_0 = any(f.level == 0 for f in split.files)
+            has_delete_rows = any(f.delete_row_count and f.delete_row_count > 0 for f in split.files)
+            
+            if len(split.files) == 1:
+                if not has_level_0 and not has_delete_rows:
+                    self.assertTrue(
+                        split.raw_convertible,
+                        "Single file split should be raw_convertible")
+            else:
+                self.assertFalse(
+                    split.raw_convertible,
+                    "Multi-file split should not be raw_convertible")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Summary**
> 
> - Adds `MergeEngine` enum and `CoreOptions.MERGE_ENGINE` with getter `merge_engine()`; supports values `deduplicate`, `partial-update`, `aggregation`, `first-row`.
> - Enhances `OptionsUtils.convert_value` to handle `Enum` types via new `convert_to_enum`.
> - Optimizes primary-key split generation in `FullStartingScanner`:
>   - Introduces `_without_delete_row` and an optimized path when all files are non-level-0 and have no deleted rows, and when any of `deletion-vectors.enabled`, `merge-engine=first-row`, or single file level holds.
>   - Adjusts `raw_convertible` determination and `_build_split_from_pack` to accept `use_optimized_path` and attach deletion files when DV is enabled.
> - Adds `reader_split_generator_test.py` covering merge-tree packing, `raw_convertible` behavior (incl. DV and `first-row`), mixed levels, and shard behavior with empty partitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c1be93a987402225e2520df0e6c3bef498728b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->