### PR TITLE
Pr 7014 review

### DIFF
--- a/paimon-python/dev/lint-python.sh
+++ b/paimon-python/dev/lint-python.sh
@@ -107,7 +107,7 @@ function collect_checks() {
 function get_all_supported_checks() {
     _OLD_IFS=$IFS
     IFS=$'\n'
-    SUPPORT_CHECKS=("flake8_check" "pytest_torch_check" "pytest_check" "mixed_check") # control the calling sequence
+    SUPPORT_CHECKS=("flake8_check" "pytest_check" "pytest_torch_check" "mixed_check") # control the calling sequence
     for fun in $(declare -F); do
         if [[ `regexp_match "$fun" "_check$"` = true ]]; then
             check_name="${fun:11}"

--- a/paimon-python/pypaimon/read/reader/field_bunch.py
+++ b/paimon-python/pypaimon/read/reader/field_bunch.py
@@ -82,11 +82,6 @@ class BlobBunch(FieldBunch):
                         "Blob file with overlapping row id should have decreasing sequence number."
                     )
                 return
-            elif first_row_id > self.expected_next_first_row_id:
-                raise ValueError(
-                    f"Blob file first row id should be continuous, expect "
-                    f"{self.expected_next_first_row_id} but got {first_row_id}"
-                )
 
             if file.schema_id != self._files[0].schema_id:
                 raise ValueError(

--- a/paimon-python/pypaimon/read/reader/shard_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/shard_batch_reader.py
@@ -25,6 +25,7 @@ class ShardBatchReader(RecordBatchReader):
     """
     A reader that reads a subset of rows from a data file
     """
+
     def __init__(self, reader, start_pos, end_pos):
         self.reader = reader
         self.start_pos = start_pos
@@ -54,6 +55,81 @@ class ShardBatchReader(RecordBatchReader):
                 return batch.slice(self.start_pos - batch_begin, self.end_pos - self.start_pos)
             elif batch_begin < self.end_pos < self.current_pos:  # batch ends after the desired range
                 return batch.slice(0, self.end_pos - batch_begin)
+            else:  # batch is outside the desired range
+                return self.read_arrow_batch()
+
+    def close(self):
+        self.reader.close()
+
+
+class SampleBatchReader(RecordBatchReader):
+    """
+    A reader that reads a subset of rows from a data file based on specified sample positions.
+
+    This reader wraps another RecordBatchReader and only returns rows at the specified
+    sample positions, enabling efficient random sampling of data without reading all rows.
+
+    The reader supports two modes:
+    1. For blob readers: Directly reads specific rows by index
+    2. For other readers: Reads batches sequentially and extracts only the sampled rows
+
+    Attributes:
+        reader: The underlying RecordBatchReader to read data from
+        sample_positions: A sorted list of row indices to sample (0-based)
+        sample_idx: Current index in the sample_positions list
+        current_pos: Current absolute row position in the data file
+    """
+
+    def __init__(self, reader, sample_positions):
+        """
+        Initialize the SampleBatchReader.
+
+        Args:
+            reader: The underlying RecordBatchReader to read data from
+            sample_positions: A sorted list of row indices to sample (0-based).
+                            Must be sorted in ascending order for correct behavior.
+        """
+        self.reader = reader
+        self.sample_positions = sample_positions
+        self.sample_idx = 0
+        self.current_pos = 0
+
+    def read_arrow_batch(self) -> Optional[RecordBatch]:
+        """
+        Read the next batch containing sampled rows.
+
+        This method reads data from the underlying reader and returns only the rows
+        at the specified sample positions. The behavior differs based on reader type:
+
+        - For FormatBlobReader: Directly reads individual rows by index
+        - For other readers: Reads batches sequentially and extracts sampled rows
+          using PyArrow's take() method
+        """
+        if self.sample_idx >= len(self.sample_positions):
+            return None
+        if isinstance(self.reader.format_reader, FormatBlobReader):
+            # For blob reader, pass begin_idx and end_idx parameters
+            self.sample_idx += 1
+            return self.reader.read_arrow_batch(start_idx=self.sample_idx - 1, end_idx=self.sample_idx)
+        else:
+            batch = self.reader.read_arrow_batch()
+            if batch is None:
+                return None
+
+            batch_begin = self.current_pos
+            self.current_pos += batch.num_rows
+            take_idxes = []
+
+            sample_pos = self.sample_positions[self.sample_idx]
+            while batch_begin <= sample_pos < self.current_pos:
+                take_idxes.append(sample_pos - batch_begin)
+                self.sample_idx += 1
+                if self.sample_idx >= len(self.sample_positions):
+                    break
+                sample_pos = self.sample_positions[self.sample_idx]
+
+            if take_idxes:
+                return batch.take(take_idxes)
             else:  # batch is outside the desired range
                 return self.read_arrow_batch()
 

--- a/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
@@ -700,7 +700,7 @@ class PartialStartingScanner(FullStartingScanner):
         # Map each sample index to its corresponding file and local index
         filtered_partitioned_files = defaultdict(list)
         file_positions = {}  # {file_name: [local_indexes]}
-        self._generate_split_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
+        self._generate_file_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
                                             sample_indexes, is_blob=False)
         return filtered_partitioned_files, file_positions
 
@@ -788,10 +788,10 @@ class PartialStartingScanner(FullStartingScanner):
         # Map each sample index to its corresponding file and local index
         filtered_partitioned_files = defaultdict(list)
         file_positions = {}  # {file_name: [local_indexes]}
-        self._generate_split_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
+        self._generate_file_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
                                             sample_indexes, is_blob=False)
         if self.data_evolution:
-            self._generate_split_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
+            self._generate_file_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
                                                 sample_indexes, is_blob=True)
 
         return filtered_partitioned_files, file_positions
@@ -803,7 +803,7 @@ class PartialStartingScanner(FullStartingScanner):
                 filtered_entries.append(entry)
         return filtered_entries
 
-    def _generate_split_sample_idx_map(self, partitioned_files, filtered_partitioned_files, file_positions,
+    def _generate_file_sample_idx_map(self, partitioned_files, filtered_partitioned_files, file_positions,
                                        sample_indexes, is_blob):
         current_row = 0
         sample_idx = 0

--- a/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
@@ -701,7 +701,7 @@ class PartialStartingScanner(FullStartingScanner):
         filtered_partitioned_files = defaultdict(list)
         file_positions = {}  # {file_name: [local_indexes]}
         self._generate_file_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
-                                            sample_indexes, is_blob=False)
+                                           sample_indexes, is_blob=False)
         return filtered_partitioned_files, file_positions
 
     def _data_evolution_filter_by_slice(self, partitioned_files: defaultdict,
@@ -789,10 +789,10 @@ class PartialStartingScanner(FullStartingScanner):
         filtered_partitioned_files = defaultdict(list)
         file_positions = {}  # {file_name: [local_indexes]}
         self._generate_file_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
-                                            sample_indexes, is_blob=False)
+                                           sample_indexes, is_blob=False)
         if self.data_evolution:
             self._generate_file_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
-                                                sample_indexes, is_blob=True)
+                                               sample_indexes, is_blob=True)
 
         return filtered_partitioned_files, file_positions
 
@@ -804,7 +804,7 @@ class PartialStartingScanner(FullStartingScanner):
         return filtered_entries
 
     def _generate_file_sample_idx_map(self, partitioned_files, filtered_partitioned_files, file_positions,
-                                       sample_indexes, is_blob):
+                                      sample_indexes, is_blob):
         current_row = 0
         sample_idx = 0
 

--- a/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
@@ -16,6 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import os
+import random
 from collections import defaultdict
 from typing import Callable, List, Optional, Dict, Set
 
@@ -60,11 +61,6 @@ class FullStartingScanner(StartingScanner):
         # Get split target size and open file cost from table options
         self.target_split_size = options.source_split_target_size()
         self.open_file_cost = options.source_split_open_file_cost()
