### PR TITLE
[core] Fix field ID mismatch in AllTablesTable, AllPartitionsTable an…

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AllPartitionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AllPartitionsTable.java
@@ -213,10 +213,7 @@ public class AllPartitionsTable implements ReadonlyTable {
                 iterator =
                         Iterators.transform(
                                 iterator,
-                                row ->
-                                        ProjectedRow.from(
-                                                        readType, AggregationFieldsTable.TABLE_TYPE)
-                                                .replaceRow(row));
+                                row -> ProjectedRow.from(readType, TABLE_TYPE).replaceRow(row));
             }
             //noinspection ReassignedVariable,unchecked
             return new IteratorRecordReader<>((Iterator<InternalRow>) iterator);

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AllTableOptionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AllTableOptionsTable.java
@@ -206,10 +206,7 @@ public class AllTableOptionsTable implements ReadonlyTable {
                 iterator =
                         Iterators.transform(
                                 iterator,
-                                row ->
-                                        ProjectedRow.from(
-                                                        readType, AggregationFieldsTable.TABLE_TYPE)
-                                                .replaceRow(row));
+                                row -> ProjectedRow.from(readType, TABLE_TYPE).replaceRow(row));
             }
             return new IteratorRecordReader<>(iterator);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AllTablesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AllTablesTable.java
@@ -233,10 +233,7 @@ public class AllTablesTable implements ReadonlyTable {
                 iterator =
                         Iterators.transform(
                                 iterator,
-                                row ->
-                                        ProjectedRow.from(
-                                                        readType, AggregationFieldsTable.TABLE_TYPE)
-                                                .replaceRow(row));
+                                row -> ProjectedRow.from(readType, TABLE_TYPE).replaceRow(row));
             }
             //noinspection ReassignedVariable,unchecked
             return new IteratorRecordReader<>((Iterator<InternalRow>) iterator);

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/AllTablesTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/AllTablesTableTest.java
@@ -19,9 +19,15 @@
 package org.apache.paimon.table.system;
 
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.ReadonlyTable;
 import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +38,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.paimon.catalog.Catalog.SYSTEM_DATABASE_NAME;
 import static org.apache.paimon.table.system.AllTablesTable.ALL_TABLES;
+import static org.apache.paimon.table.system.AllTablesTable.TABLE_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for {@link AllTablesTable}. */
@@ -63,5 +70,31 @@ public class AllTablesTableTest extends TableTestBase {
         assertThat(result)
                 .containsOnly(
                         "+I(default,T,table,true,true,null,null,null,null,null,null,null,null,null)");
+    }
+
+    @Test
+    void testAllTablesTableWithOwnerField() throws Exception {
+        ReadonlyTable table = allTablesTable;
+
+        RowType readType =
+                new RowType(
+                        java.util.Arrays.asList(
+                                TABLE_TYPE.getField(0), // database_name
+                                TABLE_TYPE.getField(1), // table_name
+                                TABLE_TYPE.getField(5))); // owner (field ID 5)
+
+        InnerTableScan scan = table.newScan();
+        InnerTableRead read = table.newRead().withReadType(readType);
+
+        List<InternalRow> rows = new java.util.ArrayList<>();
+        try (RecordReader<InternalRow> reader = read.createReader(scan.plan())) {
+            reader.forEachRemaining(rows::add);
+        }
+
+        assertThat(rows).isNotEmpty();
+        for (InternalRow row : rows) {
+            assertThat(row.getFieldCount()).isEqualTo(3);
+            assertThat(row.isNullAt(2) || row.getString(2) != null).isTrue();
+        }
     }
 }


### PR DESCRIPTION
…d AllTableOptionsTable

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves field ID/schema mismatch during projected reads for system tables.
> 
> - Replace `ProjectedRow.from(readType, AggregationFieldsTable.TABLE_TYPE)` with `ProjectedRow.from(readType, TABLE_TYPE)` in `AllTablesTable`, `AllPartitionsTable`, and `AllTableOptionsTable`
> - Add projection-focused unit tests verifying subset column reads and field counts in `AllTablesTableTest`, `AllPartitionsTableTest`, and `AllTableOptionsTableTest`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c944e30a33b7e4a47c4e86892047c4ef9847f60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->