### PR TITLE
[python] light refactor for stats collect

### DIFF
--- a/paimon-python/pypaimon/tests/reader_base_test.py
+++ b/paimon-python/pypaimon/tests/reader_base_test.py
@@ -775,7 +775,6 @@ class ReaderBasicTest(unittest.TestCase):
 
         self.assertEqual(read_entry.file.value_stats.null_counts, null_counts)
 
-<<<<<<< HEAD
     def _test_append_only_schema_match_case(self, table, pa_schema):
         """Test that for append-only tables, data.schema matches table.fields.
 
@@ -790,8 +789,7 @@ class ReaderBasicTest(unittest.TestCase):
             'id': [1, 2, 3],
             'name': ['Alice', 'Bob', 'Charlie'],
             'price': [10.5, 20.3, 30.7],
-            'category': ['A', 'B', 'C'],
-=======
+            'category': ['A', 'B', 'C']})
     def test_primary_key_value_stats(self):
         pa_schema = pa.schema([
             ('id', pa.int64()),
@@ -812,7 +810,6 @@ class ReaderBasicTest(unittest.TestCase):
             'name': ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
             'price': [10.5, 20.3, 30.7, 40.1, 50.9],
             'category': ['A', 'B', 'C', 'D', 'E']
->>>>>>> 3a303bec2 ([python] light refactor for stats collect)
         }, schema=pa_schema)
 
         write_builder = table.new_batch_write_builder()
@@ -823,7 +820,6 @@ class ReaderBasicTest(unittest.TestCase):
         commit.commit(commit_messages)
         writer.close()
 
-<<<<<<< HEAD
         # Verify that data.schema (converted to paimon schema) matches table.fields
         data_fields_from_schema = PyarrowFieldParser.to_paimon_schema(test_data.schema)
         table_fields = table.fields
@@ -841,8 +837,6 @@ class ReaderBasicTest(unittest.TestCase):
                          f"but table.fields has {table_field_names}")
 
         # Read manifest to verify value_stats_cols is None (all fields included)
-=======
->>>>>>> 3a303bec2 ([python] light refactor for stats collect)
         read_builder = table.new_read_builder()
         table_scan = read_builder.new_scan()
         latest_snapshot = SnapshotManager(table).get_latest_snapshot()
@@ -853,12 +847,10 @@ class ReaderBasicTest(unittest.TestCase):
             False
         )
 
-<<<<<<< HEAD
         if len(manifest_entries) > 0:
             file_meta = manifest_entries[0].file
             self.assertIsNone(file_meta.value_stats_cols,
                               "value_stats_cols should be None when all table fields are included")
-=======
         self.assertGreater(len(manifest_entries), 0, "Should have at least one manifest entry")
         file_meta = manifest_entries[0].file
 
@@ -924,7 +916,6 @@ class ReaderBasicTest(unittest.TestCase):
         self.assertEqual(actual_data.num_rows, 5, "Should have 5 rows")
         actual_ids = sorted(actual_data.column('id').to_pylist())
         self.assertEqual(actual_ids, [1, 2, 3, 4, 5], "All IDs should be present")
->>>>>>> 3a303bec2 ([python] light refactor for stats collect)
 
     def test_split_target_size(self):
         """Test source.split.target-size configuration effect on split generation."""

--- a/paimon-python/pypaimon/write/writer/data_blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_blob_writer.py
@@ -276,14 +276,7 @@ class DataBlobWriter(DataWriter):
         # Column stats (only for normal columns)
         metadata_stats_enabled = self.options.metadata_stats_enabled()
         stats_columns = self.normal_columns if metadata_stats_enabled else []
-        column_stats = {
-            field.name: self._get_column_stats(data, field.name)
-            for field in stats_columns
-        }
-
-        min_value_stats = [column_stats[field.name]['min_values'] for field in stats_columns]
-        max_value_stats = [column_stats[field.name]['max_values'] for field in stats_columns]
-        value_null_counts = [column_stats[field.name]['null_counts'] for field in stats_columns]
+        value_stats = self._collect_value_stats(data, stats_columns)
 
         self.sequence_generator.start = self.sequence_generator.current
 
@@ -293,14 +286,8 @@ class DataBlobWriter(DataWriter):
             row_count=data.num_rows,
             min_key=GenericRow([], []),
             max_key=GenericRow([], []),
-            key_stats=SimpleStats(
-                GenericRow([], []),
-                GenericRow([], []),
-                []),
-            value_stats=SimpleStats(
-                GenericRow(min_value_stats, stats_columns),
-                GenericRow(max_value_stats, stats_columns),
-                value_null_counts),
+            key_stats=SimpleStats.empty_stats(),
+            value_stats=value_stats,
             min_sequence_number=-1,
             max_sequence_number=-1,
             schema_id=self.table.table_schema.id,

--- a/paimon-python/pypaimon/write/writer/data_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_writer.py
@@ -206,21 +206,16 @@ class DataWriter(ABC):
         if not all(count == 0 for count in key_stats.null_counts):
             raise RuntimeError("Primary key should not be null")
         
-        value_fields = stats_fields if value_stats_enabled else []
-        value_stats = (
-            self._collect_value_stats(data, value_fields, column_stats)
-            if value_stats_enabled
-            else SimpleStats.empty_stats()
-        )
+        value_stats = self._collect_value_stats(data, stats_fields, column_stats)
 
         min_seq = self.sequence_generator.start
         max_seq = self.sequence_generator.current
         self.sequence_generator.start = self.sequence_generator.current
         if value_stats_enabled:
-            if len(value_fields) == len(self.table.fields):
+            if len(stats_fields) == len(self.table.fields):
                 value_stats_cols = None
             else:
-                value_stats_cols = [field.name for field in value_fields]
+                value_stats_cols = [field.name for field in stats_fields]
         else:
             value_stats_cols = []
         self.committed_files.append(DataFileMeta.create(

--- a/paimon-python/pypaimon/write/writer/data_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_writer.py
@@ -197,8 +197,6 @@ class DataWriter(ABC):
                 else PyarrowFieldParser.to_paimon_schema(data.schema)
         else:
             stats_fields = self.table.trimmed_primary_keys_fields
-        stats_fields = self.table.fields if self.table.is_primary_key_table \
-            else PyarrowFieldParser.to_paimon_schema(data.schema)
         column_stats = {
             field.name: self._get_column_stats(data, field.name)
             for field in stats_fields
@@ -209,7 +207,11 @@ class DataWriter(ABC):
             raise RuntimeError("Primary key should not be null")
         
         value_fields = stats_fields if value_stats_enabled else []
-        value_stats = self._collect_value_stats(data, value_fields, column_stats) if value_stats_enabled else SimpleStats.empty_stats()
+        value_stats = (
+            self._collect_value_stats(data, value_fields, column_stats)
+            if value_stats_enabled
+            else SimpleStats.empty_stats()
+        )
 
         min_seq = self.sequence_generator.start
         max_seq = self.sequence_generator.current


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactor: stats collection in writers**
> 
> - Introduces `_collect_value_stats` used by both `DataWriter` and `DataBlobWriter` to build `SimpleStats`, returning `SimpleStats.empty_stats()` when no fields
> - Sets `key_stats` via the shared helper and validates PK nulls via `key_stats.null_counts`; sets `value_stats` from data or empty when disabled
> - Enhances `_get_column_stats` to skip min/max for all-null and nested/map types; keeps null counts only
> - Uses `SimpleStats.empty_stats()` where appropriate and simplifies metadata construction (`value_stats_cols` semantics preserved)
> 
> **Tests: broaden coverage of stats behavior**
> 
> - Adds assertions that when stats are disabled, `value_stats_cols == []` and `value_stats` is empty
> - Verifies append-only schema matches table fields for stats computation
> - Adds primary-key table checks: `key_stats` present, value stats exclude system/PK fields, and arity matches `value_stats_cols` when specified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ad3e89756b7a0ed1b0ebbcc53cdd079482e5046. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->