### PR TITLE
[python] Fix IndexError when reading manifest with empty _MIN_VALUES

### DIFF
--- a/paimon-python/pypaimon/table/row/binary_row.py
+++ b/paimon-python/pypaimon/table/row/binary_row.py
@@ -31,11 +31,19 @@ class BinaryRow(InternalRow):
         Initialize BinaryRow with raw binary data and field definitions.
         """
         self.data = data
-        self.arity = int.from_bytes(data[:4], 'big')
-        # Skip the arity prefix (4 bytes) if present
-        self.actual_data = data[4:] if len(data) >= 4 else data
+        if len(data) < 4:
+            self.arity = 0
+            self.actual_data = b''
+        else:
+            self.arity = int.from_bytes(data[:4], 'big')
+            self.actual_data = data[4:] if len(data) >= 4 else data
+        
         self.fields = fields
-        self.row_kind = RowKind(self.actual_data[0])
+        
+        if len(self.actual_data) == 0:
+            self.row_kind = RowKind.INSERT
+        else:
+            self.row_kind = RowKind(self.actual_data[0])
 
     def get_field(self, index: int) -> Any:
         from pypaimon.table.row.generic_row import GenericRowDeserializer

--- a/paimon-python/pypaimon/tests/reader_base_test.py
+++ b/paimon-python/pypaimon/tests/reader_base_test.py
@@ -249,6 +249,19 @@ class ReaderBasicTest(unittest.TestCase):
                                                                 []).values
             self.assertEqual(min_value_stats, [])
             self.assertEqual(max_value_stats, [])
+            
+            self.assertGreater(len(manifest_entries[0].file.value_stats.min_values.data), 0,
+                              "MIN_VALUES.data should have bytes written, not empty (0 bytes)")
+            self.assertGreaterEqual(len(manifest_entries[0].file.value_stats.min_values.data), 12,
+                                   f"MIN_VALUES.data should be at least 12 bytes "
+                                   f"(4 bytes arity + 8 bytes fixed part for empty GenericRow), "
+                                   f"but got {len(manifest_entries[0].file.value_stats.min_values.data)} bytes")
+            self.assertGreater(len(manifest_entries[0].file.value_stats.max_values.data), 0,
+                              "MAX_VALUES.data should have bytes written, not empty (0 bytes)")
+            self.assertGreaterEqual(len(manifest_entries[0].file.value_stats.max_values.data), 12,
+                                   f"MAX_VALUES.data should be at least 12 bytes "
+                                   f"(4 bytes arity + 8 bytes fixed part for empty GenericRow), "
+                                   f"but got {len(manifest_entries[0].file.value_stats.max_values.data)} bytes")
 
     def test_write_wrong_schema(self):
         self.catalog.create_table('default.test_wrong_schema',
@@ -623,6 +636,22 @@ class ReaderBasicTest(unittest.TestCase):
             len(file_meta.value_stats.null_counts), len(empty_stats.null_counts),
             "value_stats.null_counts should be empty (same as SimpleStats.empty_stats()) when stats are disabled"
         )
+        
+        # 验证Python确实写入了字节数，而不是空的MIN_VALUES
+        # 即使min_values是empty (GenericRow([], []))，Python也应该序列化为12字节
+        # (4字节arity + 8字节fixed part)，而不是0字节或4字节
+        self.assertGreater(len(file_meta.value_stats.min_values.data), 0,
+                          "MIN_VALUES.data should have bytes written, not empty (0 bytes)")
+        self.assertGreaterEqual(len(file_meta.value_stats.min_values.data), 12,
+                               f"MIN_VALUES.data should be at least 12 bytes "
+                               f"(4 bytes arity + 8 bytes fixed part for empty GenericRow), "
+                               f"but got {len(file_meta.value_stats.min_values.data)} bytes")
+        self.assertGreater(len(file_meta.value_stats.max_values.data), 0,
+                          "MAX_VALUES.data should have bytes written, not empty (0 bytes)")
+        self.assertGreaterEqual(len(file_meta.value_stats.max_values.data), 12,
+                               f"MAX_VALUES.data should be at least 12 bytes "
+                               f"(4 bytes arity + 8 bytes fixed part for empty GenericRow), "
+                               f"but got {len(file_meta.value_stats.max_values.data)} bytes")
 
     def test_types(self):
         data_fields = [

--- a/paimon-python/pypaimon/tests/reader_base_test.py
+++ b/paimon-python/pypaimon/tests/reader_base_test.py
@@ -250,18 +250,22 @@ class ReaderBasicTest(unittest.TestCase):
             self.assertEqual(min_value_stats, [])
             self.assertEqual(max_value_stats, [])
             
-            self.assertGreater(len(manifest_entries[0].file.value_stats.min_values.data), 0,
-                              "MIN_VALUES.data should have bytes written, not empty (0 bytes)")
-            self.assertGreaterEqual(len(manifest_entries[0].file.value_stats.min_values.data), 12,
-                                   f"MIN_VALUES.data should be at least 12 bytes "
-                                   f"(4 bytes arity + 8 bytes fixed part for empty GenericRow), "
-                                   f"but got {len(manifest_entries[0].file.value_stats.min_values.data)} bytes")
-            self.assertGreater(len(manifest_entries[0].file.value_stats.max_values.data), 0,
-                              "MAX_VALUES.data should have bytes written, not empty (0 bytes)")
-            self.assertGreaterEqual(len(manifest_entries[0].file.value_stats.max_values.data), 12,
-                                   f"MAX_VALUES.data should be at least 12 bytes "
-                                   f"(4 bytes arity + 8 bytes fixed part for empty GenericRow), "
-                                   f"but got {len(manifest_entries[0].file.value_stats.max_values.data)} bytes")
+            self.assertGreater(
+                len(manifest_entries[0].file.value_stats.min_values.data), 0,
+                "MIN_VALUES.data should have bytes written, not empty (0 bytes)")
+            self.assertGreaterEqual(
+                len(manifest_entries[0].file.value_stats.min_values.data), 12,
+                f"MIN_VALUES.data should be at least 12 bytes "
+                f"(4 bytes arity + 8 bytes fixed part for empty GenericRow), "
+                f"but got {len(manifest_entries[0].file.value_stats.min_values.data)} bytes")
+            self.assertGreater(
+                len(manifest_entries[0].file.value_stats.max_values.data), 0,
+                "MAX_VALUES.data should have bytes written, not empty (0 bytes)")
+            self.assertGreaterEqual(
+                len(manifest_entries[0].file.value_stats.max_values.data), 12,
+                f"MAX_VALUES.data should be at least 12 bytes "
+                f"(4 bytes arity + 8 bytes fixed part for empty GenericRow), "
+                f"but got {len(manifest_entries[0].file.value_stats.max_values.data)} bytes")
 
     def test_write_wrong_schema(self):
         self.catalog.create_table('default.test_wrong_schema',
@@ -640,18 +644,22 @@ class ReaderBasicTest(unittest.TestCase):
         # 验证Python确实写入了字节数，而不是空的MIN_VALUES
         # 即使min_values是empty (GenericRow([], []))，Python也应该序列化为12字节
         # (4字节arity + 8字节fixed part)，而不是0字节或4字节
-        self.assertGreater(len(file_meta.value_stats.min_values.data), 0,
-                          "MIN_VALUES.data should have bytes written, not empty (0 bytes)")
-        self.assertGreaterEqual(len(file_meta.value_stats.min_values.data), 12,
-                               f"MIN_VALUES.data should be at least 12 bytes "
-                               f"(4 bytes arity + 8 bytes fixed part for empty GenericRow), "
-                               f"but got {len(file_meta.value_stats.min_values.data)} bytes")
-        self.assertGreater(len(file_meta.value_stats.max_values.data), 0,
-                          "MAX_VALUES.data should have bytes written, not empty (0 bytes)")
-        self.assertGreaterEqual(len(file_meta.value_stats.max_values.data), 12,
-                               f"MAX_VALUES.data should be at least 12 bytes "
-                               f"(4 bytes arity + 8 bytes fixed part for empty GenericRow), "
-                               f"but got {len(file_meta.value_stats.max_values.data)} bytes")
+        self.assertGreater(
+            len(file_meta.value_stats.min_values.data), 0,
+            "MIN_VALUES.data should have bytes written, not empty (0 bytes)")
+        self.assertGreaterEqual(
+            len(file_meta.value_stats.min_values.data), 12,
+            f"MIN_VALUES.data should be at least 12 bytes "
+            f"(4 bytes arity + 8 bytes fixed part for empty GenericRow), "
+            f"but got {len(file_meta.value_stats.min_values.data)} bytes")
+        self.assertGreater(
+            len(file_meta.value_stats.max_values.data), 0,
+            "MAX_VALUES.data should have bytes written, not empty (0 bytes)")
+        self.assertGreaterEqual(
+            len(file_meta.value_stats.max_values.data), 12,
+            f"MAX_VALUES.data should be at least 12 bytes "
+            f"(4 bytes arity + 8 bytes fixed part for empty GenericRow), "
+            f"but got {len(file_meta.value_stats.max_values.data)} bytes")
 
     def test_types(self):
         data_fields = [


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses failures when manifests contain empty value stats.
> 
> - Update `BinaryRow.__init__` to handle `len(data) < 4` and empty `actual_data`, defaulting `arity=0` and `row_kind=INSERT` instead of indexing into empty bytes
> - Add `BinaryRowTest.test_binary_row_with_empty_actual_data` covering empty bytes, zero-arity header, and zero-arity with fixed part
> - Strengthen `ReaderBasicTest` to assert serialized empty `GenericRow` stats (`min_values`/`max_values`) have bytes (≥12) even when stats are disabled, ensuring deserialization doesn’t crash
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5990ff4f29c3f52d3e4e6864c76ccf513bb5d884. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->