### PR TITLE
[python] do not retry for connect exception

### DIFF
--- a/paimon-python/pypaimon/api/client.py
+++ b/paimon-python/pypaimon/api/client.py
@@ -158,7 +158,7 @@ class ExponentialRetry:
         retry_kwargs = {
             'total': max_retries,
             'read': max_retries,
-            'connect': max_retries,
+            'connect': 0,
             'backoff_factor': 1,
             'status_forcelist': [429, 502, 503, 504],
             'raise_on_status': False,

--- a/paimon-python/pypaimon/tests/rest/test_exponential_retry_strategy.py
+++ b/paimon-python/pypaimon/tests/rest/test_exponential_retry_strategy.py
@@ -16,6 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 import unittest
 import requests
 from requests.exceptions import ConnectionError, ConnectTimeout, Timeout
@@ -46,13 +47,12 @@ class TestExponentialRetryStrategy(unittest.TestCase):
         session.mount("https://", self.retry_strategy.adapter)
         session.timeout = (1, 1)
 
-        import time
         start_time = time.time()
         
         try:
             session.get("http://192.168.255.255:9999", timeout=(1, 1))
             self.fail("Expected ConnectionError")
-        except (ConnectionError, ConnectTimeout, Timeout, NewConnectionError, MaxRetryError) as e:
+        except (ConnectionError, ConnectTimeout, Timeout, NewConnectionError, MaxRetryError):
             elapsed = time.time() - start_time
             self.assertLess(
                 elapsed, 5.0,
@@ -62,4 +62,3 @@ class TestExponentialRetryStrategy(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/paimon-python/pypaimon/tests/rest/test_exponential_retry_strategy.py
+++ b/paimon-python/pypaimon/tests/rest/test_exponential_retry_strategy.py
@@ -1,0 +1,65 @@
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+import requests
+from requests.exceptions import ConnectionError, ConnectTimeout, Timeout
+from urllib3.exceptions import NewConnectionError, MaxRetryError
+
+from pypaimon.api.client import ExponentialRetry
+
+
+class TestExponentialRetryStrategy(unittest.TestCase):
+
+    def setUp(self):
+        self.retry_strategy = ExponentialRetry(max_retries=5)
+
+    def test_basic_retry(self):
+        retry = ExponentialRetry._ExponentialRetry__create_retry_strategy(5)
+        
+        self.assertEqual(retry.total, 5)
+        self.assertEqual(retry.read, 5)
+        self.assertEqual(retry.connect, 0)  # Connection errors should not retry
+        
+        self.assertIn(429, retry.status_forcelist)  # Too Many Requests
+        self.assertIn(503, retry.status_forcelist)  # Service Unavailable
+        self.assertNotIn(404, retry.status_forcelist)
+
+    def test_no_retry_on_connect_error(self):
+        session = requests.Session()
+        session.mount("http://", self.retry_strategy.adapter)
+        session.mount("https://", self.retry_strategy.adapter)
+        session.timeout = (1, 1)
+
+        import time
+        start_time = time.time()
+        
+        try:
+            session.get("http://192.168.255.255:9999", timeout=(1, 1))
+            self.fail("Expected ConnectionError")
+        except (ConnectionError, ConnectTimeout, Timeout, NewConnectionError, MaxRetryError) as e:
+            elapsed = time.time() - start_time
+            self.assertLess(
+                elapsed, 5.0,
+                f"Connection error took {elapsed:.2f}s, should fail quickly without retry"
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Disable retries for connection errors**
> 
> - Set `connect` retries to `0` in `ExponentialRetry.__create_retry_strategy` to avoid retrying connection errors
> - Add `tests/rest/test_exponential_retry_strategy.py` verifying retry totals, status retry list, and quick-fail behavior on connection failures
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81a1e1e1241d183e915f70df2780914fa0e99148. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->