### PR TITLE
[Python] Fix FileIO.exists() catch all the exception issue

### DIFF
--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -211,13 +211,9 @@ class FileIO:
         return [info for info in file_infos if info.type == pyarrow.fs.FileType.Directory]
 
     def exists(self, path: str) -> bool:
-        try:
-            path_str = self.to_filesystem_path(path)
-            file_info = self.filesystem.get_file_info([path_str])[0]
-            result = file_info.type != pyarrow.fs.FileType.NotFound
-            return result
-        except Exception:
-            return False
+        path_str = self.to_filesystem_path(path)
+        file_info = self.filesystem.get_file_info([path_str])[0]
+        return file_info.type != pyarrow.fs.FileType.NotFound
 
     def delete(self, path: str, recursive: bool = False) -> bool:
         try:


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Behavior change**
> 
> - `FileIO.exists` no longer catches all exceptions; it directly checks `get_file_info` and propagates underlying filesystem errors. 
> 
> **Tests**
> 
> - Added `FileIOTest` cases to ensure `exists` does not swallow errors and that errors propagate in `new_output_stream`, `check_or_mkdirs`, `write_file`, `copy_file`, `read_overwritten_file_utf8`, `rename`, and delete-quietly paths.
> - Added `FileSystemCatalogTest.test_get_database_propagates_exists_error` to verify `Catalog.get_database` surfaces filesystem `OSError` instead of mapping it to `DatabaseNotExistException`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe6a6ccee78669d19311b3778a0b6c2846e28ba3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->