### PR TITLE
[python] fix default compression format

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -97,7 +97,7 @@ jobs:
           else
             python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu
-            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.48.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0
+            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.48.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0
           fi
           df -h
       - name: Run lint-python.sh
@@ -177,6 +177,7 @@ jobs:
             duckdb==1.3.2 \
             numpy==1.24.3 \
             pandas==2.0.3 \
+            cramjam \
             pytest~=7.0 \
             py4j==0.10.9.9 \
             requests \

--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -38,4 +38,8 @@ pyroaring
 ray>=2.10,<3
 readerwriterlock>=1,<2
 torch
-zstandard>=0.19,<1
+zstandard>=0.19,<1; python_version<"3.9"
+zstandard>=0.19,<1; python_version>="3.9"
+cramjam>=0.6,<1; python_version>="3.7"
+pylance>=0.20,<1; python_version>="3.9"
+pylance>=0.10,<1; python_version>="3.8" and python_version<"3.9"

--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -38,8 +38,5 @@ pyroaring
 ray>=2.10,<3
 readerwriterlock>=1,<2
 torch
-zstandard>=0.19,<1; python_version<"3.9"
-zstandard>=0.19,<1; python_version>="3.9"
+zstandard>=0.19,<1
 cramjam>=0.6,<1; python_version>="3.7"
-pylance>=0.20,<1; python_version>="3.9"
-pylance>=0.10,<1; python_version>="3.8" and python_version<"3.9"

--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -369,7 +369,7 @@ class FileIO:
 
         return None
 
-    def write_parquet(self, path: str, data: pyarrow.Table, compression: str = 'snappy', **kwargs):
+    def write_parquet(self, path: str, data: pyarrow.Table, compression: str = 'zstd', **kwargs):
         try:
             import pyarrow.parquet as pq
 
@@ -402,7 +402,7 @@ class FileIO:
             self.delete_quietly(path)
             raise RuntimeError(f"Failed to write ORC file {path}: {e}") from e
 
-    def write_avro(self, path: str, data: pyarrow.Table, avro_schema: Optional[Dict[str, Any]] = None, **kwargs):
+    def write_avro(self, path: str, data: pyarrow.Table, avro_schema: Optional[Dict[str, Any]] = None, compression: str = 'zstd', **kwargs):
         import fastavro
         if avro_schema is None:
             from pypaimon.schema.data_types import PyarrowFieldParser
@@ -417,8 +417,26 @@ class FileIO:
 
         records = record_generator()
 
+        codec_map = {
+            'null': 'null',
+            'deflate': 'deflate',
+            'snappy': 'snappy',
+            'bzip2': 'bzip2',
+            'xz': 'xz',
+            'zstandard': 'zstandard',
+            'zstd': 'zstandard',  # zstd is commonly used in Paimon
+        }
+        compression_lower = compression.lower()
+        
+        codec = codec_map.get(compression_lower)
+        if codec is None:
+            raise ValueError(
+                f"Unsupported compression '{compression}' for Avro format. "
+                f"Supported compressions: {', '.join(sorted(codec_map.keys()))}."
+            )
+
         with self.new_output_stream(path) as output_stream:
-            fastavro.writer(output_stream, avro_schema, records, **kwargs)
+            fastavro.writer(output_stream, avro_schema, records, codec=codec, **kwargs)
 
     def write_lance(self, path: str, data: pyarrow.Table, **kwargs):
         try:

--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -402,7 +402,10 @@ class FileIO:
             self.delete_quietly(path)
             raise RuntimeError(f"Failed to write ORC file {path}: {e}") from e
 
-    def write_avro(self, path: str, data: pyarrow.Table, avro_schema: Optional[Dict[str, Any]] = None, compression: str = 'zstd', **kwargs):
+    def write_avro(
+            self, path: str, data: pyarrow.Table,
+            avro_schema: Optional[Dict[str, Any]] = None,
+            compression: str = 'zstd', **kwargs):
         import fastavro
         if avro_schema is None:
             from pypaimon.schema.data_types import PyarrowFieldParser

--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -369,8 +369,8 @@ class FileIO:
 
         return None
 
