### PR TITLE
fix cramjam version define and introduce dependency check in CI

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -86,12 +86,17 @@ jobs:
         run: |
           cd paimon-python
           python -m pip install --upgrade pip
-          # Use --dry-run to verify dependencies can be resolved without actually installing
-          python -m pip install -r dev/requirements.txt --dry-run || {
+          # Use --target to install to a temporary directory to verify dependencies
+          # This works for both Python 3.6 (pip 21.3.1) and Python 3.10+ (pip 22.2+)
+          # since --target is supported in all pip versions
+          TEMP_DIR=$(mktemp -d)
+          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || {
             echo "ERROR: Failed to resolve dependencies from dev/requirements.txt"
             echo "This indicates a version conflict or unavailable package version"
+            rm -rf "$TEMP_DIR"
             exit 1
           }
+          rm -rf "$TEMP_DIR"
           echo "✓ All dependencies in dev/requirements.txt can be resolved"
 
       - name: Build Java

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -81,6 +81,19 @@ jobs:
       - name: Verify Python version
         run: python --version
 
+      - name: Verify requirements.txt dependencies can be installed
+        shell: bash
+        run: |
+          cd paimon-python
+          python -m pip install --upgrade pip
+          # Use --dry-run to verify dependencies can be resolved without actually installing
+          python -m pip install -r dev/requirements.txt --dry-run || {
+            echo "ERROR: Failed to resolve dependencies from dev/requirements.txt"
+            echo "This indicates a version conflict or unavailable package version"
+            exit 1
+          }
+          echo "✓ All dependencies in dev/requirements.txt can be resolved"
+
       - name: Build Java
         run: |
           echo "Start compiling modules"

--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -39,4 +39,4 @@ ray>=2.10,<3
 readerwriterlock>=1,<2
 torch
 zstandard>=0.19,<1
-cramjam>=1.3.0,<3; python_version>="3.7"
+cramjam>=0.6,<1; python_version>="3.7"

--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -35,7 +35,7 @@ pyarrow>=16,<20; python_version >= "3.8"
 pylance>=0.20,<1; python_version>="3.9"
 pylance>=0.10,<1; python_version>="3.8" and python_version<"3.9"
 pyroaring
-ray>=2.10,<3
+ray>=2.10,<3; python_version>="3.7"
 readerwriterlock>=1,<2
 torch
 zstandard>=0.19,<1

--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -39,4 +39,4 @@ ray>=2.10,<3
 readerwriterlock>=1,<2
 torch
 zstandard>=0.19,<1
-cramjam>=0.6,<1; python_version>="3.7"
+cramjam>=1.3.0,<3; python_version>="3.7"


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces CI safeguards for Python dependencies and adjusts development dependency constraints.
> 
> - **CI:** Adds a step to verify `paimon-python/dev/requirements.txt` can be installed via pip in the `lint-python` job
> - **CI:** New `requirement_version_compatible_test` job to install base deps and run tests against multiple Ray versions (`2.44.0`, `2.48.0`, `2.53.0`)
> - **Deps:** Updates `paimon-python/dev/requirements.txt` to add `python_version>="3.7"` marker for `ray>=2.10,<3` and bump `cramjam` to `>=1.3.0,<3` for Python >=3.7
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43f1ce339df8f89f79575654a37d24b9aedbfd8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->