-
-        self.idx_of_this_subtask = None
-        self.number_of_para_subtasks = None
-        self.start_pos_of_this_subtask = None
-        self.end_pos_of_this_subtask = None
 
         self.only_read_real_buckets = True if options.bucket() == BucketMode.POSTPONE_BUCKET.value else False
         self.data_evolution = options.data_evolution_enabled()
@@ -120,209 +116,135 @@ class FullStartingScanner(StartingScanner):
                                                                 self._filter_manifest_entry,
                                                                 max_workers=max_workers)
 
-    def with_shard(self, idx_of_this_subtask, number_of_para_subtasks) -> 'FullStartingScanner':
-        if idx_of_this_subtask >= number_of_para_subtasks:
-            raise Exception("idx_of_this_subtask must be less than number_of_para_subtasks")
-        if self.start_pos_of_this_subtask is not None:
-            raise Exception("with_shard and with_slice cannot be used simultaneously")
-        self.idx_of_this_subtask = idx_of_this_subtask
-        self.number_of_para_subtasks = number_of_para_subtasks
-        return self
-
-    def with_slice(self, start_pos, end_pos) -> 'FullStartingScanner':
-        if start_pos >= end_pos:
-            raise Exception("start_pos must be less than end_pos")
-        if self.idx_of_this_subtask is not None:
-            raise Exception("with_slice and with_shard cannot be used simultaneously")
-        self.start_pos_of_this_subtask = start_pos
-        self.end_pos_of_this_subtask = end_pos
-        return self
-
-    @staticmethod
-    def _append_only_filter_by_slice(partitioned_files: defaultdict,
-                                     start_pos: int,
-                                     end_pos: int) -> (defaultdict, int, int):
-        plan_start_pos = 0
-        plan_end_pos = 0
-        entry_end_pos = 0  # end row position of current file in all data
-        splits_start_pos = 0
-        filtered_partitioned_files = defaultdict(list)
-        # Iterate through all file entries to find files that overlap with current shard range
-        for key, file_entries in partitioned_files.items():
-            filtered_entries = []
-            for entry in file_entries:
-                entry_begin_pos = entry_end_pos  # Starting row position of current file in all data
-                entry_end_pos += entry.file.row_count  # Update to row position after current file
-
-                # If current file is completely after shard range, stop iteration
-                if entry_begin_pos >= end_pos:
-                    break
-                # If current file is completely before shard range, skip it
-                if entry_end_pos <= start_pos:
-                    continue
-                if entry_begin_pos <= start_pos < entry_end_pos:
-                    splits_start_pos = entry_begin_pos
-                    plan_start_pos = start_pos - entry_begin_pos
-                # If shard end position is within current file, record relative end position
-                if entry_begin_pos < end_pos <= entry_end_pos:
-                    plan_end_pos = end_pos - splits_start_pos
-                # Add files that overlap with shard range to result
-                filtered_entries.append(entry)
-            if filtered_entries:
-                filtered_partitioned_files[key] = filtered_entries
-
-        return filtered_partitioned_files, plan_start_pos, plan_end_pos
-
-    def _append_only_filter_by_shard(self, partitioned_files: defaultdict) -> (defaultdict, int, int):
-        """
-        Filter file entries by shard. Only keep the files within the range, which means
-        that only the starting and ending files need to be further divided subsequently
-        """
-        total_row = 0
-        # Sort by file creation time to ensure consistent sharding
-        for key, file_entries in partitioned_files.items():
-            for entry in file_entries:
-                total_row += entry.file.row_count
-
-        # Calculate number of rows this shard should process using balanced distribution
-        # Distribute remainder evenly among first few shards to avoid last shard overload
-        base_rows_per_shard = total_row // self.number_of_para_subtasks
-        remainder = total_row % self.number_of_para_subtasks
-
-        # Each of the first 'remainder' shards gets one extra row
-        if self.idx_of_this_subtask < remainder:
-            num_row = base_rows_per_shard + 1
-            start_pos = self.idx_of_this_subtask * (base_rows_per_shard + 1)
-        else:
-            num_row = base_rows_per_shard
-            start_pos = (remainder * (base_rows_per_shard + 1) +
-                         (self.idx_of_this_subtask - remainder) * base_rows_per_shard)
-
-        end_pos = start_pos + num_row
-
-        return self._append_only_filter_by_slice(partitioned_files, start_pos, end_pos)
-
-    def _data_evolution_filter_by_row_range(self, partitioned_files: defaultdict,
-                                            start_pos: int,
-                                            end_pos: int) -> (defaultdict, int, int):
-        plan_start_pos = 0
-        plan_end_pos = 0
-        entry_end_pos = 0  # end row position of current file in all data
-        splits_start_pos = 0
-        filtered_partitioned_files = defaultdict(list)
-        # Iterate through all file entries to find files that overlap with current shard range
-        for key, file_entries in partitioned_files.items():
-            filtered_entries = []
-            blob_added = False  # If it is true, all blobs corresponding to this data file are added
-            for entry in file_entries:
-                if self._is_blob_file(entry.file.file_name):
-                    if blob_added:
-                        filtered_entries.append(entry)
-                    continue
-                blob_added = False
-                entry_begin_pos = entry_end_pos  # Starting row position of current file in all data
-                entry_end_pos += entry.file.row_count  # Update to row position after current file
-
-                # If current file is completely after shard range, stop iteration
-                if entry_begin_pos >= end_pos:
-                    break
-                # If current file is completely before shard range, skip it
-                if entry_end_pos <= start_pos:
-                    continue
-                if entry_begin_pos <= start_pos < entry_end_pos:
-                    splits_start_pos = entry_begin_pos
-                    plan_start_pos = start_pos - entry_begin_pos
-                # If shard end position is within current file, record relative end position
-                if entry_begin_pos < end_pos <= entry_end_pos:
-                    plan_end_pos = end_pos - splits_start_pos
-                # Add files that overlap with shard range to result
-                filtered_entries.append(entry)
-                blob_added = True
-            if filtered_entries:
-                filtered_partitioned_files[key] = filtered_entries
-
-        return filtered_partitioned_files, plan_start_pos, plan_end_pos
-
-    def _data_evolution_filter_by_shard(self, partitioned_files: defaultdict) -> (defaultdict, int, int):
-        total_row = 0
-        for key, file_entries in partitioned_files.items():
-            for entry in file_entries:
-                if not self._is_blob_file(entry.file.file_name):
-                    total_row += entry.file.row_count
-
-        # Calculate number of rows this shard should process using balanced distribution
-        # Distribute remainder evenly among first few shards to avoid last shard overload
-        base_rows_per_shard = total_row // self.number_of_para_subtasks
-        remainder = total_row % self.number_of_para_subtasks
-
-        # Each of the first 'remainder' shards gets one extra row
-        if self.idx_of_this_subtask < remainder:
-            num_row = base_rows_per_shard + 1
-            start_pos = self.idx_of_this_subtask * (base_rows_per_shard + 1)
-        else:
-            num_row = base_rows_per_shard
-            start_pos = (remainder * (base_rows_per_shard + 1) +
-                         (self.idx_of_this_subtask - remainder) * base_rows_per_shard)
-
-        end_pos = start_pos + num_row
-        return self._data_evolution_filter_by_row_range(partitioned_files, start_pos, end_pos)
-
-    def _compute_split_start_end_pos(self, splits: List[Split], plan_start_pos, plan_end_pos):
-        """
-        Find files that needs to be divided for each split
-        :param splits: splits
-        :param plan_start_pos: plan begin row in all splits data
-        :param plan_end_pos: plan end row in all splits data
-        """
-        file_end_pos = 0  # end row position of current file in all splits data
-
-        for split in splits:
-            cur_split_end_pos = file_end_pos
-            # Compute split_file_idx_map for data files
-            file_end_pos = self._compute_split_file_idx_map(plan_start_pos, plan_end_pos,
-                                                            split, cur_split_end_pos, False)
-            # Compute split_file_idx_map for blob files
-            if self.data_evolution:
-                self._compute_split_file_idx_map(plan_start_pos, plan_end_pos,
-                                                 split, cur_split_end_pos, True)
-
-    def _compute_split_file_idx_map(self, plan_start_pos, plan_end_pos, split: Split,
-                                    file_end_pos: int, is_blob: bool = False):
-        """
-        Traverse all the files in current split, find the starting shard and ending shard files,
-        and add them to shard_file_idx_map;
-        - for data file, only two data files will be divided in all splits.
-        - for blob file, perhaps there will be some unnecessary files in addition to two files(start and end).
-          Add them to shard_file_idx_map as well, because they need to be removed later.
-        """
-        row_cnt = 0
-        for file in split.files:
-            if not is_blob and self._is_blob_file(file.file_name):
-                continue
-            if is_blob and not self._is_blob_file(file.file_name):
-                continue
-            row_cnt += file.row_count
-            file_begin_pos = file_end_pos  # Starting row position of current file in all data
-            file_end_pos += file.row_count  # Update to row position after current file
-            if file_begin_pos <= plan_start_pos < plan_end_pos <= file_end_pos:
-                split.shard_file_idx_map[file.file_name] = (
-                    plan_start_pos - file_begin_pos, plan_end_pos - file_begin_pos)
-            # If shard start position is within current file, record actual start position and relative offset
-            elif file_begin_pos < plan_start_pos < file_end_pos:
-                split.shard_file_idx_map[file.file_name] = (plan_start_pos - file_begin_pos, file.row_count)
-            # If shard end position is within current file, record relative end position
-            elif file_begin_pos < plan_end_pos < file_end_pos:
-                split.shard_file_idx_map[file.file_name] = (0, plan_end_pos - file_begin_pos)
-            elif file_end_pos <= plan_start_pos or file_begin_pos >= plan_end_pos:
-                split.shard_file_idx_map[file.file_name] = (-1, -1)
-        return file_end_pos
-
-    def _primary_key_filter_by_shard(self, file_entries: List[ManifestEntry]) -> List[ManifestEntry]:
-        filtered_entries = []
+    def _create_append_only_splits(
+            self, file_entries: List[ManifestEntry], deletion_files_map: dict = None) -> List['Split']:
+        partitioned_files = defaultdict(list)
         for entry in file_entries:
