### PR TITLE
[python] optimize io retry

### DIFF
--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -69,14 +69,23 @@ class FileIO:
             request_timeout: int = 60,
             connect_timeout: int = 60
     ) -> Dict[str, Any]:
-        from pyarrow.fs import AwsStandardS3RetryStrategy
-
-        retry_strategy = AwsStandardS3RetryStrategy(max_attempts=max_attempts)
-        return {
-            'retry_strategy': retry_strategy,
+        """
+        AwsStandardS3RetryStrategy is only available in PyArrow >= 8.0.0.
+        """
+        config = {
             'request_timeout': request_timeout,
             'connect_timeout': connect_timeout
         }
+
+        if parse(pyarrow.__version__) >= parse("8.0.0"):
+            try:
+                from pyarrow.fs import AwsStandardS3RetryStrategy
+                retry_strategy = AwsStandardS3RetryStrategy(max_attempts=max_attempts)
+                config['retry_strategy'] = retry_strategy
+            except ImportError:
+                pass
+
+        return config
 
     def _extract_oss_bucket(self, location) -> str:
         uri = urlparse(location)

--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -64,7 +64,11 @@ class FileIO:
             return uri.scheme, uri.netloc, f"{uri.netloc}{uri.path}"
 
     @staticmethod
-    def _create_s3_retry_config(max_attempts: int = 10, request_timeout: int = 60, connect_timeout: int = 60) -> Dict[str, Any]:
+    def _create_s3_retry_config(
+            max_attempts: int = 10,
+            request_timeout: int = 60,
+            connect_timeout: int = 60
+    ) -> Dict[str, Any]:
         from pyarrow.fs import AwsStandardS3RetryStrategy
 
         retry_strategy = AwsStandardS3RetryStrategy(max_attempts=max_attempts)

--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -70,22 +70,23 @@ class FileIO:
             connect_timeout: int = 60
     ) -> Dict[str, Any]:
         """
-        AwsStandardS3RetryStrategy is only available in PyArrow >= 8.0.0.
+        AwsStandardS3RetryStrategy and timeout parameters are only available
+        in PyArrow >= 8.0.0.
         """
-        config = {
-            'request_timeout': request_timeout,
-            'connect_timeout': connect_timeout
-        }
-
         if parse(pyarrow.__version__) >= parse("8.0.0"):
+            config = {
+                'request_timeout': request_timeout,
+                'connect_timeout': connect_timeout
+            }
             try:
                 from pyarrow.fs import AwsStandardS3RetryStrategy
                 retry_strategy = AwsStandardS3RetryStrategy(max_attempts=max_attempts)
                 config['retry_strategy'] = retry_strategy
             except ImportError:
                 pass
-
-        return config
+            return config
+        else:
+            return {}
 
     def _extract_oss_bucket(self, location) -> str:
         uri = urlparse(location)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness of S3/OSS file IO initialization.
> 
> - Introduces `FileIO._create_s3_retry_config` to set `request_timeout`, `connect_timeout`, and (when available) `AwsStandardS3RetryStrategy` for PyArrow >= 8.0.0
> - Applies the retry/timeout config to both `S3FileSystem` and OSS-backed `S3FileSystem` initialization in `file_io.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2de94bacd5f51d45b60459c491c6bea7e08fb556. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->