### PR TITLE
[python] support alterTable

### DIFF
--- a/docs/content/program-api/python-api.md
+++ b/docs/content/program-api/python-api.md
@@ -164,6 +164,33 @@ catalog.create_table(
 table = catalog.get_table('database_name.table_name')
 ```
 
+## Alter Table
+
+You can use the catalog to alter a table, but you need to pay attention to the following points.
+
+- Column cannot specify NOT NULL in the table.
+- Cannot update partition column type in the table.
+- Cannot change nullability of primary key.
+- Cannot rename or drop partition key columns.
+- Cannot rename or drop primary key columns.
+
+```python
+from pypaimon.schema.schema_change import SchemaChange
+from pypaimon.schema.data_types import AtomicType
+
+# add column
+add_column = SchemaChange.add_column("new_col", AtomicType("STRING"))
+# rename column
+rename_column = SchemaChange.rename_column("old_col", "new_col")
+# drop column
+drop_column = SchemaChange.drop_column("col_to_drop")
+# update column type
+update_column_type = SchemaChange.update_column_type("col1", AtomicType("BIGINT"), keep_nullability=False)
+
+schema_changes = [add_column, rename_column, drop_column, update_column_type]
+catalog.alter_table('database_name.table_name', schema_changes, ignore_if_not_exists=False)
+```
+
 ## Batch Write
 
 Paimon table write is Two-Phase Commit, you can write many times, but once committed, no more data can be written.
@@ -683,6 +710,15 @@ The following shows the supported features of Python Paimon compared to Java Pai
      - `bucket = -2` (postpone)
      - `bucket > 0` (fixed)
      - read with deletion vectors enabled
+   - Schema Evolution
+     - Alter table schema
+     - Add column
+     - Rename column
+     - Drop column
+     - Update column type
+     - Update column nullability
+     - Update column comment
+     - Set/Remove table options
    - Read/Write Operations
      - Batch read and write for append tables and primary key tables
      - Predicate filtering

--- a/paimon-python/pypaimon/api/api_request.py
+++ b/paimon-python/pypaimon/api/api_request.py
@@ -23,6 +23,7 @@ from typing import Dict, List, Optional
 from pypaimon.common.identifier import Identifier
 from pypaimon.common.json_util import json_field
 from pypaimon.schema.schema import Schema
+from pypaimon.schema.schema_change import SchemaChange
 from pypaimon.snapshot.snapshot import Snapshot
 from pypaimon.snapshot.snapshot_commit import PartitionStatistics
 
@@ -76,3 +77,10 @@ class CommitTableRequest(RESTRequest):
     table_uuid: Optional[str] = json_field(FIELD_TABLE_UUID)
     snapshot: Snapshot = json_field(FIELD_SNAPSHOT)
     statistics: List[PartitionStatistics] = json_field(FIELD_STATISTICS)
+
+
+@dataclass
+class AlterTableRequest(RESTRequest):
+    FIELD_CHANGES = "changes"
+
+    changes: List[SchemaChange] = json_field(FIELD_CHANGES)

--- a/paimon-python/pypaimon/api/rest_api.py
+++ b/paimon-python/pypaimon/api/rest_api.py
@@ -18,7 +18,7 @@
 import logging
 from typing import Callable, Dict, List, Optional, Union
 
-from pypaimon.api.api_request import (AlterDatabaseRequest, CommitTableRequest,
+from pypaimon.api.api_request import (AlterDatabaseRequest, AlterTableRequest, CommitTableRequest,
                                       CreateDatabaseRequest,
                                       CreateTableRequest, RenameTableRequest)
 from pypaimon.api.api_response import (CommitTableResponse, ConfigResponse,
@@ -286,6 +286,17 @@ class RESTApi:
         request = RenameTableRequest(source_identifier, target_identifier)
         return self.client.post(
             self.resource_paths.rename_table(),
+            request,
+            self.rest_auth_function)
+
+    def alter_table(self, identifier: Identifier, changes: List):
+        database_name, table_name = self.__validate_identifier(identifier)
+        if not changes:
+            raise ValueError("Changes cannot be empty")
+
+        request = AlterTableRequest(changes)
+        return self.client.post(
+            self.resource_paths.table(database_name, table_name),
             request,
             self.rest_auth_function)
 

--- a/paimon-python/pypaimon/catalog/catalog.py
+++ b/paimon-python/pypaimon/catalog/catalog.py
@@ -21,6 +21,7 @@ from typing import List, Optional, Union
 
 from pypaimon.common.identifier import Identifier
 from pypaimon.schema.schema import Schema
+from pypaimon.schema.schema_change import SchemaChange
 from pypaimon.snapshot.snapshot import Snapshot
 from pypaimon.snapshot.snapshot_commit import PartitionStatistics
 
@@ -53,6 +54,15 @@ class Catalog(ABC):
     @abstractmethod
     def create_table(self, identifier: Union[str, Identifier], schema: Schema, ignore_if_exists: bool):
         """Create table with schema."""
+
+    @abstractmethod
+    def alter_table(
+        self,
+        identifier: Union[str, Identifier],
+        changes: List[SchemaChange],
+        ignore_if_not_exists: bool = False
+    ):
+        """Alter table with schema changes."""
 
     def supports_version_management(self) -> bool:
         """

--- a/paimon-python/pypaimon/catalog/filesystem_catalog.py
+++ b/paimon-python/pypaimon/catalog/filesystem_catalog.py
@@ -20,12 +20,12 @@ from typing import List, Optional, Union
 
 from pypaimon.catalog.catalog import Catalog
 from pypaimon.catalog.catalog_environment import CatalogEnvironment
-from pypaimon.catalog.catalog_exception import (ColumnAlreadyExistException,
-                                                ColumnNotExistException,
-                                                DatabaseAlreadyExistException,
-                                                DatabaseNotExistException,
-                                                TableAlreadyExistException,
-                                                TableNotExistException)
+from pypaimon.catalog.catalog_exception import (
+    DatabaseAlreadyExistException,
+    DatabaseNotExistException,
+    TableAlreadyExistException,
+    TableNotExistException
+)
 from pypaimon.catalog.database import Database
 from pypaimon.common.options import Options
 from pypaimon.common.options.config import CatalogOptions
@@ -128,7 +128,7 @@ class FileSystemCatalog(Catalog):
             identifier = Identifier.from_string(identifier)
         try:
             self.get_table(identifier)
-        except TableNotExistException as e:
+        except TableNotExistException:
             if not ignore_if_not_exists:
                 raise
             return
@@ -136,11 +136,7 @@ class FileSystemCatalog(Catalog):
         table_path = self.get_table_path(identifier)
         schema_manager = SchemaManager(self.file_io, table_path)
         try:
-            old_schema = schema_manager.latest()
-            if old_schema is None:
-                raise TableNotExistException(identifier)
-            new_schema = schema_manager.commit_changes(old_schema, changes)
-            schema_manager.commit(new_schema)
+            schema_manager.commit_changes(changes)
         except Exception as e:
             raise RuntimeError(f"Failed to alter table {identifier.get_full_name()}: {e}") from e
 

--- a/paimon-python/pypaimon/catalog/rest/rest_catalog.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_catalog.py
@@ -34,6 +34,7 @@ from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.common.file_io import FileIO
 from pypaimon.common.identifier import Identifier
 from pypaimon.schema.schema import Schema
+from pypaimon.schema.schema_change import SchemaChange
 from pypaimon.schema.table_schema import TableSchema
 from pypaimon.snapshot.snapshot import Snapshot
 from pypaimon.snapshot.snapshot_commit import PartitionStatistics
@@ -173,6 +174,20 @@ class RESTCatalog(Catalog):
             identifier = Identifier.from_string(identifier)
         try:
             self.rest_api.drop_table(identifier)
+        except NoSuchResourceException as e:
+            if not ignore_if_not_exists:
+                raise TableNotExistException(identifier) from e
+
+    def alter_table(
+        self,
+        identifier: Union[str, Identifier],
+        changes: List[SchemaChange],
+        ignore_if_not_exists: bool = False
+    ):
+        if not isinstance(identifier, Identifier):
+            identifier = Identifier.from_string(identifier)
+        try:
+            self.rest_api.alter_table(identifier, changes)
         except NoSuchResourceException as e:
             if not ignore_if_not_exists:
                 raise TableNotExistException(identifier) from e

--- a/paimon-python/pypaimon/schema/schema_change.py
+++ b/paimon-python/pypaimon/schema/schema_change.py
@@ -52,7 +52,12 @@ class SchemaChange(ABC):
         return UpdateComment(comment)
 
     @staticmethod
-    def add_column(field_name: Union[str, List[str]], data_type: DataType, comment: Optional[str] = None, move: Optional["Move"] = None) -> "AddColumn":
+    def add_column(
+            field_name: Union[str, List[str]],
+            data_type: DataType,
+            comment: Optional[str] = None,
+            move: Optional["Move"] = None
+    ) -> "AddColumn":
         if isinstance(field_name, str):
             return AddColumn(field_names=[field_name], data_type=data_type, comment=comment, move=move)
         else:
@@ -73,14 +78,21 @@ class SchemaChange(ABC):
             return DropColumn(field_name)
 
     @staticmethod
-    def update_column_type(field_name: Union[str, List[str]], new_data_type: DataType, keep_nullability: bool = False) -> "UpdateColumnType":
+    def update_column_type(
+            field_name: Union[str, List[str]],
+            new_data_type: DataType,
+            keep_nullability: bool = False
+    ) -> "UpdateColumnType":
         if isinstance(field_name, str):
             return UpdateColumnType([field_name], new_data_type, keep_nullability)
         else:
             return UpdateColumnType(field_name, new_data_type, keep_nullability)
 
     @staticmethod
-    def update_column_nullability(field_name: Union[str, List[str]], new_nullability: bool) -> "UpdateColumnNullability":
+    def update_column_nullability(
+            field_name: Union[str, List[str]],
+            new_nullability: bool
+    ) -> "UpdateColumnNullability":
         if isinstance(field_name, str):
             return UpdateColumnNullability([field_name], new_nullability)
         else:
@@ -275,4 +287,3 @@ class Move:
     field_name: str = json_field(FIELD_FIELD_NAME)
     reference_field_name: Optional[str] = json_field(FIELD_REFERENCE_FIELD_NAME)
     type: MoveType = json_field(FIELD_TYPE)
-

--- a/paimon-python/pypaimon/schema/schema_change.py
+++ b/paimon-python/pypaimon/schema/schema_change.py
@@ -1,0 +1,262 @@
+from abc import ABC
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional, Union
+
+from pypaimon.common.json_util import json_field
+from pypaimon.schema.data_types import DataType
+
+
+class Actions:
+    FIELD_ACTION = "action"
+    SET_OPTION_ACTION = "setOption"
+    REMOVE_OPTION_ACTION = "removeOption"
+    UPDATE_COMMENT_ACTION = "updateComment"
+    ADD_COLUMN_ACTION = "addColumn"
+    RENAME_COLUMN_ACTION = "renameColumn"
+    DROP_COLUMN_ACTION = "dropColumn"
+    UPDATE_COLUMN_TYPE_ACTION = "updateColumnType"
+    UPDATE_COLUMN_NULLABILITY_ACTION = "updateColumnNullability"
+    UPDATE_COLUMN_COMMENT_ACTION = "updateColumnComment"
+    UPDATE_COLUMN_DEFAULT_VALUE_ACTION = "updateColumnDefaultValue"
+    UPDATE_COLUMN_POSITION_ACTION = "updateColumnPosition"
+
+
+class SchemaChange(ABC):
+    @staticmethod
+    def set_option(key: str, value: str) -> "SetOption":
+        return SetOption(key=key, value=value)
+
+    @staticmethod
+    def remove_option(key: str) -> "RemoveOption":
+        return RemoveOption(key)
+
+    @staticmethod
+    def update_comment(comment: Optional[str]) -> "UpdateComment":
+        return UpdateComment(comment)
+
+    @staticmethod
+    def add_column(field_name: Union[str, List[str]], data_type: DataType, comment: Optional[str] = None, move: Optional["Move"] = None) -> "AddColumn":
+        if isinstance(field_name, str):
+            return AddColumn(field_names=[field_name], data_type=data_type, comment=comment, move=move)
+        else:
+            return AddColumn(field_names=field_name, data_type=data_type, comment=comment, move=move)
+
+    @staticmethod
+    def rename_column(field_name: Union[str, List[str]], new_name: str) -> "RenameColumn":
+        if isinstance(field_name, str):
+            return RenameColumn([field_name], new_name)
+        else:
+            return RenameColumn(field_name, new_name)
+
+    @staticmethod
+    def drop_column(field_name: Union[str, List[str]]) -> "DropColumn":
+        if isinstance(field_name, str):
+            return DropColumn([field_name])
+        else:
+            return DropColumn(field_name)
+
+    @staticmethod
+    def update_column_type(field_name: Union[str, List[str]], new_data_type: DataType, keep_nullability: bool = False) -> "UpdateColumnType":
+        if isinstance(field_name, str):
+            return UpdateColumnType([field_name], new_data_type, keep_nullability)
+        else:
+            return UpdateColumnType(field_name, new_data_type, keep_nullability)
+
+    @staticmethod
+    def update_column_nullability(field_name: Union[str, List[str]], new_nullability: bool) -> "UpdateColumnNullability":
+        if isinstance(field_name, str):
+            return UpdateColumnNullability([field_name], new_nullability)
+        else:
+            return UpdateColumnNullability(field_name, new_nullability)
+
+    @staticmethod
+    def update_column_comment(field_name: Union[str, List[str]], comment: str) -> "UpdateColumnComment":
+        if isinstance(field_name, str):
+            return UpdateColumnComment([field_name], comment)
+        else:
+            return UpdateColumnComment(field_name, comment)
+
+    @staticmethod
+    def update_column_default_value(field_names: List[str], default_value: str) -> "UpdateColumnDefaultValue":
+        return UpdateColumnDefaultValue(field_names, default_value)
+
+    @staticmethod
+    def update_column_position(move: "Move") -> "UpdateColumnPosition":
+        return UpdateColumnPosition(move)
+
+
+@dataclass
+class SetOption(SchemaChange):
+    FIELD_KEY = "key"
+    FIELD_VALUE = "value"
+    key: str = json_field(FIELD_KEY)
+    value: str = json_field(FIELD_VALUE)
+    action: str = json_field(Actions.FIELD_ACTION, default=Actions.SET_OPTION_ACTION)
+
+    def __post_init__(self):
+        if not hasattr(self, 'action') or self.action is None:
+            self.action = Actions.SET_OPTION_ACTION
+
+
+@dataclass
+class RemoveOption(SchemaChange):
+    FIELD_KEY = "key"
+    key: str = json_field(FIELD_KEY)
+    action: str = json_field(Actions.FIELD_ACTION, default=Actions.REMOVE_OPTION_ACTION)
+
+    def __post_init__(self):
+        if not hasattr(self, 'action') or self.action is None:
+            self.action = Actions.REMOVE_OPTION_ACTION
+
+
+@dataclass
+class UpdateComment(SchemaChange):
+    FIELD_COMMENT = "comment"
+    comment: Optional[str] = json_field(FIELD_COMMENT)
+    action: str = json_field(Actions.FIELD_ACTION, default=Actions.UPDATE_COMMENT_ACTION)
+
+    def __post_init__(self):
+        if not hasattr(self, 'action') or self.action is None:
+            self.action = Actions.UPDATE_COMMENT_ACTION
+
+
+@dataclass
+class AddColumn(SchemaChange):
+    FIELD_FIELD_NAMES = "fieldNames"
+    FIELD_DATA_TYPE = "dataType"
+    FIELD_COMMENT = "comment"
+    FIELD_MOVE = "move"
+    field_names: List[str] = json_field(FIELD_FIELD_NAMES)
+    data_type: DataType = json_field(FIELD_DATA_TYPE)
+    comment: Optional[str] = json_field(FIELD_COMMENT)
+    move: Optional["Move"] = json_field(FIELD_MOVE)
+    action: str = json_field(Actions.FIELD_ACTION, default=Actions.ADD_COLUMN_ACTION)
+
+    def __post_init__(self):
+        if not hasattr(self, 'action') or self.action is None:
+            self.action = Actions.ADD_COLUMN_ACTION
+
+
+@dataclass
+class RenameColumn(SchemaChange):
+    FIELD_FIELD_NAMES = "fieldNames"
+    FIELD_NEW_NAME = "newName"
+    field_names: List[str] = json_field(FIELD_FIELD_NAMES)
+    new_name: str = json_field(FIELD_NEW_NAME)
+    action: str = json_field(Actions.FIELD_ACTION, default=Actions.RENAME_COLUMN_ACTION)
+
+    def __post_init__(self):
+        if not hasattr(self, 'action') or self.action is None:
+            self.action = Actions.RENAME_COLUMN_ACTION
+
+
+@dataclass
+class DropColumn(SchemaChange):
+    FIELD_FIELD_NAMES = "fieldNames"
+    field_names: List[str] = json_field(FIELD_FIELD_NAMES)
+    action: str = json_field(Actions.FIELD_ACTION, default=Actions.DROP_COLUMN_ACTION)
+
+    def __post_init__(self):
+        if not hasattr(self, 'action') or self.action is None:
+            self.action = Actions.DROP_COLUMN_ACTION
+
+
+@dataclass
+class UpdateColumnType(SchemaChange):
+    FIELD_FIELD_NAMES = "fieldNames"
+    FIELD_NEW_DATA_TYPE = "newDataType"
+    FIELD_KEEP_NULLABILITY = "keepNullability"
+    field_names: List[str] = json_field(FIELD_FIELD_NAMES)
+    new_data_type: DataType = json_field(FIELD_NEW_DATA_TYPE)
+    keep_nullability: bool = json_field(FIELD_KEEP_NULLABILITY)
+    action: str = json_field(Actions.FIELD_ACTION, default=Actions.UPDATE_COLUMN_TYPE_ACTION)
+
+    def __post_init__(self):
+        if not hasattr(self, 'action') or self.action is None:
+            self.action = Actions.UPDATE_COLUMN_TYPE_ACTION
+
+
+@dataclass
+class UpdateColumnNullability(SchemaChange):
+    FIELD_FIELD_NAMES = "fieldNames"
+    FIELD_NEW_NULLABILITY = "newNullability"
+    field_names: List[str] = json_field(FIELD_FIELD_NAMES)
+    new_nullability: bool = json_field(FIELD_NEW_NULLABILITY)
+    action: str = json_field(Actions.FIELD_ACTION, default=Actions.UPDATE_COLUMN_NULLABILITY_ACTION)
+
+    def __post_init__(self):
+        if not hasattr(self, 'action') or self.action is None:
+            self.action = Actions.UPDATE_COLUMN_NULLABILITY_ACTION
+
+
+@dataclass
+class UpdateColumnComment(SchemaChange):
+    FIELD_FIELD_NAMES = "fieldNames"
+    FIELD_NEW_COMMENT = "newComment"
+    field_names: List[str] = json_field(FIELD_FIELD_NAMES)
+    new_comment: str = json_field(FIELD_NEW_COMMENT)
+    action: str = json_field(Actions.FIELD_ACTION, default=Actions.UPDATE_COLUMN_COMMENT_ACTION)
+
+    def __post_init__(self):
+        if not hasattr(self, 'action') or self.action is None:
+            self.action = Actions.UPDATE_COLUMN_COMMENT_ACTION
+
+
+@dataclass
+class UpdateColumnDefaultValue(SchemaChange):
+    FIELD_FIELD_NAMES = "fieldNames"
+    FIELD_NEW_DEFAULT_VALUE = "newDefaultValue"
+    field_names: List[str] = json_field(FIELD_FIELD_NAMES)
+    new_default_value: str = json_field(FIELD_NEW_DEFAULT_VALUE)
+    action: str = json_field(Actions.FIELD_ACTION, default=Actions.UPDATE_COLUMN_DEFAULT_VALUE_ACTION)
+
+    def __post_init__(self):
+        if not hasattr(self, 'action') or self.action is None:
+            self.action = Actions.UPDATE_COLUMN_DEFAULT_VALUE_ACTION
+
+
+@dataclass
+class UpdateColumnPosition(SchemaChange):
+    FIELD_MOVE = "move"
+    move: "Move" = json_field(FIELD_MOVE)
+    action: str = json_field(Actions.FIELD_ACTION, default=Actions.UPDATE_COLUMN_POSITION_ACTION)
+
+    def __post_init__(self):
+        if not hasattr(self, 'action') or self.action is None:
+            self.action = Actions.UPDATE_COLUMN_POSITION_ACTION
+
+
+class MoveType(Enum):
+    FIRST = "FIRST"
+    AFTER = "AFTER"
+    BEFORE = "BEFORE"
+    LAST = "LAST"
+
+
+@dataclass
+class Move:
+    FIELD_FIELD_NAME = "fieldName"
+    FIELD_REFERENCE_FIELD_NAME = "referenceFieldName"
+    FIELD_TYPE = "type"
+
+    @staticmethod
+    def first(field_name: str) -> "Move":
+        return Move(field_name, None, MoveType.FIRST)
+
+    @staticmethod
+    def after(field_name: str, reference_field_name: str) -> "Move":
+        return Move(field_name, reference_field_name, MoveType.AFTER)
+
+    @staticmethod
+    def before(field_name: str, reference_field_name: str) -> "Move":
+        return Move(field_name, reference_field_name, MoveType.BEFORE)
+
+    @staticmethod
+    def last(field_name: str) -> "Move":
+        return Move(field_name, None, MoveType.LAST)
+
+    field_name: str = json_field(FIELD_FIELD_NAME)
+    reference_field_name: Optional[str] = json_field(FIELD_REFERENCE_FIELD_NAME)
+    type: MoveType = json_field(FIELD_TYPE)
+

--- a/paimon-python/pypaimon/schema/schema_change.py
+++ b/paimon-python/pypaimon/schema/schema_change.py
@@ -1,3 +1,19 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 from abc import ABC
 from dataclasses import dataclass
 from enum import Enum

--- a/paimon-python/pypaimon/schema/schema_manager.py
+++ b/paimon-python/pypaimon/schema/schema_manager.py
@@ -17,10 +17,149 @@
 ################################################################################
 from typing import Optional, List
 
+from pypaimon.catalog.catalog_exception import ColumnAlreadyExistException, ColumnNotExistException
 from pypaimon.common.file_io import FileIO
 from pypaimon.common.json_util import JSON
+from pypaimon.schema.data_types import AtomicInteger, DataField
 from pypaimon.schema.schema import Schema
+from pypaimon.schema.schema_change import (AddColumn, DropColumn, RemoveOption, RenameColumn,
+                                          SchemaChange, SetOption, UpdateColumnComment,
+                                          UpdateColumnNullability, UpdateColumnPosition,
+                                          UpdateColumnType, UpdateComment)
 from pypaimon.schema.table_schema import TableSchema
+
+
+def _find_field_index(fields: List[DataField], field_name: str) -> Optional[int]:
+    for i, field in enumerate(fields):
+        if field.name == field_name:
+            return i
+    return None
+
+
+def _get_rename_mappings(changes: List[SchemaChange]) -> dict:
+    rename_mappings = {}
+    for change in changes:
+        if isinstance(change, RenameColumn) and len(change.field_names) == 1:
+            rename_mappings[change.field_names[0]] = change.new_name
+    return rename_mappings
+
+
+def _handle_update_column_comment(
+        change: UpdateColumnComment, new_fields: List[DataField]
+):
+    field_name = change.field_names[-1]
+    field_index = _find_field_index(new_fields, field_name)
+    if field_index is None:
+        raise ColumnNotExistException(field_name)
+    field = new_fields[field_index]
+    new_fields[field_index] = DataField(
+        field.id, field.name, field.type, change.new_comment, field.default_value
+    )
+
+
+def _handle_update_column_nullability(
+        change: UpdateColumnNullability, new_fields: List[DataField]
+):
+    field_name = change.field_names[-1]
+    field_index = _find_field_index(new_fields, field_name)
+    if field_index is None:
+        raise ColumnNotExistException(field_name)
+    field = new_fields[field_index]
+    new_type = field.type
+    new_type.nullable = change.new_nullability
+    new_fields[field_index] = DataField(
+        field.id, field.name, new_type, field.description, field.default_value
+    )
+
+
+def _handle_update_column_type(
+        change: UpdateColumnType, new_fields: List[DataField]
+):
+    field_name = change.field_names[-1]
+    field_index = _find_field_index(new_fields, field_name)
+    if field_index is None:
+        raise ColumnNotExistException(field_name)
+    field = new_fields[field_index]
+    new_type = change.new_data_type
+    if change.keep_nullability:
+        new_type.nullable = field.type.nullable
+    new_fields[field_index] = DataField(
+        field.id, field.name, new_type, field.description, field.default_value
+    )
+
+
+def _handle_drop_column(change: DropColumn, new_fields: List[DataField]):
+    field_name = change.field_names[-1]
+    field_index = _find_field_index(new_fields, field_name)
+    if field_index is None:
+        raise ColumnNotExistException(field_name)
+    new_fields.pop(field_index)
+    if not new_fields:
+        raise ValueError("Cannot drop all fields in table")
+
+
+def _handle_rename_column(change: RenameColumn, new_fields: List[DataField]):
+    field_name = change.field_names[-1]
+    new_name = change.new_name
+    field_index = _find_field_index(new_fields, field_name)
+    if field_index is None:
+        raise ColumnNotExistException(field_name)
+    if _find_field_index(new_fields, new_name) is not None:
+        raise ColumnAlreadyExistException(new_name)
+    field = new_fields[field_index]
+    new_fields[field_index] = DataField(
+        field.id, new_name, field.type, field.description, field.default_value
+    )
+
+
+def _apply_move(fields: List[DataField], new_field: Optional[DataField], move):
+    from pypaimon.schema.schema_change import MoveType
+
+    if new_field:
+        pass
+    else:
+        field_name = move.field_name
+        new_field = None
+        for i, field in enumerate(fields):
+            if field.name == field_name:
+                new_field = fields.pop(i)
+                break
+        if new_field is None:
+            raise ColumnNotExistException(field_name)
+
+    field_map = {field.name: i for i, field in enumerate(fields)}
+    if move.type == MoveType.FIRST:
+        fields.insert(0, new_field)
+    elif move.type == MoveType.AFTER:
+        if move.reference_field_name not in field_map:
+            raise ColumnNotExistException(move.reference_field_name)
+        fields.insert(field_map[move.reference_field_name] + 1, new_field)
+    elif move.type == MoveType.BEFORE:
+        if move.reference_field_name not in field_map:
+            raise ColumnNotExistException(move.reference_field_name)
+        fields.insert(field_map[move.reference_field_name], new_field)
+    elif move.type == MoveType.LAST:
+        fields.append(new_field)
+    else:
+        raise ValueError(f"Unsupported move type: {move.type}")
+
+
+def _handle_add_column(
+        change: AddColumn, new_fields: List[DataField], highest_field_id: AtomicInteger
+):
+    if not change.data_type.nullable:
+        raise ValueError(
+            f"Column {'.'.join(change.field_names)} cannot specify NOT NULL in the table."
+        )
+    field_id = highest_field_id.increment_and_get()
+    field_name = change.field_names[-1]
+    if _find_field_index(new_fields, field_name) is not None:
+        raise ColumnAlreadyExistException(field_name)
+    new_field = DataField(field_id, field_name, change.data_type, change.comment)
+    if change.move:
+        _apply_move(new_fields, new_field, change.move)
+    else:
+        new_fields.append(new_field)
 
 
 class SchemaManager:
@@ -94,3 +233,104 @@ class SchemaManager:
                 except ValueError:
                     continue
         return versions
+
+    def commit_changes(self, old_table_schema: TableSchema, changes: List[SchemaChange]) -> TableSchema:
+        while True:
+            new_table_schema = self._generate_table_schema(old_table_schema, changes)
+            try:
+                success = self.commit(new_table_schema)
+                if success:
+                    return new_table_schema
+            except Exception as e:
+                raise RuntimeError(f"Failed to commit schema changes: {e}") from e
+
+    def _generate_table_schema(
+        self, old_table_schema: TableSchema, changes: List[SchemaChange]
+    ) -> TableSchema:
+        new_options = dict(old_table_schema.options)
+        new_fields = list(old_table_schema.fields)
+        highest_field_id = AtomicInteger(old_table_schema.highest_field_id)
+        new_comment = old_table_schema.comment
+
+        for change in changes:
+            if isinstance(change, SetOption):
+                new_options[change.key] = change.value
+            elif isinstance(change, RemoveOption):
+                new_options.pop(change.key, None)
+            elif isinstance(change, UpdateComment):
+                new_comment = change.comment
+            elif isinstance(change, AddColumn):
+                _handle_add_column(change, new_fields, highest_field_id)
+            elif isinstance(change, RenameColumn):
+                _handle_rename_column(change, new_fields)
+            elif isinstance(change, DropColumn):
+                _handle_drop_column(change, new_fields)
+            elif isinstance(change, UpdateColumnType):
+                _handle_update_column_type(change, new_fields)
+            elif isinstance(change, UpdateColumnNullability):
+                _handle_update_column_nullability(change, new_fields)
+            elif isinstance(change, UpdateColumnComment):
+                _handle_update_column_comment(change, new_fields)
+            elif isinstance(change, UpdateColumnPosition):
+                _apply_move(new_fields, None, change.move)
+            else:
+                raise NotImplementedError(f"Unsupported change: {type(change)}")
+
+        rename_mappings = _get_rename_mappings(changes)
+        new_primary_keys = SchemaManager._apply_not_nested_column_rename(
+            old_table_schema.primary_keys, rename_mappings
+        )
+        new_options = SchemaManager._apply_rename_columns_to_options(new_options, rename_mappings)
+
+        new_schema = Schema(
+            fields=new_fields,
+            partition_keys=old_table_schema.partition_keys,
+            primary_keys=new_primary_keys,
+            options=new_options,
+            comment=new_comment
+        )
+
+        return TableSchema(
+            version=old_table_schema.version,
+            id=old_table_schema.id + 1,
+            fields=new_schema.fields,
+            highest_field_id=highest_field_id.get(),
+            partition_keys=new_schema.partition_keys,
+            primary_keys=new_schema.primary_keys,
+            options=new_schema.options,
+            comment=new_schema.comment
+        )
+
+    @staticmethod
+    def _apply_not_nested_column_rename(
+        columns: List[str], rename_mappings: dict
+    ) -> List[str]:
+        return [rename_mappings.get(col, col) for col in columns]
+
+    @staticmethod
+    def _apply_rename_columns_to_options(
+        options: dict, rename_mappings: dict
+    ) -> dict:
+        if not rename_mappings:
+            return options
+        new_options = dict(options)
+        from pypaimon.common.options.core_options import CoreOptions
+
+        bucket_key = CoreOptions.BUCKET_KEY.key()
+        if bucket_key in new_options:
+            bucket_columns = new_options[bucket_key].split(",")
+            new_bucket_columns = SchemaManager._apply_not_nested_column_rename(
+                bucket_columns, rename_mappings
+            )
+            new_options[bucket_key] = ",".join(new_bucket_columns)
+
+        sequence_field = "sequence.field"
+        if sequence_field in new_options:
+            sequence_fields = new_options[sequence_field].split(",")
+            new_sequence_fields = SchemaManager._apply_not_nested_column_rename(
+                sequence_fields, rename_mappings
+            )
+            new_options[sequence_field] = ",".join(new_sequence_fields)
+
+        return new_options
+

--- a/paimon-python/pypaimon/schema/schema_manager.py
+++ b/paimon-python/pypaimon/schema/schema_manager.py
@@ -106,8 +106,6 @@ def _handle_drop_column(change: DropColumn, new_fields: List[DataField]):
 
 def _assert_not_updating_partition_keys(
         schema: 'TableSchema', field_names: List[str], operation: str):
-    """Assert that the operation is not updating partition keys."""
-    # partition keys can't be nested columns
     if len(field_names) > 1:
         return
     field_name = field_names[0]

--- a/paimon-python/pypaimon/tests/filesystem_catalog_test.py
+++ b/paimon-python/pypaimon/tests/filesystem_catalog_test.py
@@ -25,6 +25,7 @@ from pypaimon.catalog.catalog_exception import (DatabaseAlreadyExistException,
                                                 TableAlreadyExistException,
                                                 TableNotExistException)
 from pypaimon.schema.data_types import AtomicType, DataField
+from pypaimon.schema.schema_change import SchemaChange
 from pypaimon.table.file_store_table import FileStoreTable
 
 
@@ -85,3 +86,88 @@ class FileSystemCatalogTest(unittest.TestCase):
         self.assertEqual(table.fields[2].name, "f2")
         self.assertTrue(isinstance(table.fields[2].type, AtomicType))
         self.assertEqual(table.fields[2].type.type, "STRING")
+
+    def test_alter_table(self):
+        catalog = CatalogFactory.create({
+            "warehouse": self.warehouse
+        })
+        catalog.create_database("test_db", False)
+
+        identifier = "test_db.test_table"
+        schema = Schema(
+            fields=[
+                DataField.from_dict({"id": 0, "name": "col1", "type": "STRING", "description": "field1"}),
+                DataField.from_dict({"id": 1, "name": "col2", "type": "STRING", "description": "field2"})
+            ],
+            partition_keys=[],
+            primary_keys=[],
+            options={},
+            comment="comment"
+        )
+        catalog.create_table(identifier, schema, False)
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.add_column("col3", AtomicType("DATE"))],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertEqual(len(table.fields), 3)
+        self.assertEqual(table.fields[2].name, "col3")
+        self.assertEqual(table.fields[2].type.type, "DATE")
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.update_comment("new comment")],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertEqual(table.table_schema.comment, "new comment")
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.rename_column("col1", "new_col1")],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertEqual(table.fields[0].name, "new_col1")
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.update_column_type("col2", AtomicType("BIGINT"))],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertEqual(table.fields[1].type.type, "BIGINT")
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.update_column_comment("col2", "col2 field")],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertEqual(table.fields[1].description, "col2 field")
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.set_option("write-buffer-size", "256 MB")],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertEqual(table.table_schema.options.get("write-buffer-size"), "256 MB")
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.remove_option("write-buffer-size")],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertNotIn("write-buffer-size", table.table_schema.options)
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.drop_column("col3")],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertEqual(len(table.fields), 2)

--- a/paimon-python/pypaimon/tests/rest/rest_server.py
+++ b/paimon-python/pypaimon/tests/rest/rest_server.py
@@ -152,7 +152,7 @@ def _dict_to_schema_change(change_dict: dict) -> SchemaChange:
         return UpdateColumnType(
             field_names=change_dict["fieldNames"],
             new_data_type=new_type,
-            keep_nullability=change_dict.get("keepNullability", True)
+            keep_nullability=change_dict.get("keepNullability", False)
         )
     elif action == Actions.UPDATE_COLUMN_NULLABILITY_ACTION:
         return UpdateColumnNullability(

--- a/paimon-python/pypaimon/tests/rest/rest_server.py
+++ b/paimon-python/pypaimon/tests/rest/rest_server.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
-from pypaimon.api.api_request import (CreateDatabaseRequest,
+from pypaimon.api.api_request import (AlterTableRequest, CreateDatabaseRequest,
                                       CreateTableRequest, RenameTableRequest)
 from pypaimon.api.api_response import (ConfigResponse, GetDatabaseResponse,
                                        GetTableResponse, ListDatabasesResponse,
@@ -44,6 +44,8 @@ from pypaimon.catalog.rest.table_metadata import TableMetadata
 from pypaimon.common.identifier import Identifier
 from pypaimon.common.json_util import JSON
 from pypaimon import Schema
+from pypaimon.schema.schema_change import Actions, SchemaChange
+from pypaimon.schema.schema_manager import SchemaManager
 from pypaimon.schema.table_schema import TableSchema
 
 
@@ -89,6 +91,103 @@ SNAPSHOT_CLEAN_EMPTY_DIRECTORIES = "snapshot.clean-empty-directories"
 # Table types
 FORMAT_TABLE = "FORMAT_TABLE"
 OBJECT_TABLE = "OBJECT_TABLE"
+
+
+def _dict_to_schema_change(change_dict: dict) -> SchemaChange:
+    from pypaimon.schema.schema_change import (
+        SetOption, RemoveOption, UpdateComment, AddColumn, RenameColumn,
+        DropColumn, UpdateColumnType, UpdateColumnNullability,
+        UpdateColumnComment, UpdateColumnDefaultValue, UpdateColumnPosition, Move, MoveType
+    )
+
+    action = change_dict.get(Actions.FIELD_ACTION)
+    if action == Actions.SET_OPTION_ACTION:
+        return SetOption(key=change_dict["key"], value=change_dict["value"])
+    elif action == Actions.REMOVE_OPTION_ACTION:
+        return RemoveOption(key=change_dict["key"])
+    elif action == Actions.UPDATE_COMMENT_ACTION:
+        return UpdateComment(comment=change_dict.get("comment"))
+    elif action == Actions.ADD_COLUMN_ACTION:
+        from pypaimon.schema.data_types import DataTypeParser
+        # JSON field name is "dataType" (from FIELD_DATA_TYPE)
+        data_type_value = change_dict.get("dataType") or change_dict.get(AddColumn.FIELD_DATA_TYPE)
+        if data_type_value is None:
+            raise ValueError(f"Missing dataType field in AddColumn change: {change_dict}")
+        # dataType might be a dict (if DataType.to_dict() was called) or a string
+        data_type = DataTypeParser.parse_data_type(data_type_value)
+        move = None
+        if "move" in change_dict and change_dict["move"] is not None:
+            move_dict = change_dict["move"]
+            if isinstance(move_dict, dict):
+                move_type_str = move_dict.get("type") or move_dict.get(Move.FIELD_TYPE)
+                if move_type_str is None:
+                    raise ValueError(f"Missing type field in Move: {move_dict}")
+                move_type = MoveType(move_type_str)
+                field_name = move_dict.get("fieldName") or move_dict.get(Move.FIELD_FIELD_NAME)
+                if field_name is None:
+                    raise ValueError(f"Missing fieldName field in Move: {move_dict}")
+                move = Move(
+                    field_name=field_name,
+                    reference_field_name=move_dict.get("referenceFieldName") or move_dict.get(Move.FIELD_REFERENCE_FIELD_NAME),
+                    type=move_type
+                )
+        field_names = change_dict.get("fieldNames") or change_dict.get(AddColumn.FIELD_FIELD_NAMES)
+        if field_names is None:
+            raise ValueError(f"Missing fieldNames field in AddColumn change: {change_dict}")
+        return AddColumn(
+            field_names=field_names,
+            data_type=data_type,
+            comment=change_dict.get("comment") or change_dict.get(AddColumn.FIELD_COMMENT),
+            move=move
+        )
+    elif action == Actions.RENAME_COLUMN_ACTION:
+        return RenameColumn(field_names=change_dict["fieldNames"], new_name=change_dict["newName"])
+    elif action == Actions.DROP_COLUMN_ACTION:
+        return DropColumn(field_names=change_dict["fieldNames"])
+    elif action == Actions.UPDATE_COLUMN_TYPE_ACTION:
+        from pypaimon.schema.data_types import DataTypeParser
+        new_type = DataTypeParser.parse_data_type(change_dict["newDataType"])
+        return UpdateColumnType(
+            field_names=change_dict["fieldNames"],
+            new_data_type=new_type,
+            keep_nullability=change_dict.get("keepNullability", True)
+        )
+    elif action == Actions.UPDATE_COLUMN_NULLABILITY_ACTION:
+        return UpdateColumnNullability(
+            field_names=change_dict["fieldNames"],
+            new_nullability=change_dict["newNullability"]
+        )
+    elif action == Actions.UPDATE_COLUMN_COMMENT_ACTION:
+        return UpdateColumnComment(
+            field_names=change_dict["fieldNames"],
+            new_comment=change_dict.get("newComment")
+        )
+    elif action == Actions.UPDATE_COLUMN_DEFAULT_VALUE_ACTION:
+        return UpdateColumnDefaultValue(
+            field_names=change_dict["fieldNames"],
+            new_default_value=change_dict["newDefaultValue"]
+        )
+    elif action == Actions.UPDATE_COLUMN_POSITION_ACTION:
+        move_dict = change_dict.get("move") or change_dict.get(UpdateColumnPosition.FIELD_MOVE)
+        if move_dict is None:
+            raise ValueError(f"Missing move field in UpdateColumnPosition change: {change_dict}")
+        if not isinstance(move_dict, dict):
+            raise ValueError(f"move field must be a dict in UpdateColumnPosition change: {change_dict}")
+        move_type_str = move_dict.get("type") or move_dict.get(Move.FIELD_TYPE)
+        if move_type_str is None:
+            raise ValueError(f"Missing type field in Move: {move_dict}")
+        move_type = MoveType(move_type_str)
+        field_name = move_dict.get("fieldName") or move_dict.get(Move.FIELD_FIELD_NAME)
+        if field_name is None:
+            raise ValueError(f"Missing fieldName field in Move: {move_dict}")
+        move = Move(
+            field_name=field_name,
+            reference_field_name=move_dict.get("referenceFieldName") or move_dict.get(Move.FIELD_REFERENCE_FIELD_NAME),
+            type=move_type
+        )
+        return UpdateColumnPosition(move=move)
+    else:
+        raise ValueError(f"Unknown schema change action: {action}")
 
 
 class RESTCatalogServer:
@@ -453,13 +552,11 @@ class RESTCatalogServer:
             schema = table_metadata.schema.to_schema()
             response = self.mock_table(identifier, table_metadata, table_path, schema)
             return self._mock_response(response, 200)
-        #
-        # elif method == "POST":
-        #     # Alter table
-        #     request_body = JSON.from_json(data, AlterTableRequest)
-        #     self._alter_table_impl(identifier, request_body.get_changes())
-        #     return self._mock_response("", 200)
-
+        elif method == "POST":
+            # Alter table
+            request_body = JSON.from_json(data, AlterTableRequest)
+            self._alter_table_impl(identifier, request_body.changes)
+            return self._mock_response("", 200)
         elif method == "DELETE":
             # Drop table
             if identifier.get_full_name() not in self.table_metadata_store:
@@ -664,6 +761,43 @@ class RESTCatalogServer:
                 regex.append(re.escape(char))
 
         return '^' + ''.join(regex) + '$'
+
+    def _alter_table_impl(self, identifier: Identifier, changes: List) -> None:
+        if identifier.get_full_name() not in self.table_metadata_store:
+            raise TableNotExistException(identifier)
+
+        schema_changes = []
+        for change in changes:
+            if isinstance(change, dict):
+                try:
+                    schema_changes.append(_dict_to_schema_change(change))
+                except (KeyError, TypeError) as e:
+                    raise ValueError(f"Failed to convert change dict to SchemaChange: {change}, error: {e}") from e
+            else:
+                schema_changes.append(change)
+
+        table_metadata = self.table_metadata_store[identifier.get_full_name()]
+        old_schema = table_metadata.schema
+
+        table_path = Path(self.data_path) / self.warehouse / identifier.get_database_name() / identifier.get_object_name()
+        schema_manager = SchemaManager(self._get_file_io(), str(table_path))
+        new_schema = schema_manager.commit_changes(old_schema, schema_changes)
+        schema_manager.commit(new_schema)
+
+        updated_metadata = TableMetadata(
+            schema=new_schema,
+            is_external=table_metadata.is_external,
+            uuid=table_metadata.uuid
+        )
+        self.table_metadata_store[identifier.get_full_name()] = updated_metadata
+
+    def _get_file_io(self):
+        """Get FileIO instance for SchemaManager"""
+        from pypaimon.common.file_io import FileIO
+        from pypaimon.common.options import Options
+        warehouse_path = str(Path(self.data_path) / self.warehouse)
+        options = Options({"warehouse": warehouse_path})
+        return FileIO(warehouse_path, options)
 
     def _create_table_metadata(self, identifier: Identifier, schema_id: int,
                                schema: Schema, uuid_str: str, is_external: bool) -> TableMetadata:

--- a/paimon-python/pypaimon/tests/rest/rest_server.py
+++ b/paimon-python/pypaimon/tests/rest/rest_server.py
@@ -109,11 +109,9 @@ def _dict_to_schema_change(change_dict: dict) -> SchemaChange:
         return UpdateComment(comment=change_dict.get("comment"))
     elif action == Actions.ADD_COLUMN_ACTION:
         from pypaimon.schema.data_types import DataTypeParser
-        # JSON field name is "dataType" (from FIELD_DATA_TYPE)
         data_type_value = change_dict.get("dataType") or change_dict.get(AddColumn.FIELD_DATA_TYPE)
         if data_type_value is None:
             raise ValueError(f"Missing dataType field in AddColumn change: {change_dict}")
-        # dataType might be a dict (if DataType.to_dict() was called) or a string
         data_type = DataTypeParser.parse_data_type(data_type_value)
         move = None
         if "move" in change_dict and change_dict["move"] is not None:

--- a/paimon-python/pypaimon/tests/rest/rest_simple_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_simple_test.py
@@ -21,6 +21,8 @@ import pyarrow as pa
 from pypaimon import Schema
 from pypaimon.catalog.catalog_exception import DatabaseAlreadyExistException, TableAlreadyExistException, \
     DatabaseNotExistException, TableNotExistException
+from pypaimon.schema.data_types import AtomicType, DataField
+from pypaimon.schema.schema_change import SchemaChange
 from pypaimon.tests.rest.rest_base_test import RESTBaseTest
 from pypaimon.write.row_key_extractor import FixedBucketRowKeyExtractor, DynamicBucketRowKeyExtractor, \
     UnawareBucketRowKeyExtractor
@@ -710,3 +712,91 @@ class RESTSimpleTest(RESTBaseTest):
             self.rest_catalog.drop_database("db1", True)
         except DatabaseNotExistException:
             self.fail("drop_database with ignore_if_not_exists=True should not raise DatabaseNotExistException")
+
+    def test_alter_table(self):
+        catalog = self.rest_catalog
+        catalog.create_database("test_db_alter", True)
+
+        identifier = "test_db_alter.test_table"
+        schema = Schema(
+            fields=[
+                DataField.from_dict({"id": 0, "name": "col1", "type": "STRING", "description": "field1"}),
+                DataField.from_dict({"id": 1, "name": "col2", "type": "STRING", "description": "field2"})
+            ],
+            partition_keys=[],
+            primary_keys=[],
+            options={},
+            comment="comment"
+        )
+        catalog.create_table(identifier, schema, False)
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.add_column("col3", AtomicType("DATE"))],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertEqual(len(table.fields), 3)
+        self.assertEqual(table.fields[2].name, "col3")
+        self.assertEqual(table.fields[2].type.type, "DATE")
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.update_comment("new comment")],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertEqual(table.table_schema.comment, "new comment")
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.rename_column("col1", "new_col1")],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertEqual(table.fields[0].name, "new_col1")
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.update_column_type("col2", AtomicType("BIGINT"))],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertEqual(table.fields[1].type.type, "BIGINT")
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.update_column_comment("col2", "col2 field")],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertEqual(table.fields[1].description, "col2 field")
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.set_option("write-buffer-size", "256 MB")],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertEqual(table.table_schema.options.get("write-buffer-size"), "256 MB")
+
+        catalog.alter_table(
+            identifier,
+            [SchemaChange.remove_option("write-buffer-size")],
+            False
+        )
+        table = catalog.get_table(identifier)
+        self.assertNotIn("write-buffer-size", table.table_schema.options)
+
+        with self.assertRaises(TableNotExistException):
+            catalog.alter_table(
+                "test_db_alter.non_existing_table",
+                [SchemaChange.add_column("col2", AtomicType("INT"))],
+                False
+            )
+
+        catalog.alter_table(
+            "test_db_alter.non_existing_table",
+            [SchemaChange.add_column("col2", AtomicType("INT"))],
+            True
+        )


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Python-side table schema evolution through a new `alter_table` API.
> 
> - Introduces `SchemaChange` (add/rename/drop/update columns, nullability/comment, set/remove options) and `SchemaManager.commit_changes` to apply changes
> - Extends `Catalog` with `alter_table`; implements in `FileSystemCatalog` and `RESTCatalog`
> - Adds REST support: `AlterTableRequest`, `RESTApi.alter_table`, and mock REST server POST handling to mutate table schema
> - Updates docs with an "Alter Table" section and lists schema evolution under supported features
> - Adds unit tests for both filesystem and REST catalogs covering add/rename/drop column, type/comment updates, and options changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 197ae55ce4f9e1c3ae7e2f39017a88ebd20e4162. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->