-            if entry.bucket % self.number_of_para_subtasks == self.idx_of_this_subtask:
-                filtered_entries.append(entry)
-        return filtered_entries
+            partitioned_files[(tuple(entry.partition.values), entry.bucket)].append(entry)
+        if self._partial_read():
+            partitioned_files = self._filter_by_pos(partitioned_files)
+
+        def weight_func(f: DataFileMeta) -> int:
+            return max(f.file_size, self.open_file_cost)
+
+        splits = []
+        for key, file_entries in partitioned_files.items():
+            if not file_entries:
+                return []
+
+            data_files: List[DataFileMeta] = [e.file for e in file_entries]
+
+            packed_files: List[List[DataFileMeta]] = self._pack_for_ordered(data_files, weight_func,
+                                                                            self.target_split_size)
+            splits += self._build_split_from_pack(packed_files, file_entries, False, deletion_files_map)
+        if self._partial_read():
+            self._compute_split_pos(splits)
+        return splits
+
+    def _create_primary_key_splits(
+            self, file_entries: List[ManifestEntry], deletion_files_map: dict = None) -> List['Split']:
+        if self._partial_read():
+            file_entries = self._filter_by_pos(file_entries)
+        partitioned_files = defaultdict(list)
+        for entry in file_entries:
+            partitioned_files[(tuple(entry.partition.values), entry.bucket)].append(entry)
+
+        def single_weight_func(f: DataFileMeta) -> int:
+            return max(f.file_size, self.open_file_cost)
+
+        def weight_func(fl: List[DataFileMeta]) -> int:
+            return max(sum(f.file_size for f in fl), self.open_file_cost)
+
+        merge_engine = self.table.options.merge_engine()
+        merge_engine_first_row = merge_engine == MergeEngine.FIRST_ROW
+
+        splits = []
+        for key, file_entries in partitioned_files.items():
+            if not file_entries:
+                continue
+
+            data_files: List[DataFileMeta] = [e.file for e in file_entries]
+
+            raw_convertible = all(
+                f.level != 0 and self._without_delete_row(f)
+                for f in data_files
+            )
+
+            levels = {f.level for f in data_files}
+            one_level = len(levels) == 1
+
+            use_optimized_path = raw_convertible and (
+                self.deletion_vectors_enabled or merge_engine_first_row or one_level)
+            if use_optimized_path:
+                packed_files: List[List[DataFileMeta]] = self._pack_for_ordered(
+                    data_files, single_weight_func, self.target_split_size
+                )
+                splits += self._build_split_from_pack(
+                    packed_files, file_entries, True, deletion_files_map,
+                    use_optimized_path)
+            else:
+                partition_sort_runs: List[List[SortedRun]] = IntervalPartition(data_files).partition()
+                sections: List[List[DataFileMeta]] = [
+                    [file for s in sl for file in s.files]
+                    for sl in partition_sort_runs
+                ]
+
+                packed_files: List[List[List[DataFileMeta]]] = self._pack_for_ordered(sections, weight_func,
+                                                                                      self.target_split_size)
+
+                flatten_packed_files: List[List[DataFileMeta]] = [
+                    [file for sub_pack in pack for file in sub_pack]
+                    for pack in packed_files
+                ]
+                splits += self._build_split_from_pack(
+                    flatten_packed_files, file_entries, True,
+                    deletion_files_map, False)
+        return splits
+
+    def _create_data_evolution_splits(
+            self, file_entries: List[ManifestEntry], deletion_files_map: dict = None) -> List['Split']:
+        def sort_key(manifest_entry: ManifestEntry) -> tuple:
+            first_row_id = manifest_entry.file.first_row_id if manifest_entry.file.first_row_id is not None else float(
+                '-inf')
+            is_blob = 1 if self._is_blob_file(manifest_entry.file.file_name) else 0
+            # For files with same firstRowId, sort by maxSequenceNumber in descending order
+            # (larger sequence number means more recent data)
+            max_seq = manifest_entry.file.max_sequence_number
+            return first_row_id, is_blob, -max_seq
+
+        partitioned_files = defaultdict(list)
+        for entry in file_entries:
+            partitioned_files[(tuple(entry.partition.values), entry.bucket)].append(entry)
+        if self._partial_read():
+            partitioned_files = self._filter_by_pos(partitioned_files)
+
+        def weight_func(file_list: List[DataFileMeta]) -> int:
+            return max(sum(f.file_size for f in file_list), self.open_file_cost)
+
+        splits = []
+        for key, sorted_entries in partitioned_files.items():
+            if not sorted_entries:
+                continue
+            sorted_entries = sorted(sorted_entries, key=sort_key)
+            data_files: List[DataFileMeta] = [e.file for e in sorted_entries]
+
+            # Split files by firstRowId for data evolution
+            split_by_row_id = self._split_by_row_id(data_files)
+
+            # Pack the split groups for optimal split sizes
+            packed_files: List[List[List[DataFileMeta]]] = self._pack_for_ordered(split_by_row_id, weight_func,
+                                                                                  self.target_split_size)
+
+            # Flatten the packed files and build splits
+            flatten_packed_files: List[List[DataFileMeta]] = [
+                [file for sub_pack in pack for file in sub_pack]
+                for pack in packed_files
+            ]
+
+            splits += self._build_split_from_pack(flatten_packed_files, sorted_entries, False, deletion_files_map)
+        if self._partial_read():
+            self._compute_split_pos(splits)
+        return splits
 
     def _apply_push_down_limit(self, splits: List[Split]) -> List[Split]:
         if self.limit is None:
@@ -468,161 +390,6 @@ class FullStartingScanner(StartingScanner):
 
         return deletion_files if any(df is not None for df in deletion_files) else None
 
