### PR TITLE
[python] support table scan with row range

### DIFF
--- a/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
@@ -63,6 +63,8 @@ class FullStartingScanner(StartingScanner):
 
         self.idx_of_this_subtask = None
         self.number_of_para_subtasks = None
+        self.start_row_of_this_subtask = None
+        self.end_row_of_this_subtask = None
 
         self.only_read_real_buckets = True if options.bucket() == BucketMode.POSTPONE_BUCKET.value else False
         self.data_evolution = options.data_evolution_enabled()
@@ -125,33 +127,16 @@ class FullStartingScanner(StartingScanner):
         self.number_of_para_subtasks = number_of_para_subtasks
         return self
 
-    def _append_only_filter_by_shard(self, partitioned_files: defaultdict) -> (defaultdict, int, int):
-        """
-        Filter file entries by shard. Only keep the files within the range, which means
-        that only the starting and ending files need to be further divided subsequently
-        """
-        total_row = 0
-        # Sort by file creation time to ensure consistent sharding
-        for key, file_entries in partitioned_files.items():
-            for entry in file_entries:
-                total_row += entry.file.row_count
+    def with_row_range(self, start_row, end_row) -> 'FullStartingScanner':
+        if start_row >= end_row:
+            raise Exception("start_row must be less than end_row")
+        self.start_row_of_this_subtask = start_row
+        self.end_row_of_this_subtask = end_row
+        return self
 
-        # Calculate number of rows this shard should process using balanced distribution
-        # Distribute remainder evenly among first few shards to avoid last shard overload
-        base_rows_per_shard = total_row // self.number_of_para_subtasks
-        remainder = total_row % self.number_of_para_subtasks
-
-        # Each of the first 'remainder' shards gets one extra row
-        if self.idx_of_this_subtask < remainder:
-            num_row = base_rows_per_shard + 1
-            start_row = self.idx_of_this_subtask * (base_rows_per_shard + 1)
-        else:
-            num_row = base_rows_per_shard
-            start_row = (remainder * (base_rows_per_shard + 1) +
-                         (self.idx_of_this_subtask - remainder) * base_rows_per_shard)
-
-        end_row = start_row + num_row
-
+    def _append_only_filter_by_row_range(self, partitioned_files: defaultdict,
+                                         start_row: int,
+                                         end_row: int) -> (defaultdict, int, int):
         plan_start_row = 0
         plan_end_row = 0
         entry_end_row = 0  # end row position of current file in all data
@@ -183,12 +168,16 @@ class FullStartingScanner(StartingScanner):
 
         return filtered_partitioned_files, plan_start_row, plan_end_row
 
-    def _data_evolution_filter_by_shard(self, partitioned_files: defaultdict) -> (defaultdict, int, int):
+    def _append_only_filter_by_shard(self, partitioned_files: defaultdict) -> (defaultdict, int, int):
+        """
+        Filter file entries by shard. Only keep the files within the range, which means
+        that only the starting and ending files need to be further divided subsequently
+        """
         total_row = 0
+        # Sort by file creation time to ensure consistent sharding
         for key, file_entries in partitioned_files.items():
             for entry in file_entries:
-                if not self._is_blob_file(entry.file.file_name):
-                    total_row += entry.file.row_count
+                total_row += entry.file.row_count
 
         # Calculate number of rows this shard should process using balanced distribution
         # Distribute remainder evenly among first few shards to avoid last shard overload
@@ -206,6 +195,11 @@ class FullStartingScanner(StartingScanner):
 
         end_row = start_row + num_row
 
+        return self._append_only_filter_by_row_range(partitioned_files, start_row, end_row)
+
+    def _data_evolution_filter_by_row_range(self, partitioned_files: defaultdict,
+                                            start_row: int,
+                                            end_row: int) -> (defaultdict, int, int):
         plan_start_row = 0
         plan_end_row = 0
         entry_end_row = 0  # end row position of current file in all data
@@ -243,6 +237,30 @@ class FullStartingScanner(StartingScanner):
                 filtered_partitioned_files[key] = filtered_entries
 
         return filtered_partitioned_files, plan_start_row, plan_end_row
