### PR TITLE
ray version compatible

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -102,7 +102,7 @@ jobs:
           chmod +x paimon-python/dev/lint-python.sh
           ./paimon-python/dev/lint-python.sh
 
-  ray_version_compatible_test:
+  requirement_version_compatible_test:
     runs-on: ubuntu-latest
     container: "python:3.10-slim"
 
@@ -166,14 +166,17 @@ jobs:
             parameterized==0.9.0 \
             packaging
 
-      - name: Test Ray version compatibility
+      - name: Test requirement version compatibility
         shell: bash
         run: |
           cd paimon-python
+          
+          # Test Ray version compatibility
+          echo "=========================================="
+          echo "Testing Ray version compatibility"
+          echo "=========================================="
           for ray_version in 2.44.0 2.48.0 2.53.0; do
-            echo "=========================================="
             echo "Testing Ray version: $ray_version"
-            echo "=========================================="
             
             # Install specific Ray version
             python -m pip install -q ray==$ray_version
@@ -191,5 +194,14 @@ jobs:
             # Uninstall Ray to avoid conflicts
             python -m pip uninstall -y ray
           done
+          
+          # Add other dependency version tests here in the future
+          # Example:
+          # echo "=========================================="
+          # echo "Testing PyArrow version compatibility"
+          # echo "=========================================="
+          # for pyarrow_version in 16.0.0 17.0.0 18.0.0; do
+          #   ...
+          # done
         env:
           PYTHONPATH: ${{ github.workspace }}/paimon-python

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -101,3 +101,87 @@ jobs:
         run: |
           chmod +x paimon-python/dev/lint-python.sh
           ./paimon-python/dev/lint-python.sh
+
+  test-ray-versions:
+    runs-on: ubuntu-latest
+    container: "python:3.10-slim"
+    strategy:
+      fail-fast: false
+      matrix:
+        ray-version: ['2.44.0', '2.48.0', '2.53.0']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK ${{ env.JDK_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JDK_VERSION }}
+          distribution: 'temurin'
+
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.8.8
+
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          apt-get update && apt-get install -y \
+            build-essential \
+            git \
+            curl \
+            && rm -rf /var/lib/apt/lists/*
+
+      - name: Verify Java and Maven installation
+        run: |
+          java -version
+          mvn -version
+
+      - name: Verify Python version
+        run: python --version
+
+      - name: Build Java
+        run: |
+          echo "Start compiling modules"
+          mvn -T 2C -B clean install -DskipTests
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -q \
+            pyroaring \
+            readerwriterlock==1.0.9 \
+            fsspec==2024.3.1 \
+            cachetools==5.3.3 \
+            ossfs==2023.12.0 \
+            ray==${{ matrix.ray-version }} \
+            fastavro==1.11.1 \
+            pyarrow==16.0.0 \
+            zstandard==0.24.0 \
+            polars==1.32.0 \
+            duckdb==1.3.2 \
+            numpy==1.24.3 \
+            pandas==2.0.3 \
+            flake8==4.0.1 \
+            pytest~=7.0 \
+            py4j==0.10.9.9 \
+            requests \
+            parameterized==0.9.0
+
+      - name: Verify Ray version
+        shell: bash
+        run: |
+          python -m pip install packaging
+          python -c "import ray; print(f'Ray version: {ray.__version__}')"
+          python -c "from packaging.version import parse; import ray; assert parse(ray.__version__) == parse('${{ matrix.ray-version }}'), f'Expected Ray ${{ matrix.ray-version }}, got {ray.__version__}'"
+
+      - name: Run Ray Data tests
+        shell: bash
+        run: |
+          cd paimon-python
+          python -m pytest pypaimon/tests/ray_data_test.py::RayDataTest -v --tb=short
+        env:
+          PYTHONPATH: ${{ github.workspace }}/paimon-python

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -102,13 +102,9 @@ jobs:
           chmod +x paimon-python/dev/lint-python.sh
           ./paimon-python/dev/lint-python.sh
 
-  test-ray-versions:
+  ray_version_compatible_test:
     runs-on: ubuntu-latest
     container: "python:3.10-slim"
-    strategy:
-      fail-fast: false
-      matrix:
-        ray-version: ['2.44.0', '2.48.0', '2.53.0']
 
     steps:
       - name: Checkout code
@@ -147,7 +143,7 @@ jobs:
           echo "Start compiling modules"
           mvn -T 2C -B clean install -DskipTests
 
-      - name: Install Python dependencies
+      - name: Install base Python dependencies
         shell: bash
         run: |
           python -m pip install --upgrade pip
@@ -157,7 +153,6 @@ jobs:
             fsspec==2024.3.1 \
             cachetools==5.3.3 \
             ossfs==2023.12.0 \
-            ray==${{ matrix.ray-version }} \
             fastavro==1.11.1 \
             pyarrow==16.0.0 \
             zstandard==0.24.0 \
@@ -165,23 +160,36 @@ jobs:
             duckdb==1.3.2 \
             numpy==1.24.3 \
             pandas==2.0.3 \
-            flake8==4.0.1 \
             pytest~=7.0 \
             py4j==0.10.9.9 \
             requests \
-            parameterized==0.9.0
+            parameterized==0.9.0 \
+            packaging
 
-      - name: Verify Ray version
-        shell: bash
-        run: |
-          python -m pip install packaging
-          python -c "import ray; print(f'Ray version: {ray.__version__}')"
-          python -c "from packaging.version import parse; import ray; assert parse(ray.__version__) == parse('${{ matrix.ray-version }}'), f'Expected Ray ${{ matrix.ray-version }}, got {ray.__version__}'"
-
-      - name: Run Ray Data tests
+      - name: Test Ray version compatibility
         shell: bash
         run: |
           cd paimon-python
-          python -m pytest pypaimon/tests/ray_data_test.py::RayDataTest -v --tb=short
+          for ray_version in 2.44.0 2.48.0 2.53.0; do
+            echo "=========================================="
+            echo "Testing Ray version: $ray_version"
+            echo "=========================================="
+            
+            # Install specific Ray version
+            python -m pip install -q ray==$ray_version
+            
+            # Verify Ray version
+            python -c "import ray; print(f'Ray version: {ray.__version__}')"
+            python -c "from packaging.version import parse; import ray; assert parse(ray.__version__) == parse('$ray_version'), f'Expected Ray $ray_version, got {ray.__version__}'"
+            
+            # Run tests
+            python -m pytest pypaimon/tests/ray_data_test.py::RayDataTest -v --tb=short || {
+              echo "Tests failed for Ray $ray_version"
+              exit 1
+            }
+            
+            # Uninstall Ray to avoid conflicts
+            python -m pip uninstall -y ray
+          done
         env:
           PYTHONPATH: ${{ github.workspace }}/paimon-python


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures Ray Data integration works across Ray versions and verifies it in CI.
> 
> - **Ray datasource compatibility**: `PaimonDatasource.get_read_tasks` now accepts `**kwargs` to support `per_task_row_limit`; conditionally attaches `schema` to `BlockMetadata` (Ray < `2.48.0`) or `ReadTask` (Ray ≥ `2.48.0`); enables `per_task_row_limit` when Ray ≥ `2.52.0`.
> - **CI**: Adds `requirement_version_compatible_test` workflow job that builds Java, installs base deps, and runs `pypaimon/tests/ray_data_test.py::RayDataTest` against Ray `2.44.0`, `2.48.0`, and `2.53.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6b46a59aebf422545d4566f87acadbb3ee1faef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->