-    def _create_append_only_splits(
-            self, file_entries: List[ManifestEntry], deletion_files_map: dict = None) -> List['Split']:
-        partitioned_files = defaultdict(list)
-        for entry in file_entries:
-            partitioned_files[(tuple(entry.partition.values), entry.bucket)].append(entry)
-
-        if self.start_pos_of_this_subtask is not None:
-            # shard data range: [plan_start_pos, plan_end_pos)
-            partitioned_files, plan_start_pos, plan_end_pos = \
-                self._append_only_filter_by_slice(partitioned_files,
-                                                  self.start_pos_of_this_subtask,
-                                                  self.end_pos_of_this_subtask)
-        elif self.idx_of_this_subtask is not None:
-            partitioned_files, plan_start_pos, plan_end_pos = self._append_only_filter_by_shard(partitioned_files)
-
-        def weight_func(f: DataFileMeta) -> int:
-            return max(f.file_size, self.open_file_cost)
-
-        splits = []
-        for key, file_entries in partitioned_files.items():
-            if not file_entries:
-                return []
-
-            data_files: List[DataFileMeta] = [e.file for e in file_entries]
-
-            packed_files: List[List[DataFileMeta]] = self._pack_for_ordered(data_files, weight_func,
-                                                                            self.target_split_size)
-            splits += self._build_split_from_pack(packed_files, file_entries, False, deletion_files_map)
-        if self.start_pos_of_this_subtask is not None or self.idx_of_this_subtask is not None:
-            # When files are combined into splits, it is necessary to find files that needs to be divided for each split
-            self._compute_split_start_end_pos(splits, plan_start_pos, plan_end_pos)
-        return splits
-
-    def _without_delete_row(self, data_file_meta: DataFileMeta) -> bool:
-        # null to true to be compatible with old version
-        if data_file_meta.delete_row_count is None:
-            return True
-        return data_file_meta.delete_row_count == 0
-
-    def _create_primary_key_splits(
-            self, file_entries: List[ManifestEntry], deletion_files_map: dict = None) -> List['Split']:
-        if self.idx_of_this_subtask is not None:
-            file_entries = self._primary_key_filter_by_shard(file_entries)
-        partitioned_files = defaultdict(list)
-        for entry in file_entries:
-            partitioned_files[(tuple(entry.partition.values), entry.bucket)].append(entry)
-
-        def single_weight_func(f: DataFileMeta) -> int:
-            return max(f.file_size, self.open_file_cost)
-
-        def weight_func(fl: List[DataFileMeta]) -> int:
-            return max(sum(f.file_size for f in fl), self.open_file_cost)
-
-        merge_engine = self.table.options.merge_engine()
-        merge_engine_first_row = merge_engine == MergeEngine.FIRST_ROW
-
-        splits = []
-        for key, file_entries in partitioned_files.items():
-            if not file_entries:
-                continue
-
-            data_files: List[DataFileMeta] = [e.file for e in file_entries]
-
-            raw_convertible = all(
-                f.level != 0 and self._without_delete_row(f)
-                for f in data_files
-            )
-
-            levels = {f.level for f in data_files}
-            one_level = len(levels) == 1
-
-            use_optimized_path = raw_convertible and (
-                self.deletion_vectors_enabled or merge_engine_first_row or one_level)
-            if use_optimized_path:
-                packed_files: List[List[DataFileMeta]] = self._pack_for_ordered(
-                    data_files, single_weight_func, self.target_split_size
-                )
-                splits += self._build_split_from_pack(
-                    packed_files, file_entries, True, deletion_files_map,
-                    use_optimized_path)
-            else:
-                partition_sort_runs: List[List[SortedRun]] = IntervalPartition(data_files).partition()
-                sections: List[List[DataFileMeta]] = [
-                    [file for s in sl for file in s.files]
-                    for sl in partition_sort_runs
-                ]
-
-                packed_files: List[List[List[DataFileMeta]]] = self._pack_for_ordered(sections, weight_func,
-                                                                                      self.target_split_size)
-
-                flatten_packed_files: List[List[DataFileMeta]] = [
-                    [file for sub_pack in pack for file in sub_pack]
-                    for pack in packed_files
-                ]
-                splits += self._build_split_from_pack(
-                    flatten_packed_files, file_entries, True,
-                    deletion_files_map, False)
-        return splits
-
-    def _create_data_evolution_splits(
-            self, file_entries: List[ManifestEntry], deletion_files_map: dict = None) -> List['Split']:
-        def sort_key(manifest_entry: ManifestEntry) -> tuple:
-            first_row_id = manifest_entry.file.first_row_id if manifest_entry.file.first_row_id is not None else float(
-                '-inf')
-            is_blob = 1 if self._is_blob_file(manifest_entry.file.file_name) else 0
-            # For files with same firstRowId, sort by maxSequenceNumber in descending order
-            # (larger sequence number means more recent data)
-            max_seq = manifest_entry.file.max_sequence_number
-            return first_row_id, is_blob, -max_seq
-
-        sorted_entries = sorted(file_entries, key=sort_key)
-
-        partitioned_files = defaultdict(list)
-        for entry in sorted_entries:
-            partitioned_files[(tuple(entry.partition.values), entry.bucket)].append(entry)
-
-        if self.start_pos_of_this_subtask is not None:
-            # shard data range: [plan_start_pos, plan_end_pos)
-            partitioned_files, plan_start_pos, plan_end_pos = \
-                self._data_evolution_filter_by_row_range(partitioned_files,
-                                                         self.start_pos_of_this_subtask,
-                                                         self.end_pos_of_this_subtask)
-        elif self.idx_of_this_subtask is not None:
-            # shard data range: [plan_start_pos, plan_end_pos)
-            partitioned_files, plan_start_pos, plan_end_pos = self._data_evolution_filter_by_shard(partitioned_files)
-
-        def weight_func(file_list: List[DataFileMeta]) -> int:
-            return max(sum(f.file_size for f in file_list), self.open_file_cost)
-
-        splits = []
-        for key, sorted_entries in partitioned_files.items():
-            if not sorted_entries:
-                continue
-
-            data_files: List[DataFileMeta] = [e.file for e in sorted_entries]
-
-            # Split files by firstRowId for data evolution
-            split_by_row_id = self._split_by_row_id(data_files)
-
-            # Pack the split groups for optimal split sizes
-            packed_files: List[List[List[DataFileMeta]]] = self._pack_for_ordered(split_by_row_id, weight_func,
-                                                                                  self.target_split_size)
-
-            # Flatten the packed files and build splits
-            flatten_packed_files: List[List[DataFileMeta]] = [
-                [file for sub_pack in pack for file in sub_pack]
-                for pack in packed_files
-            ]
-
-            splits += self._build_split_from_pack(flatten_packed_files, sorted_entries, False, deletion_files_map)
-
-        if self.start_pos_of_this_subtask is not None or self.idx_of_this_subtask is not None:
-            self._compute_split_start_end_pos(splits, plan_start_pos, plan_end_pos)
-        return splits
-
     def _split_by_row_id(self, files: List[DataFileMeta]) -> List[List[DataFileMeta]]:
         split_by_row_id = []
 
@@ -753,3 +520,380 @@ class FullStartingScanner(StartingScanner):
                         result.append(file)
 
         return result
