### PR TITLE
[python] Fix KeyError when reading manifest files without _VALUE_STAT…

### DIFF
--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -160,7 +160,8 @@ class ManifestFileManager:
         return entries
 
     def _get_value_stats_fields(self, file_dict: dict, schema_fields: list) -> List:
-        if file_dict['_VALUE_STATS_COLS'] is None:
+        value_stats_cols = file_dict.get('_VALUE_STATS_COLS')
+        if value_stats_cols is None:
             if '_WRITE_COLS' in file_dict:
                 if file_dict['_WRITE_COLS'] is None:
                     fields = schema_fields
@@ -169,10 +170,10 @@ class ManifestFileManager:
                     fields = [self.table.field_dict[col] for col in read_fields]
             else:
                 fields = schema_fields
-        elif not file_dict['_VALUE_STATS_COLS']:
+        elif not value_stats_cols:
             fields = []
         else:
-            fields = [self.table.field_dict[col] for col in file_dict['_VALUE_STATS_COLS']]
+            fields = [self.table.field_dict[col] for col in value_stats_cols]
         return fields
 
     def write(self, file_name, entries: List[ManifestEntry]):


### PR DESCRIPTION
…S_COLS field

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix**
> 
> - Update `ManifestFileManager._get_value_stats_fields` to use `file_dict.get('_VALUE_STATS_COLS')`, safely handling missing field and avoiding `KeyError`.
> 
> **Tests**
> 
> - Extend `reader_base_test` to cover `_VALUE_STATS_COLS` being `None`, empty, specific, and entirely missing (simulated old manifests), asserting read behavior and backward compatibility.
> - Add verification that manifests written with `value_stats_cols=None` still include the `_VALUE_STATS_COLS` field (with `None`) to prevent fastavro omission.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4c2f773b65fa4d8ff783f24c96e00f8a9e8c11a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->