### PR TITLE
Pr 7032

### DIFF
--- a/paimon-python/dev/lint-python.sh
+++ b/paimon-python/dev/lint-python.sh
@@ -107,7 +107,7 @@ function collect_checks() {
 function get_all_supported_checks() {
     _OLD_IFS=$IFS
     IFS=$'\n'
-    SUPPORT_CHECKS=("flake8_check" "pytest_torch_check" "pytest_check" "mixed_check") # control the calling sequence
+    SUPPORT_CHECKS=("flake8_check" "pytest_check" "pytest_torch_check" "mixed_check") # control the calling sequence
     for fun in $(declare -F); do
         if [[ `regexp_match "$fun" "_check$"` = true ]]; then
             check_name="${fun:11}"

--- a/paimon-python/pypaimon/read/table_scan.py
+++ b/paimon-python/pypaimon/read/table_scan.py
@@ -85,14 +85,3 @@ class TableScan:
         self.starting_scanner = self._create_starting_scanner()
         self.starting_scanner.with_slice(start_pos, end_pos)
         return self
-
-    def with_sample(self, num_rows: int) -> 'TableScan':
-        """Sample the table with the given number of rows.
-
-        params:
-            num_rows: The number of rows to sample.
-        """
-        self.partial_read = True
-        self.starting_scanner = self._create_starting_scanner()
-        self.starting_scanner.with_sample(num_rows)
-        return self

--- a/paimon-python/pypaimon/tests/reader_primary_key_test.py
+++ b/paimon-python/pypaimon/tests/reader_primary_key_test.py
@@ -358,6 +358,7 @@ class PkReaderTest(unittest.TestCase):
         latest_snapshot = snapshot_manager.get_latest_snapshot()
         read_builder = table.new_read_builder()
         table_scan = read_builder.new_scan()
+        table_scan.starting_scanner = table_scan._create_starting_scanner()
         manifest_list_manager = table_scan.starting_scanner.manifest_list_manager
         manifest_files = manifest_list_manager.read_all(latest_snapshot)
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors Python reader scan flow to cleanly support partial reads and updates tests accordingly.
> 
> - Introduces `PartialStartingScanner` (subclass of `FullStartingScanner`) encapsulating shard/slice logic: positional filtering and split start/end computation; `FullStartingScanner` now exposes hooks (`_partial_read`, `_filter_by_pos`, `_compute_split_pos`) and no longer carries shard state
> - Updates split creation for append-only/PK/data-evolution paths to conditionally apply partial-read filtering and position computation
> - `TableScan` lazily creates `starting_scanner` and chooses `PartialStartingScanner` when `with_shard`/`with_slice` is used; adds `partial_read` flag
> - Tests adjusted to explicitly initialize `starting_scanner` via `_create_starting_scanner` before using internals; minor whitespace tweaks
> - Dev tooling: reorder lint checks to run `pytest_check` before `pytest_torch_check`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81294e3de1a91c648582f905c627c8e5bac57915. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->