+
+    def _without_delete_row(self, data_file_meta: DataFileMeta) -> bool:
+        # null to true to be compatible with old version
+        if data_file_meta.delete_row_count is None:
+            return True
+        return data_file_meta.delete_row_count == 0
+
+    def _partial_read(self):
+        return False
+
+    def _filter_by_pos(self, files):
+        pass
+
+    def _compute_split_pos(self, splits: List['Split']) -> None:
+        pass
+
+
+class PartialStartingScanner(FullStartingScanner):
+    def __init__(self, table, predicate: Optional[Predicate], limit: Optional[int]):
+        super().__init__(table, predicate, limit)
+        # for shard
+        self.idx_of_this_subtask = None
+        self.number_of_para_subtasks = None
+        self.start_pos_of_this_subtask = None
+        self.end_pos_of_this_subtask = None
+        self.plan_start_end_pos = None
+        # for sample
+        self.sample_num_rows = None
+        self.sample_indexes = None
+        self.file_positions = None
+
+    def with_shard(self, idx_of_this_subtask, number_of_para_subtasks) -> 'FullStartingScanner':
+        if idx_of_this_subtask >= number_of_para_subtasks:
+            raise Exception("idx_of_this_subtask must be less than number_of_para_subtasks")
+        if self.start_pos_of_this_subtask is not None:
+            raise Exception("with_shard and with_slice cannot be used simultaneously")
+        if self.sample_num_rows is not None:
+            raise Exception("with_shard and with_sample cannot be used simultaneously now")
+        self.idx_of_this_subtask = idx_of_this_subtask
+        self.number_of_para_subtasks = number_of_para_subtasks
+        return self
+
+    def with_slice(self, start_pos, end_pos) -> 'FullStartingScanner':
+        if start_pos >= end_pos:
+            raise Exception("start_pos must be less than end_pos")
+        if self.idx_of_this_subtask is not None:
+            raise Exception("with_slice and with_shard cannot be used simultaneously")
+        if self.sample_num_rows is not None:
+            raise Exception("with_slice and with_sample cannot be used simultaneously now")
+        self.start_pos_of_this_subtask = start_pos
+        self.end_pos_of_this_subtask = end_pos
+        return self
+
+    def with_sample(self, num_rows: int) -> 'FullStartingScanner':
+        if self.idx_of_this_subtask is not None:
+            raise Exception("with_sample and with_shard cannot be used simultaneously now")
+        if self.start_pos_of_this_subtask is not None:
+            raise Exception("with_sample and with_slice cannot be used simultaneously now")
+        self.sample_num_rows = num_rows
+        return self
+
+    def _filter_by_pos(self, files):
+        if self.table.is_primary_key_table:
+            return self._primary_key_filter_by_shard(files)
+        elif self.data_evolution:
+            if self.start_pos_of_this_subtask is not None:
+                # shard data range: [plan_start_pos, plan_end_pos)
+                files, self.plan_start_end_pos = \
+                    self._data_evolution_filter_by_slice(files,
+                                                         self.start_pos_of_this_subtask,
+                                                         self.end_pos_of_this_subtask)
+            elif self.idx_of_this_subtask is not None:
+                files, self.plan_start_end_pos = self._data_evolution_filter_by_shard(files)
+            elif self.sample_num_rows is not None:
+                files, self.file_positions = self._data_evolution_filter_by_sample(files)
+            return files
+        else:
+            if self.start_pos_of_this_subtask is not None:
+                # shard data range: [plan_start_pos, plan_end_pos)
+                files, self.plan_start_end_pos = \
+                    self._append_only_filter_by_slice(files,
+                                                      self.start_pos_of_this_subtask,
+                                                      self.end_pos_of_this_subtask)
+            elif self.idx_of_this_subtask is not None:
+                files, self.plan_start_end_pos = self._append_only_filter_by_shard(files)
+            elif self.sample_num_rows is not None:
+                files, self.file_positions = self._append_only_filter_by_sample(files)
+            return files
+
+    def _compute_split_pos(self, splits: List['Split']) -> None:
+        if self.start_pos_of_this_subtask is not None or self.idx_of_this_subtask is not None:
+            # When files are combined into splits, it is necessary to find files that needs to be divided for each split
+            self._compute_split_start_end_pos(splits, self.plan_start_end_pos[0], self.plan_start_end_pos[1])
+        elif self.sample_num_rows is not None:
+            # Set sample file positions for each split
+            for split in splits:
+                for file in split.files:
+                    split.sample_file_idx_map[file.file_name] = self.file_positions[file.file_name]
+
+    def _append_only_filter_by_slice(self, partitioned_files: defaultdict, start_pos: int,
+                                     end_pos: int) -> (defaultdict, int, int):
+        plan_start_pos = 0
+        plan_end_pos = 0
+        entry_end_pos = 0  # end row position of current file in all data
+        splits_start_pos = 0
+        filtered_partitioned_files = defaultdict(list)
+        # Iterate through all file entries to find files that overlap with current shard range
+        for key, file_entries in partitioned_files.items():
+            filtered_entries = []
+            for entry in file_entries:
+                entry_begin_pos = entry_end_pos  # Starting row position of current file in all data
+                entry_end_pos += entry.file.row_count  # Update to row position after current file
+
+                # If current file is completely after shard range, stop iteration
+                if entry_begin_pos >= end_pos:
+                    break
+                # If current file is completely before shard range, skip it
+                if entry_end_pos <= start_pos:
+                    continue
+                if entry_begin_pos <= start_pos < entry_end_pos:
+                    splits_start_pos = entry_begin_pos
+                    plan_start_pos = start_pos - entry_begin_pos
+                # If shard end position is within current file, record relative end position
+                if entry_begin_pos < end_pos <= entry_end_pos:
+                    plan_end_pos = end_pos - splits_start_pos
+                # Add files that overlap with shard range to result
+                filtered_entries.append(entry)
+            if filtered_entries:
+                filtered_partitioned_files[key] = filtered_entries
+
+        return filtered_partitioned_files, (plan_start_pos, plan_end_pos)
+
+    def _append_only_filter_by_shard(self, partitioned_files: defaultdict) -> (defaultdict, int, int):
+        """
+        Filter file entries by shard. Only keep the files within the range, which means
+        that only the starting and ending files need to be further divided subsequently
+        """
+        total_row = 0
+        # Sort by file creation time to ensure consistent sharding
+        for key, file_entries in partitioned_files.items():
+            for entry in file_entries:
+                total_row += entry.file.row_count
+
+        # Calculate number of rows this shard should process using balanced distribution
+        # Distribute remainder evenly among first few shards to avoid last shard overload
+        base_rows_per_shard = total_row // self.number_of_para_subtasks
+        remainder = total_row % self.number_of_para_subtasks
+
+        # Each of the first 'remainder' shards gets one extra row
+        if self.idx_of_this_subtask < remainder:
+            num_row = base_rows_per_shard + 1
+            start_pos = self.idx_of_this_subtask * (base_rows_per_shard + 1)
+        else:
+            num_row = base_rows_per_shard
+            start_pos = (remainder * (base_rows_per_shard + 1) +
+                         (self.idx_of_this_subtask - remainder) * base_rows_per_shard)
+
+        end_pos = start_pos + num_row
+
+        return self._append_only_filter_by_slice(partitioned_files, start_pos, end_pos)
+
+    def _append_only_filter_by_sample(self, partitioned_files) -> (defaultdict, Dict[str, List[int]]):
+        """
+        Randomly sample num_rows data from partitioned_files:
+        1. First use random to generate num_rows indexes
+        2. Iterate through partitioned_files, find the file entries where corresponding indexes are located,
+           add them to filtered_partitioned_files, and for each entry, add indexes to the list
+        """
+        # Calculate total number of rows
+        total_rows = 0
+        for key, file_entries in partitioned_files.items():
+            for entry in file_entries:
+                total_rows += entry.file.row_count
+
+        # Generate random sample indexes
+        sample_indexes = sorted(random.sample(range(total_rows), self.sample_num_rows))
+
+        # Map each sample index to its corresponding file and local index
+        filtered_partitioned_files = defaultdict(list)
+        file_positions = {}  # {file_name: [local_indexes]}
+        self._generate_split_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
+                                            sample_indexes, is_blob=False)
+        return filtered_partitioned_files, file_positions
+
+    def _data_evolution_filter_by_slice(self, partitioned_files: defaultdict,
+                                        start_pos: int,
+                                        end_pos: int) -> (defaultdict, int, int):
+        plan_start_pos = 0
+        plan_end_pos = 0
+        entry_end_pos = 0  # end row position of current file in all data
+        splits_start_pos = 0
+        filtered_partitioned_files = defaultdict(list)
+        # Iterate through all file entries to find files that overlap with current shard range
+        for key, file_entries in partitioned_files.items():
+            filtered_entries = []
+            blob_added = False  # If it is true, all blobs corresponding to this data file are added
+            for entry in file_entries:
+                if self._is_blob_file(entry.file.file_name):
+                    if blob_added:
+                        filtered_entries.append(entry)
+                    continue
+                blob_added = False
+                entry_begin_pos = entry_end_pos  # Starting row position of current file in all data
+                entry_end_pos += entry.file.row_count  # Update to row position after current file
+
+                # If current file is completely after shard range, stop iteration
+                if entry_begin_pos >= end_pos:
+                    break
+                # If current file is completely before shard range, skip it
+                if entry_end_pos <= start_pos:
+                    continue
+                if entry_begin_pos <= start_pos < entry_end_pos:
+                    splits_start_pos = entry_begin_pos
+                    plan_start_pos = start_pos - entry_begin_pos
+                # If shard end position is within current file, record relative end position
+                if entry_begin_pos < end_pos <= entry_end_pos:
+                    plan_end_pos = end_pos - splits_start_pos
+                # Add files that overlap with shard range to result
+                filtered_entries.append(entry)
+                blob_added = True
+            if filtered_entries:
+                filtered_partitioned_files[key] = filtered_entries
+
+        return filtered_partitioned_files, (plan_start_pos, plan_end_pos)
+
+    def _data_evolution_filter_by_shard(self, partitioned_files: defaultdict) -> (defaultdict, int, int):
+        total_row = 0
+        for key, file_entries in partitioned_files.items():
+            for entry in file_entries:
+                if not self._is_blob_file(entry.file.file_name):
+                    total_row += entry.file.row_count
+
+        # Calculate number of rows this shard should process using balanced distribution
+        # Distribute remainder evenly among first few shards to avoid last shard overload
+        base_rows_per_shard = total_row // self.number_of_para_subtasks
+        remainder = total_row % self.number_of_para_subtasks
+
+        # Each of the first 'remainder' shards gets one extra row
+        if self.idx_of_this_subtask < remainder:
+            num_row = base_rows_per_shard + 1
+            start_pos = self.idx_of_this_subtask * (base_rows_per_shard + 1)
+        else:
+            num_row = base_rows_per_shard
+            start_pos = (remainder * (base_rows_per_shard + 1) +
+                         (self.idx_of_this_subtask - remainder) * base_rows_per_shard)
+
+        end_pos = start_pos + num_row
+        return self._data_evolution_filter_by_slice(partitioned_files, start_pos, end_pos)
+
+    def _data_evolution_filter_by_sample(self, partitioned_files) -> (defaultdict, Dict[str, List[int]]):
+        """
+        Randomly sample num_rows data from partitioned_files:
+        1. First use random to generate num_rows indexes
+        2. Iterate through partitioned_files, find the file entries where corresponding indexes are located,
+           add them to filtered_partitioned_files, and for each entry, add indexes to the list
+        """
+        # Calculate total number of rows
+        total_rows = 0
+        for key, file_entries in partitioned_files.items():
+            for entry in file_entries:
+                if not self._is_blob_file(entry.file.file_name):
+                    total_rows += entry.file.row_count
+        # Generate random sample indexes
+        sample_indexes = sorted(random.sample(range(total_rows), self.sample_num_rows))
+
+        # Map each sample index to its corresponding file and local index
+        filtered_partitioned_files = defaultdict(list)
+        file_positions = {}  # {file_name: [local_indexes]}
+        self._generate_split_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
+                                            sample_indexes, is_blob=False)
+        if self.data_evolution:
+            self._generate_split_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
+                                                sample_indexes, is_blob=True)
+
+        return filtered_partitioned_files, file_positions
+
+    def _primary_key_filter_by_shard(self, file_entries: List[ManifestEntry]) -> List[ManifestEntry]:
+        filtered_entries = []
+        for entry in file_entries:
+            if entry.bucket % self.number_of_para_subtasks == self.idx_of_this_subtask:
+                filtered_entries.append(entry)
+        return filtered_entries
+
+    def _generate_split_sample_idx_map(self, partitioned_files, filtered_partitioned_files, file_positions,
+                                       sample_indexes, is_blob):
+        current_row = 0
+        sample_idx = 0
+
+        for key, file_entries in partitioned_files.items():
+            filtered_entries = []
+            for entry in file_entries:
+                if not is_blob and self._is_blob_file(entry.file.file_name):
+                    continue
+                if is_blob and not self._is_blob_file(entry.file.file_name):
+                    continue
+                file_start_row = current_row
+                file_end_row = current_row + entry.file.row_count
+
+                # Find all sample indexes that fall within this file
+                local_indexes = []
+                while sample_idx < len(sample_indexes) and sample_indexes[sample_idx] < file_end_row:
+                    if sample_indexes[sample_idx] >= file_start_row:
+                        # Convert global index to local index within this file
+                        local_index = sample_indexes[sample_idx] - file_start_row
+                        local_indexes.append(local_index)
+                    sample_idx += 1
+
+                # If this file contains any sampled rows, include it
+                if local_indexes:
+                    filtered_entries.append(entry)
+                    file_positions[entry.file.file_name] = local_indexes
+
+                current_row = file_end_row
+
+                # Early exit if we've processed all sample indexes
+                if sample_idx >= len(sample_indexes):
+                    break
+
+            if filtered_entries:
+                filtered_partitioned_files[key] = filtered_partitioned_files.get(key, []) + filtered_entries
+
+                # Early exit if we've processed all sample indexes
+            if sample_idx >= len(sample_indexes):
+                break
+
+    def _compute_split_start_end_pos(self, splits: List[Split], plan_start_pos, plan_end_pos):
+        """
+        Find files that needs to be divided for each split
+        :param splits: splits
+        :param plan_start_pos: plan begin row in all splits data
+        :param plan_end_pos: plan end row in all splits data
+        """
+        file_end_pos = 0  # end row position of current file in all splits data
+
+        for split in splits:
+            cur_split_end_pos = file_end_pos
+            # Compute split_file_idx_map for data files
+            file_end_pos = self._compute_split_file_idx_map(plan_start_pos, plan_end_pos,
+                                                            split, cur_split_end_pos, False)
+            # Compute split_file_idx_map for blob files
+            if self.data_evolution:
+                self._compute_split_file_idx_map(plan_start_pos, plan_end_pos,
+                                                 split, cur_split_end_pos, True)
+
+    def _compute_split_file_idx_map(self, plan_start_pos, plan_end_pos, split: Split,
+                                    file_end_pos: int, is_blob: bool = False):
+        """
+        Traverse all the files in current split, find the starting shard and ending shard files,
+        and add them to shard_file_idx_map;
+        - for data file, only two data files will be divided in all splits.
+        - for blob file, perhaps there will be some unnecessary files in addition to two files(start and end).
+          Add them to shard_file_idx_map as well, because they need to be removed later.
+        """
+        row_cnt = 0
+        for file in split.files:
+            if not is_blob and self._is_blob_file(file.file_name):
+                continue
+            if is_blob and not self._is_blob_file(file.file_name):
+                continue
+            row_cnt += file.row_count
+            file_begin_pos = file_end_pos  # Starting row position of current file in all data
+            file_end_pos += file.row_count  # Update to row position after current file
+            if file_begin_pos <= plan_start_pos < plan_end_pos <= file_end_pos:
+                split.shard_file_idx_map[file.file_name] = (
+                    plan_start_pos - file_begin_pos, plan_end_pos - file_begin_pos)
+            # If shard start position is within current file, record actual start position and relative offset
+            elif file_begin_pos < plan_start_pos < file_end_pos:
+                split.shard_file_idx_map[file.file_name] = (plan_start_pos - file_begin_pos, file.row_count)
+            # If shard end position is within current file, record relative end position
+            elif file_begin_pos < plan_end_pos < file_end_pos:
+                split.shard_file_idx_map[file.file_name] = (0, plan_end_pos - file_begin_pos)
+            elif file_end_pos <= plan_start_pos or file_begin_pos >= plan_end_pos:
+                split.shard_file_idx_map[file.file_name] = (-1, -1)
+        return file_end_pos
+
+    def _partial_read(self):
+        return True