-    def write_parquet(self, path: str, data: pyarrow.Table, compression: str = 'zstd', 
-                     zstd_level: int = 1, **kwargs):
+    def write_parquet(self, path: str, data: pyarrow.Table, compression: str = 'zstd',
+                      zstd_level: int = 1, **kwargs):
         try:
             import pyarrow.parquet as pq
 
@@ -383,8 +383,8 @@ class FileIO:
             self.delete_quietly(path)
             raise RuntimeError(f"Failed to write Parquet file {path}: {e}") from e
 
-    def write_orc(self, path: str, data: pyarrow.Table, compression: str = 'zstd', 
-                 zstd_level: int = 1, **kwargs):
+    def write_orc(self, path: str, data: pyarrow.Table, compression: str = 'zstd',
+                  zstd_level: int = 1, **kwargs):
         try:
             """Write ORC file using PyArrow ORC writer.
             

--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -369,20 +369,30 @@ class FileIO:
 
         return None
 
-    def write_parquet(self, path: str, data: pyarrow.Table, compression: str = 'zstd', **kwargs):
+    def write_parquet(self, path: str, data: pyarrow.Table, compression: str = 'zstd', 
+                     zstd_level: int = 1, **kwargs):
         try:
             import pyarrow.parquet as pq
 
             with self.new_output_stream(path) as output_stream:
+                if compression.lower() == 'zstd':
+                    kwargs['compression_level'] = zstd_level
                 pq.write_table(data, output_stream, compression=compression, **kwargs)
 
         except Exception as e:
             self.delete_quietly(path)
             raise RuntimeError(f"Failed to write Parquet file {path}: {e}") from e
 
-    def write_orc(self, path: str, data: pyarrow.Table, compression: str = 'zstd', **kwargs):
+    def write_orc(self, path: str, data: pyarrow.Table, compression: str = 'zstd', 
+                 zstd_level: int = 1, **kwargs):
         try:
-            """Write ORC file using PyArrow ORC writer."""
+            """Write ORC file using PyArrow ORC writer.
+            
+            Note: PyArrow's ORC writer doesn't support compression_level parameter.
+            ORC files will use zstd compression with default level
+            (which is 3, see https://github.com/facebook/zstd/blob/dev/programs/zstdcli.c)
+            instead of the specified level.
+            """
             import sys
             import pyarrow.orc as orc
 
@@ -405,7 +415,7 @@ class FileIO:
     def write_avro(
             self, path: str, data: pyarrow.Table,
             avro_schema: Optional[Dict[str, Any]] = None,
-            compression: str = 'zstd', **kwargs):
+            compression: str = 'zstd', zstd_level: int = 1, **kwargs):
         import fastavro
         if avro_schema is None:
             from pypaimon.schema.data_types import PyarrowFieldParser
@@ -439,6 +449,8 @@ class FileIO:
             )
 
         with self.new_output_stream(path) as output_stream:
+            if codec == 'zstandard':
+                kwargs['codec_compression_level'] = zstd_level
             fastavro.writer(output_stream, avro_schema, records, codec=codec, **kwargs)
 
     def write_lance(self, path: str, data: pyarrow.Table, **kwargs):

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -129,6 +129,16 @@ class CoreOptions:
         .with_description("Default file compression format. For faster read and write, it is recommended to use zstd.")
     )
 
+    FILE_COMPRESSION_ZSTD_LEVEL: ConfigOption[int] = (
+        ConfigOptions.key("file.compression.zstd-level")
+        .int_type()
+        .default_value(1)
+        .with_description(
+            "Default file compression zstd level. For higher compression rates, it can be configured to 9, "
+            "but the read and write speed will significantly decrease."
+        )
+    )
+
     FILE_COMPRESSION_PER_LEVEL: ConfigOption[Dict[str, str]] = (
         ConfigOptions.key("file.compression.per.level")
         .map_type()
@@ -345,6 +355,9 @@ class CoreOptions:
 
     def file_compression(self, default=None):
         return self.options.get(CoreOptions.FILE_COMPRESSION, default)
+
+    def file_compression_zstd_level(self, default=None):
+        return self.options.get(CoreOptions.FILE_COMPRESSION_ZSTD_LEVEL, default)
 
     def file_compression_per_level(self, default=None):
         return self.options.get(CoreOptions.FILE_COMPRESSION_PER_LEVEL, default)

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -125,8 +125,8 @@ class CoreOptions:
     FILE_COMPRESSION: ConfigOption[str] = (
         ConfigOptions.key("file.compression")
         .string_type()
-        .default_value("lz4")
-        .with_description("Default file compression format.")
+        .default_value("zstd")
+        .with_description("Default file compression format. For faster read and write, it is recommended to use zstd.")
     )
 
     FILE_COMPRESSION_PER_LEVEL: ConfigOption[Dict[str, str]] = (

--- a/paimon-python/pypaimon/tests/reader_base_test.py
+++ b/paimon-python/pypaimon/tests/reader_base_test.py
@@ -786,10 +786,12 @@ class ReaderBasicTest(unittest.TestCase):
             self._verify_file_compression_with_format(
                 file_format, compression, db_name, table_name, expected_rows=3
             )
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, RuntimeError):
             raise
 
-    def _verify_file_compression_with_format(self, file_format: str, compression: str, db_name: str, table_name: str, expected_rows: int = 3):
+    def _verify_file_compression_with_format(
+            self, file_format: str, compression: str,
+            db_name: str, table_name: str, expected_rows: int = 3):
         if file_format == 'parquet':
             parquet_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.parquet")
             self.assertEqual(len(parquet_files), 1)
@@ -801,8 +803,9 @@ class ReaderBasicTest(unittest.TestCase):
                 actual_compression = column_metadata.compression
                 compression_str = str(actual_compression).upper()
                 expected_compression_upper = compression.upper()
-                self.assertIn(expected_compression_upper, compression_str,
-                             f"Expected compression to be {compression}, but got {actual_compression}")
+                self.assertIn(
+                    expected_compression_upper, compression_str,
+                    f"Expected compression to be {compression}, but got {actual_compression}")
         elif file_format == 'orc':
             orc_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.orc")
             self.assertEqual(len(orc_files), 1)
@@ -828,9 +831,11 @@ class ReaderBasicTest(unittest.TestCase):
                     'snappy': 'snappy',
                     'deflate': 'deflate',
                 }
-                expected_codec = expected_codec_map.get(compression.lower(), compression.lower())
-                self.assertEqual(codec, expected_codec,
-                               f"Expected compression codec to be '{expected_codec}', but got '{codec}'")
+                expected_codec = expected_codec_map.get(
+                    compression.lower(), compression.lower())
+                self.assertEqual(
+                    codec, expected_codec,
+                    f"Expected compression codec to be '{expected_codec}', but got '{codec}'")
 
     def _verify_file_compression(self, file_format: str, db_name: str, table_name: str, expected_rows: int = 3):
         if file_format == 'parquet':
@@ -843,9 +848,10 @@ class ReaderBasicTest(unittest.TestCase):
                 column_metadata = parquet_metadata.row_group(0).column(i)
                 compression = column_metadata.compression
                 compression_str = str(compression).upper()
-                self.assertIn('ZSTD', compression_str,
-                             f"Expected compression to be ZSTD , "
-                             f"but got {compression}")
+                self.assertIn(
+                    'ZSTD', compression_str,
+                    f"Expected compression to be ZSTD , "
+                    f"but got {compression}")
         elif file_format == 'orc':
             orc_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.orc")
             self.assertEqual(len(orc_files), 1)
@@ -865,9 +871,10 @@ class ReaderBasicTest(unittest.TestCase):
             with open(avro_file_path, 'rb') as f:
                 reader = fastavro.reader(f)
                 codec = reader.codec
-                self.assertEqual(codec, 'zstandard',
-                               f"Expected compression codec to be 'zstandard', "
-                               f"but got '{codec}'")
+                self.assertEqual(
+                    codec, 'zstandard',
+                    f"Expected compression codec to be 'zstandard', "
+                    f"but got '{codec}'")
 
     def _test_value_stats_cols_case(self, manifest_manager, table, value_stats_cols, expected_fields_count, test_name):
         """Helper method to test a specific _VALUE_STATS_COLS case."""

--- a/paimon-python/pypaimon/tests/reader_base_test.py
+++ b/paimon-python/pypaimon/tests/reader_base_test.py
@@ -842,7 +842,8 @@ class ReaderBasicTest(unittest.TestCase):
                     codec, expected_codec,
                     f"Expected compression codec to be '{expected_codec}', but got '{codec}'")
 
-    def _verify_file_compression(self, file_format: str, db_name: str, table_name: str, expected_rows: int = 3, expected_zstd_level: int = 1):
+    def _verify_file_compression(self, file_format: str, db_name: str, table_name: str,
+                                 expected_rows: int = 3, expected_zstd_level: int = 1):
         if file_format == 'parquet':
             parquet_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.parquet")
             self.assertEqual(len(parquet_files), 1)

--- a/paimon-python/pypaimon/tests/reader_base_test.py
+++ b/paimon-python/pypaimon/tests/reader_base_test.py
@@ -28,6 +28,7 @@ from unittest.mock import Mock
 
 import pandas as pd
 import pyarrow as pa
+from parameterized import parameterized
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.manifest.manifest_file_manager import ManifestFileManager
@@ -675,7 +676,12 @@ class ReaderBasicTest(unittest.TestCase):
             l2.append(field.to_dict())
         self.assertEqual(l1, l2)
 
-    def test_write(self):
+    @parameterized.expand([
+        ('parquet',),
+        ('orc',),
+        ('avro',),
+    ])
+    def test_write(self, file_format):
         pa_schema = pa.schema([
             ('f0', pa.int32()),
             ('f1', pa.string()),
@@ -684,9 +690,15 @@ class ReaderBasicTest(unittest.TestCase):
         catalog = CatalogFactory.create({
             "warehouse": self.warehouse
         })
-        catalog.create_database("test_write_db", False)
-        catalog.create_table("test_write_db.test_table", Schema.from_pyarrow_schema(pa_schema), False)
-        table = catalog.get_table("test_write_db.test_table")
+        db_name = f"test_write_{file_format}_db"
+        table_name = f"test_{file_format}_table"
+        catalog.create_database(db_name, False)
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={'file.format': file_format}
+        )
+        catalog.create_table(f"{db_name}.{table_name}", schema, False)
+        table = catalog.get_table(f"{db_name}.{table_name}")
 
         data = {
             'f0': [1, 2, 3],
@@ -704,17 +716,7 @@ class ReaderBasicTest(unittest.TestCase):
         table_write.close()
         table_commit.close()
 
-        self.assertTrue(os.path.exists(self.warehouse + "/test_write_db.db/test_table/snapshot/LATEST"))
-        self.assertTrue(os.path.exists(self.warehouse + "/test_write_db.db/test_table/snapshot/snapshot-1"))
-        self.assertTrue(os.path.exists(self.warehouse + "/test_write_db.db/test_table/manifest"))
-        self.assertTrue(os.path.exists(self.warehouse + "/test_write_db.db/test_table/bucket-0"))
-        self.assertEqual(len(glob.glob(self.warehouse + "/test_write_db.db/test_table/manifest/*")), 3)
-        self.assertEqual(len(glob.glob(self.warehouse + "/test_write_db.db/test_table/bucket-0/*.parquet")), 1)
-
-        with open(self.warehouse + '/test_write_db.db/test_table/snapshot/snapshot-1', 'r', encoding='utf-8') as file:
-            content = ''.join(file.readlines())
-            self.assertTrue(content.__contains__('\"totalRecordCount\": 3'))
-            self.assertTrue(content.__contains__('\"deltaRecordCount\": 3'))
+        self._verify_file_compression(file_format, db_name, table_name, expected_rows=3)
 
         write_builder = table.new_batch_write_builder()
         table_write = write_builder.new_write()
@@ -725,10 +727,147 @@ class ReaderBasicTest(unittest.TestCase):
         table_write.close()
         table_commit.close()
 
-        with open(self.warehouse + '/test_write_db.db/test_table/snapshot/snapshot-2', 'r', encoding='utf-8') as file:
+        snapshot_path = os.path.join(self.warehouse, f"{db_name}.db", table_name, "snapshot", "snapshot-2")
+        with open(snapshot_path, 'r', encoding='utf-8') as file:
             content = ''.join(file.readlines())
             self.assertTrue(content.__contains__('\"totalRecordCount\": 6'))
             self.assertTrue(content.__contains__('\"deltaRecordCount\": 3'))
+
+    @parameterized.expand([
+        ('parquet', 'zstd'),
+        ('parquet', 'lz4'),
+        ('parquet', 'snappy'),
+        ('orc', 'zstd'),
+        ('orc', 'lz4'),
+        ('orc', 'snappy'),
+        ('avro', 'zstd'),
+        ('avro', 'snappy'),
+    ])
+    def test_write_with_compression(self, file_format, compression):
+        pa_schema = pa.schema([
+            ('f0', pa.int32()),
+            ('f1', pa.string()),
+            ('f2', pa.string())
+        ])
+        catalog = CatalogFactory.create({
+            "warehouse": self.warehouse
+        })
+        db_name = f"test_write_{file_format}_{compression}_db"
+        table_name = f"test_{file_format}_{compression}_table"
+        catalog.create_database(db_name, False)
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'file.format': file_format,
+                'file.compression': compression
+            }
+        )
+        catalog.create_table(f"{db_name}.{table_name}", schema, False)
+        table = catalog.get_table(f"{db_name}.{table_name}")
+
+        data = {
+            'f0': [1, 2, 3],
+            'f1': ['a', 'b', 'c'],
+            'f2': ['X', 'Y', 'Z']
+        }
+        expect = pa.Table.from_pydict(data, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+
+        try:
+            table_write.write_arrow(expect)
+            commit_messages = table_write.prepare_commit()
+            table_commit.commit(commit_messages)
+            table_write.close()
+            table_commit.close()
+
+            self._verify_file_compression_with_format(
+                file_format, compression, db_name, table_name, expected_rows=3
+            )
+        except (ValueError, RuntimeError) as e:
+            raise
+
+    def _verify_file_compression_with_format(self, file_format: str, compression: str, db_name: str, table_name: str, expected_rows: int = 3):
+        if file_format == 'parquet':
+            parquet_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.parquet")
+            self.assertEqual(len(parquet_files), 1)
+            import pyarrow.parquet as pq
+            parquet_file_path = parquet_files[0]
+            parquet_metadata = pq.read_metadata(parquet_file_path)
+            for i in range(parquet_metadata.num_columns):
+                column_metadata = parquet_metadata.row_group(0).column(i)
+                actual_compression = column_metadata.compression
+                compression_str = str(actual_compression).upper()
+                expected_compression_upper = compression.upper()
+                self.assertIn(expected_compression_upper, compression_str,
+                             f"Expected compression to be {compression}, but got {actual_compression}")
+        elif file_format == 'orc':
+            orc_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.orc")
+            self.assertEqual(len(orc_files), 1)
+            import pyarrow.orc as orc
+            orc_file_path = orc_files[0]
+            orc_file = orc.ORCFile(orc_file_path)
+            try:
+                table = orc_file.read()
+                self.assertEqual(table.num_rows, expected_rows, "ORC file should contain expected rows")
+            except Exception as e:
+                self.fail(f"Failed to read ORC file (compression may be incorrect): {e}")
+        elif file_format == 'avro':
+            avro_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.avro")
+            self.assertEqual(len(avro_files), 1)
+            import fastavro
+            avro_file_path = avro_files[0]
+            with open(avro_file_path, 'rb') as f:
+                reader = fastavro.reader(f)
+                codec = reader.codec
+                expected_codec_map = {
+                    'zstd': 'zstandard',
+                    'zstandard': 'zstandard',
+                    'snappy': 'snappy',
+                    'deflate': 'deflate',
+                }
+                expected_codec = expected_codec_map.get(compression.lower(), compression.lower())
+                self.assertEqual(codec, expected_codec,
+                               f"Expected compression codec to be '{expected_codec}', but got '{codec}'")
+
+    def _verify_file_compression(self, file_format: str, db_name: str, table_name: str, expected_rows: int = 3):
+        if file_format == 'parquet':
+            parquet_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.parquet")
+            self.assertEqual(len(parquet_files), 1)
+            import pyarrow.parquet as pq
+            parquet_file_path = parquet_files[0]
+            parquet_metadata = pq.read_metadata(parquet_file_path)
+            for i in range(parquet_metadata.num_columns):
+                column_metadata = parquet_metadata.row_group(0).column(i)
+                compression = column_metadata.compression
+                compression_str = str(compression).upper()
+                self.assertIn('ZSTD', compression_str,
+                             f"Expected compression to be ZSTD , "
+                             f"but got {compression}")
+        elif file_format == 'orc':
+            orc_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.orc")
+            self.assertEqual(len(orc_files), 1)
+            import pyarrow.orc as orc
+            orc_file_path = orc_files[0]
+            orc_file = orc.ORCFile(orc_file_path)
+            try:
+                table = orc_file.read()
+                self.assertEqual(table.num_rows, expected_rows, "ORC file should contain expected rows")
+            except Exception as e:
+                self.fail(f"Failed to read ORC file (compression may be incorrect): {e}")
+        elif file_format == 'avro':
+            avro_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.avro")
+            self.assertEqual(len(avro_files), 1)
+            import fastavro
+            avro_file_path = avro_files[0]
+            with open(avro_file_path, 'rb') as f:
+                reader = fastavro.reader(f)
+                codec = reader.codec
+                self.assertEqual(codec, 'zstandard',
+                               f"Expected compression codec to be 'zstandard', "
+                               f"but got '{codec}'")
 
     def _test_value_stats_cols_case(self, manifest_manager, table, value_stats_cols, expected_fields_count, test_name):
         """Helper method to test a specific _VALUE_STATS_COLS case."""

--- a/paimon-python/pypaimon/tests/reader_base_test.py
+++ b/paimon-python/pypaimon/tests/reader_base_test.py
@@ -791,7 +791,7 @@ class ReaderBasicTest(unittest.TestCase):
 
     def _verify_file_compression_with_format(
             self, file_format: str, compression: str,
-            db_name: str, table_name: str, expected_rows: int = 3):
+            db_name: str, table_name: str, expected_rows: int = 3, expected_zstd_level: int = 1):
         if file_format == 'parquet':
             parquet_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.parquet")
             self.assertEqual(len(parquet_files), 1)
@@ -806,6 +806,11 @@ class ReaderBasicTest(unittest.TestCase):
                 self.assertIn(
                     expected_compression_upper, compression_str,
                     f"Expected compression to be {compression}, but got {actual_compression}")
+                if compression.lower() == 'zstd' and hasattr(column_metadata, 'compression_level'):
+                    actual_level = column_metadata.compression_level
+                    self.assertEqual(
+                        actual_level, expected_zstd_level,
+                        f"Expected zstd compression level to be {expected_zstd_level}, but got {actual_level}")
         elif file_format == 'orc':
             orc_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.orc")
             self.assertEqual(len(orc_files), 1)
@@ -837,7 +842,7 @@ class ReaderBasicTest(unittest.TestCase):
                     codec, expected_codec,
                     f"Expected compression codec to be '{expected_codec}', but got '{codec}'")
 
-    def _verify_file_compression(self, file_format: str, db_name: str, table_name: str, expected_rows: int = 3):
+    def _verify_file_compression(self, file_format: str, db_name: str, table_name: str, expected_rows: int = 3, expected_zstd_level: int = 1):
         if file_format == 'parquet':
             parquet_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.parquet")
             self.assertEqual(len(parquet_files), 1)
@@ -852,6 +857,11 @@ class ReaderBasicTest(unittest.TestCase):
                     'ZSTD', compression_str,
                     f"Expected compression to be ZSTD , "
                     f"but got {compression}")
+                if hasattr(column_metadata, 'compression_level'):
+                    actual_level = column_metadata.compression_level
+                    self.assertEqual(
+                        actual_level, expected_zstd_level,
+                        f"Expected zstd compression level to be {expected_zstd_level}, but got {actual_level}")
         elif file_format == 'orc':
             orc_files = glob.glob(self.warehouse + f"/{db_name}.db/{table_name}/bucket-0/*.orc")
             self.assertEqual(len(orc_files), 1)

--- a/paimon-python/pypaimon/write/writer/data_blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_blob_writer.py
@@ -259,7 +259,7 @@ class DataBlobWriter(DataWriter):
         elif self.file_format == CoreOptions.FILE_FORMAT_ORC:
             self.file_io.write_orc(file_path, data, compression=self.compression)
         elif self.file_format == CoreOptions.FILE_FORMAT_AVRO:
-            self.file_io.write_avro(file_path, data)
+            self.file_io.write_avro(file_path, data, compression=self.compression)
         elif self.file_format == CoreOptions.FILE_FORMAT_LANCE:
             self.file_io.write_lance(file_path, data)
         else:

--- a/paimon-python/pypaimon/write/writer/data_blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_blob_writer.py
@@ -255,11 +255,11 @@ class DataBlobWriter(DataWriter):
 
         # Write file based on format
         if self.file_format == CoreOptions.FILE_FORMAT_PARQUET:
-            self.file_io.write_parquet(file_path, data, compression=self.compression)
+            self.file_io.write_parquet(file_path, data, compression=self.compression, zstd_level=self.zstd_level)
         elif self.file_format == CoreOptions.FILE_FORMAT_ORC:
-            self.file_io.write_orc(file_path, data, compression=self.compression)
+            self.file_io.write_orc(file_path, data, compression=self.compression, zstd_level=self.zstd_level)
         elif self.file_format == CoreOptions.FILE_FORMAT_AVRO:
-            self.file_io.write_avro(file_path, data, compression=self.compression)
+            self.file_io.write_avro(file_path, data, compression=self.compression, zstd_level=self.zstd_level)
         elif self.file_format == CoreOptions.FILE_FORMAT_LANCE:
             self.file_io.write_lance(file_path, data)
         else:

--- a/paimon-python/pypaimon/write/writer/data_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_writer.py
@@ -56,6 +56,7 @@ class DataWriter(ABC):
         )
         self.file_format = self.options.file_format(default_format)
         self.compression = self.options.file_compression()
+        self.zstd_level = self.options.file_compression_zstd_level()
         self.sequence_generator = SequenceGenerator(max_seq_number)
 
         self.pending_data: Optional[pa.Table] = None
@@ -169,11 +170,11 @@ class DataWriter(ABC):
             external_path_str = None
 
         if self.file_format == CoreOptions.FILE_FORMAT_PARQUET:
-            self.file_io.write_parquet(file_path, data, compression=self.compression)
+            self.file_io.write_parquet(file_path, data, compression=self.compression, zstd_level=self.zstd_level)
         elif self.file_format == CoreOptions.FILE_FORMAT_ORC:
-            self.file_io.write_orc(file_path, data, compression=self.compression)
+            self.file_io.write_orc(file_path, data, compression=self.compression, zstd_level=self.zstd_level)
         elif self.file_format == CoreOptions.FILE_FORMAT_AVRO:
-            self.file_io.write_avro(file_path, data, compression=self.compression)
+            self.file_io.write_avro(file_path, data, compression=self.compression, zstd_level=self.zstd_level)
         elif self.file_format == CoreOptions.FILE_FORMAT_BLOB:
             self.file_io.write_blob(file_path, data, self.blob_as_descriptor)
         elif self.file_format == CoreOptions.FILE_FORMAT_LANCE:

--- a/paimon-python/pypaimon/write/writer/data_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_writer.py
@@ -173,7 +173,7 @@ class DataWriter(ABC):
         elif self.file_format == CoreOptions.FILE_FORMAT_ORC:
             self.file_io.write_orc(file_path, data, compression=self.compression)
         elif self.file_format == CoreOptions.FILE_FORMAT_AVRO:
-            self.file_io.write_avro(file_path, data)
+            self.file_io.write_avro(file_path, data, compression=self.compression)
         elif self.file_format == CoreOptions.FILE_FORMAT_BLOB:
             self.file_io.write_blob(file_path, data, self.blob_as_descriptor)
         elif self.file_format == CoreOptions.FILE_FORMAT_LANCE:


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Compression defaults and configurability**
> 
> - Change default `file.compression` to `zstd`; add `file.compression.zstd-level` (default `1`) in `CoreOptions`
> - Add accessor `file_compression_zstd_level` and use it in writers
> 
> **I/O updates**
> 
> - `write_parquet`/`write_orc`/`write_avro` now accept `compression` and (where supported) `zstd_level`; Avro adds codec mapping (zstd/zstandard/deflate/snappy/etc.) and sets `codec_compression_level` for zstd
> - Writers (`data_writer.py`, `data_blob_writer.py`) pass `compression` and `zstd_level` to file writes
> 
> **Tests**
> 
> - Parameterize write tests across `parquet`/`orc`/`avro` and multiple compressions; verify codecs and zstd level in output files; minor snapshot-path assertion tweak
> 
> **Build/Deps**
> 
> - Add `cramjam` to requirements and CI install lists
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e0a410e915141ba1a438ea06f51b8ba34f4eb13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->