### PR TITLE
Cramjam version fix

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -81,6 +81,19 @@ jobs:
       - name: Verify Python version
         run: python --version
 
+      - name: Verify requirements.txt dependencies can be installed
+        shell: bash
+        run: |
+          cd paimon-python
+          python -m pip install --upgrade pip
+          # Use --dry-run to verify dependencies can be resolved without actually installing
+          python -m pip install -r dev/requirements.txt --dry-run || {
+            echo "ERROR: Failed to resolve dependencies from dev/requirements.txt"
+            echo "This indicates a version conflict or unavailable package version"
+            exit 1
+          }
+          echo "✓ All dependencies in dev/requirements.txt can be resolved"
+
       - name: Build Java
         run: |
           echo "Start compiling modules"

--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -39,4 +39,4 @@ ray>=2.10,<3
 readerwriterlock>=1,<2
 torch
 zstandard>=0.19,<1
-cramjam>=1.3.0,<3; python_version>="3.7"
+cramjam>=0.6,<1; python_version>="3.7"

--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -39,4 +39,4 @@ ray>=2.10,<3
 readerwriterlock>=1,<2
 torch
 zstandard>=0.19,<1
-cramjam>=0.6,<1; python_version>="3.7"
+cramjam>=1.3.0,<3; python_version>="3.7"

--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -211,13 +211,9 @@ class FileIO:
         return [info for info in file_infos if info.type == pyarrow.fs.FileType.Directory]
 
     def exists(self, path: str) -> bool:
-        try:
-            path_str = self.to_filesystem_path(path)
-            file_info = self.filesystem.get_file_info([path_str])[0]
-            result = file_info.type != pyarrow.fs.FileType.NotFound
-            return result
-        except Exception:
-            return False
+        path_str = self.to_filesystem_path(path)
+        file_info = self.filesystem.get_file_info([path_str])[0]
+        return file_info.type != pyarrow.fs.FileType.NotFound
 
     def delete(self, path: str, recursive: bool = False) -> bool:
         try:


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an early dependency resolution check in the Python CI workflow to catch version conflicts before build and tests.
> 
> - Adds a step to run `pip install -r paimon-python/dev/requirements.txt --dry-run` and fail fast on unresolved dependencies
> - Placed before the Java build within `paimon-python-checks.yml` to surface Python dependency issues earlier
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bacc57cc91b9ccd3850effb128ab692eb9263d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->