--- a/paimon-python/pypaimon/read/split.py
+++ b/paimon-python/pypaimon/read/split.py
@@ -34,6 +34,7 @@ class Split:
     _row_count: int
     _file_size: int
     shard_file_idx_map: Dict[str, Tuple[int, int]] = field(default_factory=dict)  # file_name -> (start_idx, end_idx)
+    sample_file_idx_map: Dict[str, List[int]] = field(default_factory=dict)  # file_name -> [sample_indexes]
     raw_convertible: bool = False
     data_deletion_files: Optional[List[DeletionFile]] = None
 

--- a/paimon-python/pypaimon/read/table_scan.py
+++ b/paimon-python/pypaimon/read/table_scan.py
@@ -23,7 +23,7 @@ from pypaimon.common.predicate import Predicate
 
 from pypaimon.read.plan import Plan
 from pypaimon.read.scanner.empty_starting_scanner import EmptyStartingScanner
-from pypaimon.read.scanner.full_starting_scanner import FullStartingScanner
+from pypaimon.read.scanner.full_starting_scanner import FullStartingScanner, PartialStartingScanner
 from pypaimon.read.scanner.incremental_starting_scanner import \
     IncrementalStartingScanner
 from pypaimon.read.scanner.starting_scanner import StartingScanner
@@ -39,9 +39,12 @@ class TableScan:
         self.table: FileStoreTable = table
         self.predicate = predicate
         self.limit = limit