+
+    def _data_evolution_filter_by_shard(self, partitioned_files: defaultdict) -> (defaultdict, int, int):
+        total_row = 0
+        for key, file_entries in partitioned_files.items():
+            for entry in file_entries:
+                if not self._is_blob_file(entry.file.file_name):
+                    total_row += entry.file.row_count
+
+        # Calculate number of rows this shard should process using balanced distribution
+        # Distribute remainder evenly among first few shards to avoid last shard overload
+        base_rows_per_shard = total_row // self.number_of_para_subtasks
+        remainder = total_row % self.number_of_para_subtasks
+
+        # Each of the first 'remainder' shards gets one extra row
+        if self.idx_of_this_subtask < remainder:
+            num_row = base_rows_per_shard + 1
+            start_row = self.idx_of_this_subtask * (base_rows_per_shard + 1)
+        else:
+            num_row = base_rows_per_shard
+            start_row = (remainder * (base_rows_per_shard + 1) +
+                         (self.idx_of_this_subtask - remainder) * base_rows_per_shard)
+
+        end_row = start_row + num_row
+        return self._data_evolution_filter_by_row_range(partitioned_files, start_row, end_row)
 
     def _compute_split_start_end_row(self, splits: List[Split], plan_start_row, plan_end_row):
         """
@@ -451,7 +469,13 @@ class FullStartingScanner(StartingScanner):
         for entry in file_entries:
             partitioned_files[(tuple(entry.partition.values), entry.bucket)].append(entry)
 
-        if self.idx_of_this_subtask is not None:
+        if self.start_row_of_this_subtask is not None:
+            # shard data range: [plan_start_row, plan_end_row)
+            partitioned_files, plan_start_row, plan_end_row = \
+                self._append_only_filter_by_row_range(partitioned_files,
+                                                      self.start_row_of_this_subtask,
+                                                      self.end_row_of_this_subtask)
+        elif self.idx_of_this_subtask is not None:
             partitioned_files, plan_start_row, plan_end_row = self._append_only_filter_by_shard(partitioned_files)
 
         def weight_func(f: DataFileMeta) -> int:
@@ -467,7 +491,7 @@ class FullStartingScanner(StartingScanner):
             packed_files: List[List[DataFileMeta]] = self._pack_for_ordered(data_files, weight_func,
                                                                             self.target_split_size)
             splits += self._build_split_from_pack(packed_files, file_entries, False, deletion_files_map)
-        if self.idx_of_this_subtask is not None:
+        if self.start_row_of_this_subtask is not None or self.idx_of_this_subtask is not None:
             # When files are combined into splits, it is necessary to find files that needs to be divided for each split
             self._compute_split_start_end_row(splits, plan_start_row, plan_end_row)
         return splits
@@ -555,7 +579,14 @@ class FullStartingScanner(StartingScanner):
         for entry in sorted_entries:
             partitioned_files[(tuple(entry.partition.values), entry.bucket)].append(entry)
 
-        if self.idx_of_this_subtask is not None:
+        print("self.start_row_of_this_subtask:{}".format(self.start_row_of_this_subtask))
+        if self.start_row_of_this_subtask is not None:
+            # shard data range: [plan_start_row, plan_end_row)
+            partitioned_files, plan_start_row, plan_end_row = \
+                self._data_evolution_filter_by_row_range(partitioned_files,
+                                                         self.start_row_of_this_subtask,
+                                                         self.end_row_of_this_subtask)
+        elif self.idx_of_this_subtask is not None:
             # shard data range: [plan_start_row, plan_end_row)
             partitioned_files, plan_start_row, plan_end_row = self._data_evolution_filter_by_shard(partitioned_files)
 
@@ -584,7 +615,7 @@ class FullStartingScanner(StartingScanner):
 
             splits += self._build_split_from_pack(flatten_packed_files, sorted_entries, False, deletion_files_map)
 
-        if self.idx_of_this_subtask is not None:
+        if self.start_row_of_this_subtask is not None or self.idx_of_this_subtask is not None:
             self._compute_split_start_end_row(splits, plan_start_row, plan_end_row)
         return splits
 

--- a/paimon-python/pypaimon/read/table_scan.py
+++ b/paimon-python/pypaimon/read/table_scan.py
@@ -71,3 +71,7 @@ class TableScan:
     def with_shard(self, idx_of_this_subtask, number_of_para_subtasks) -> 'TableScan':
         self.starting_scanner.with_shard(idx_of_this_subtask, number_of_para_subtasks)
         return self
+
+    def with_row_range(self, start_row, end_row) -> 'TableScan':
+        self.starting_scanner.with_row_range(start_row, end_row)
+        return self


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds targeted row-range scanning to the Python reader and wires it into split planning.
> 
> - New API: `TableScan.with_row_range(start_row, end_row)` delegates to `FullStartingScanner.with_row_range`
> - `FullStartingScanner` stores `start_row_of_this_subtask`/`end_row_of_this_subtask` and filters files by range via `_append_only_filter_by_row_range` and `_data_evolution_filter_by_row_range`
> - Shard-based helpers now reuse row-range logic to compute `start_row`/`end_row`, ensuring consistent behavior
> - When shard or row range is set, `_compute_split_start_end_row` marks per-file boundaries for partial reads
> - Tests: add `test_data_blob_writer_with_row_range` validating row-range reads on blob-enabled tables
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12df60e94b86826fc46aced52b5954d1e25460af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->