-        self.starting_scanner = self._create_starting_scanner()
+        self.starting_scanner = None
+        self.partial_read: bool = None
 
     def plan(self) -> Plan:
+        if self.starting_scanner is None:
+            self.starting_scanner = self._create_starting_scanner()
         return self.starting_scanner.scan()
 
     def _create_starting_scanner(self) -> Optional[StartingScanner]:
@@ -66,12 +69,30 @@ class TableScan:
                 return EmptyStartingScanner()
             return IncrementalStartingScanner.between_timestamps(self.table, self.predicate, self.limit,
                                                                  start_timestamp, end_timestamp)
-        return FullStartingScanner(self.table, self.predicate, self.limit)
+        elif self.partial_read:
+            return PartialStartingScanner(self.table, self.predicate, self.limit)
+        else:
+            return FullStartingScanner(self.table, self.predicate, self.limit)
 
     def with_shard(self, idx_of_this_subtask, number_of_para_subtasks) -> 'TableScan':
+        self.partial_read = True
+        self.starting_scanner = self._create_starting_scanner()
         self.starting_scanner.with_shard(idx_of_this_subtask, number_of_para_subtasks)
         return self
 
     def with_slice(self, start_pos, end_pos) -> 'TableScan':
+        self.partial_read = True
+        self.starting_scanner = self._create_starting_scanner()
         self.starting_scanner.with_slice(start_pos, end_pos)
+        return self
+
+    def with_sample(self, num_rows: int) -> 'TableScan':
+        """Sample the table with the given number of rows.
+
+        params:
+            num_rows: The number of rows to sample.
+        """
+        self.partial_read = True
+        self.starting_scanner = self._create_starting_scanner()
+        self.starting_scanner.with_sample(num_rows)
         return self

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -2567,6 +2567,207 @@ class DataBlobWriterTest(unittest.TestCase):
 
         self.assertEqual(actual, expected)
 
+    def test_data_blob_writer_with_sample(self):
+        """Test DataBlobWriter with mixed data types in blob column."""
+
+        # Create schema with blob column
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('type', pa.string()),
+            ('data', pa.large_binary()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true'
+            }
+        )
+        self.catalog.create_table('test_db.with_sample', schema, False)
+        table = self.catalog.get_table('test_db.with_sample')
+
+        # Use proper table API to create writer
+        write_builder = table.new_batch_write_builder()
+        blob_writer = write_builder.new_write()
+
+        # Test data with different types of blob content
+        test_data = pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'type': ['text', 'json', 'binary', 'image', 'pdf'],
+            'data': [
+                b'This is text content',
+                b'{"key": "value", "number": 42}',
+                b'\x00\x01\x02\x03\xff\xfe\xfd',
+                b'PNG_IMAGE_DATA_PLACEHOLDER',
+                b'%PDF-1.4\nPDF_CONTENT_PLACEHOLDER'
+            ]
+        }, schema=pa_schema)
+
+        # Write mixed data
+        total_rows = 0
+        for batch in test_data.to_batches():
+            blob_writer.write_arrow_batch(batch)
+            total_rows += batch.num_rows
+
+        # Test prepare commit
+        commit_messages = blob_writer.prepare_commit()
+        # Create commit and commit the data
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        blob_writer.close()
+
+        # Read data back using table API
+        read_builder = table.new_read_builder()
+        table_scan = read_builder.new_scan().with_sample(2)
+        table_read = read_builder.new_read()
+        splits = table_scan.plan().splits()
+        actual = table_read.to_arrow(splits)
+        expected_ids = set(test_data['id'].to_pylist())
+        actual_ids = set(actual['id'].to_pylist())
+        self.assertEqual(2, actual.num_rows, "Should have 2 rows")
+        self.assertTrue(actual_ids.issubset(expected_ids),
+                        f"Actual user_ids {actual_ids} should be subset of written ids {expected_ids}")
+
+    def test_blob_write_read_large_data_with_rolling_with_sample(self):
+        """
+        Test writing and reading large blob data with file rolling and sample.
+
+        Test workflow:
+        - Creates a table with blob column and 10MB target file size
+        - Writes 4 batches of 40 records each (160 total records)
+        - Each record contains a 3MB blob
+        - Random sample 12 records
+        - Verifies blob data integrity and size
+        """
+
+        # Create schema with blob column
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('record_id_of_batch', pa.int32()),
+            ('metadata', pa.string()),
+            ('large_blob', pa.large_binary()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'blob.target-file-size': '10MB'
+            }
+        )
+        self.catalog.create_table('test_db.with_rolling_with_sample', schema, False)
+        table = self.catalog.get_table('test_db.with_rolling_with_sample')
+
+        # Create large blob data
+        large_blob_size = 3 * 1024 * 1024
+        blob_pattern = b'LARGE_BLOB_PATTERN_' + b'X' * 1024  # ~1KB pattern
+        pattern_size = len(blob_pattern)
+        repetitions = large_blob_size // pattern_size
+        large_blob_data = blob_pattern * repetitions
+
+        actual_size = len(large_blob_data)
+        print(f"Created blob data: {actual_size:,} bytes ({actual_size / (1024 * 1024):.2f} MB)")
+        # Write 4 batches of 40 records
+        for i in range(4):
+            write_builder = table.new_batch_write_builder()
+            writer = write_builder.new_write()
+            # Write 40 records
+            for record_id in range(40):
+                test_data = pa.Table.from_pydict({
+                    'id': [i * 40 + record_id + 1],  # Unique ID for each row
+                    'record_id_of_batch': [record_id],
+                    'metadata': [f'Large blob batch {record_id + 1}'],
+                    'large_blob': [large_blob_data]
+                }, schema=pa_schema)
+                writer.write_arrow(test_data)
+
+            commit_messages = writer.prepare_commit()
+            commit = write_builder.new_commit()
+            commit.commit(commit_messages)
+            writer.close()
+
+        # Read data back
+        read_builder = table.new_read_builder()
+        table_scan = read_builder.new_scan().with_sample(12)
+        table_read = read_builder.new_read()
+        result = table_read.to_arrow(table_scan.plan().splits())
+
+        # Verify the data
+        self.assertEqual(result.num_rows, 12, "Should have 12 rows")
+        self.assertEqual(result.num_columns, 4, "Should have 4 columns")
+
+        # Verify blob data integrity
+        blob_data = result.column('large_blob').to_pylist()
+        self.assertEqual(len(blob_data), 12, "Should have 54 blob records")
+
+    def test_blob_write_read_large_data_volums_with_rolling_with_sample(self):
+        """
+        Test writing and reading large blob data with file rolling and sample.
+        Test workflow:
+        - Creates a table with blob column and 10MB target file size
+        - Writes 10000 records of 5KB blob data each
+        - Random sample 1000 records
+        - Verifies data size
+        """
+        # Create schema with blob column
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('batch_id', pa.int32()),
+            ('metadata', pa.string()),
+            ('large_blob', pa.large_binary()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'blob.target-file-size': '10MB'
+            }
+        )
+        self.catalog.create_table('test_db.large_rolling_with_sample', schema, False)
+        table = self.catalog.get_table('test_db.large_rolling_with_sample')
+
+        # Create large blob data
+        large_blob_size = 5 * 1024  #
+        blob_pattern = b'LARGE_BLOB_PATTERN_' + b'X' * 1024  # ~1KB pattern
+        pattern_size = len(blob_pattern)
+        repetitions = large_blob_size // pattern_size
+        large_blob_data = blob_pattern * repetitions
+
+        actual_size = len(large_blob_data)
+        print(f"Created blob data: {actual_size:,} bytes ({actual_size / (1024 * 1024):.2f} MB)")
+        # Write 10000 records of data
+        num_row = 10000
+        expected = pa.Table.from_pydict({
+            'id': [i for i in range(1, num_row + 1)],
+            'batch_id': [11] * num_row,
+            'metadata': [f'Large blob batch {11}'] * num_row,
+            'large_blob': [i.to_bytes(2, byteorder='little') + large_blob_data for i in range(num_row)]
+        }, schema=pa_schema)
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(expected)
+
+        commit_messages = writer.prepare_commit()
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        writer.close()
+
+        # Read data back
+        read_builder = table.new_read_builder()
+        table_scan = read_builder.new_scan().with_sample(1000)
+        table_read = read_builder.new_read()
+        actual = table_read.to_arrow(table_scan.plan().splits())
+
+        # Verify the data
+        actual_ids = set(actual['id'].to_pylist())
+        expected_ids = set(list(range(1, num_row + 1)))
+        self.assertEqual(1000, actual.num_rows, "Should have 1000 rows")
+        self.assertTrue(actual_ids.issubset(expected_ids))
+
     def test_concurrent_blob_writes_with_retry(self):
         """Test concurrent blob writes to verify retry mechanism works correctly."""
         import threading

--- a/paimon-python/pypaimon/tests/reader_base_test.py
+++ b/paimon-python/pypaimon/tests/reader_base_test.py
@@ -512,6 +512,7 @@ class ReaderBasicTest(unittest.TestCase):
 
         pk_read_builder = pk_table.new_read_builder()
         pk_table_scan = pk_read_builder.new_scan()
+        pk_table_scan.starting_scanner = pk_table_scan._create_starting_scanner()
         latest_snapshot = SnapshotManager(pk_table).get_latest_snapshot()
         pk_manifest_files = pk_table_scan.starting_scanner.manifest_list_manager.read_all(latest_snapshot)
         pk_manifest_entries = pk_table_scan.starting_scanner.manifest_file_manager.read(
@@ -582,6 +583,7 @@ class ReaderBasicTest(unittest.TestCase):
 
         read_builder = table.new_read_builder()
         table_scan = read_builder.new_scan()
+        table_scan.starting_scanner = table_scan._create_starting_scanner()
         latest_snapshot = SnapshotManager(table).get_latest_snapshot()
         manifest_files = table_scan.starting_scanner.manifest_list_manager.read_all(latest_snapshot)
         manifest_entries = table_scan.starting_scanner.manifest_file_manager.read(
@@ -1089,6 +1091,7 @@ class ReaderBasicTest(unittest.TestCase):
         # Read manifest to verify value_stats_cols is None (all fields included)
         read_builder = table.new_read_builder()
         table_scan = read_builder.new_scan()
+        table_scan.starting_scanner = table_scan._create_starting_scanner()
         latest_snapshot = SnapshotManager(table).get_latest_snapshot()
         manifest_files = table_scan.starting_scanner.manifest_list_manager.read_all(latest_snapshot)
         manifest_entries = table_scan.starting_scanner.manifest_file_manager.read(
@@ -1111,7 +1114,7 @@ class ReaderBasicTest(unittest.TestCase):
 
         value_stats = file_meta.value_stats
         self.assertIsNotNone(value_stats, "value_stats should not be None")
-        
+
         if file_meta.value_stats_cols is None:
             expected_value_fields = ['name', 'price', 'category']
             self.assertGreaterEqual(value_stats.min_values.arity, len(expected_value_fields),
@@ -1135,17 +1138,17 @@ class ReaderBasicTest(unittest.TestCase):
             self.assertEqual(len(value_stats.null_counts), expected_arity,
                              f"value_stats null_counts should have {expected_arity} elements, "
                              f"but got {len(value_stats.null_counts)}")
-            
+
             self.assertEqual(value_stats.min_values.arity, len(file_meta.value_stats_cols),
                              f"value_stats.min_values.arity ({value_stats.min_values.arity}) must match "
                              f"value_stats_cols length ({len(file_meta.value_stats_cols)})")
-            
+
             for field_name in file_meta.value_stats_cols:
                 is_system_field = (field_name.startswith('_KEY_') or
                                    field_name in ['_SEQUENCE_NUMBER', '_VALUE_KIND', '_ROW_ID'])
                 self.assertFalse(is_system_field,
                                  f"value_stats_cols should not contain system field: {field_name}")
-            
+
             value_stats_fields = table_scan.starting_scanner.manifest_file_manager._get_value_stats_fields(
                 {'_VALUE_STATS_COLS': file_meta.value_stats_cols},
                 table.fields
@@ -1161,7 +1164,7 @@ class ReaderBasicTest(unittest.TestCase):
 
             self.assertEqual(len(min_value_stats), 3, "min_value_stats should have 3 values")
             self.assertEqual(len(max_value_stats), 3, "max_value_stats should have 3 values")
-        
+
         actual_data = read_builder.new_read().to_arrow(table_scan.plan().splits())
         self.assertEqual(actual_data.num_rows, 5, "Should have 5 rows")
         actual_ids = sorted(actual_data.column('id').to_pylist())

--- a/paimon-python/pypaimon/tests/reader_primary_key_test.py
+++ b/paimon-python/pypaimon/tests/reader_primary_key_test.py
@@ -358,6 +358,7 @@ class PkReaderTest(unittest.TestCase):
         latest_snapshot = snapshot_manager.get_latest_snapshot()
         read_builder = table.new_read_builder()
         table_scan = read_builder.new_scan()
+        table_scan.starting_scanner = table_scan._create_starting_scanner()
         manifest_list_manager = table_scan.starting_scanner.manifest_list_manager
         manifest_files = manifest_list_manager.read_all(latest_snapshot)
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds random row sampling and unifies partial-reading (shard/slice/sample).
> 
> - New `TableScan.with_sample(num_rows)` API; selects `PartialStartingScanner` for shard/slice/sample paths and defers scanner creation until planning
> - Introduces `SampleBatchReader` and `Split.sample_file_idx_map`; integrated in `SplitRead` (raw/data evolution) to read sampled rows efficiently (including blobs)
> - Refactors split generation to support partial reads via `_partial_read`, `_filter_by_pos`, and `_compute_split_pos` hooks; computes shard/slice/sample positions for append-only and data-evolution tables; preserves DV handling
> - Eases blob merge constraints by removing strict continuous `first_row_id` check in `BlobBunch`
> - Reorders lint checks (`pytest_check` before `pytest_torch_check`)
> - Adds extensive sampling tests across blob tables, REST, Ray Data, and large datasets; minor test setup tweaks to materialize scanners early
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1775a35ce1fe014fd45f00949fef4eff42265c81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->