### PR TITLE
[python] Fix RecordBatch compatibility issues in py36

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -53,7 +53,6 @@ import org.apache.paimon.utils.TraceableFileIO;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import java.nio.file.Files;
@@ -357,7 +356,6 @@ public class JavaPyE2ETest {
 
     @Test
     @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
-    @DisabledIfSystemProperty(named = "python.version", matches = "3.6")
     public void testReadPkTable() throws Exception {
         Identifier identifier = identifier("mixed_test_pk_tablep_parquet");
         Table table = catalog.getTable(identifier);

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -105,11 +105,6 @@ class JavaPyReadWriteTest(unittest.TestCase):
 
     @parameterized.expand(get_file_format_params())
     def test_py_write_read_pk_table(self, file_format):
-        if sys.version_info[:2] == (3, 6):
-            self.skipTest(
-                "Skipping on Python 3.6 due to PyArrow compatibility issue (RecordBatch.add_column not available). "
-                "Will be fixed in next PR."
-            )
         pa_schema = pa.schema([
             ('id', pa.int32()),
             ('name', pa.string()),

--- a/paimon-python/pypaimon/write/writer/key_value_data_writer.py
+++ b/paimon-python/pypaimon/write/writer/key_value_data_writer.py
@@ -34,9 +34,7 @@ class KeyValueDataWriter(DataWriter):
         return self._sort_by_primary_key(combined)
 
     def _add_system_fields(self, data: pa.RecordBatch) -> pa.RecordBatch:
-        """
-        Add system fields: _KEY_{pk_key}, _SEQUENCE_NUMBER, _VALUE_KIND.
-        """
+        """Add system fields: _KEY_{pk_key}, _SEQUENCE_NUMBER, _VALUE_KIND."""
         num_rows = data.num_rows
         
         new_arrays = []

--- a/paimon-python/pypaimon/write/writer/key_value_data_writer.py
+++ b/paimon-python/pypaimon/write/writer/key_value_data_writer.py
@@ -36,26 +36,34 @@ class KeyValueDataWriter(DataWriter):
     def _add_system_fields(self, data: pa.RecordBatch) -> pa.RecordBatch:
         """Add system fields: _KEY_{pk_key}, _SEQUENCE_NUMBER, _VALUE_KIND."""
         num_rows = data.num_rows
-        enhanced_table = data
-
+        
+        new_arrays = []
+        new_names = []
+        
         for pk_key in reversed(self.trimmed_primary_keys):
-            if pk_key in data.column_names:
+            if pk_key in data.schema.names:
                 key_column = data.column(pk_key)
-                enhanced_table = enhanced_table.add_column(0, f'_KEY_{pk_key}', key_column)
-
+                new_arrays.append(key_column)
+                new_names.append(f'_KEY_{pk_key}')
+        
+        for i in range(data.num_columns):
+            new_arrays.append(data.column(i))
+            new_names.append(data.schema.names[i])
+        
         sequence_column = pa.array([self.sequence_generator.next() for _ in range(num_rows)], type=pa.int64())
-        enhanced_table = enhanced_table.add_column(len(self.trimmed_primary_keys), '_SEQUENCE_NUMBER', sequence_column)
-
+        new_arrays.append(sequence_column)
+        new_names.append('_SEQUENCE_NUMBER')
+        
         # TODO: support real row kind here
         value_kind_column = pa.array([0] * num_rows, type=pa.int8())
-        enhanced_table = enhanced_table.add_column(len(self.trimmed_primary_keys) + 1, '_VALUE_KIND',
-                                                   value_kind_column)
-
-        return enhanced_table
+        new_arrays.append(value_kind_column)
+        new_names.append('_VALUE_KIND')
+        
+        return pa.RecordBatch.from_arrays(new_arrays, names=new_names)
 
     def _sort_by_primary_key(self, data: pa.RecordBatch) -> pa.RecordBatch:
         sort_keys = [(key, 'ascending') for key in self.trimmed_primary_keys]
-        if '_SEQUENCE_NUMBER' in data.column_names:
+        if '_SEQUENCE_NUMBER' in data.schema.names:
             sort_keys.append(('_SEQUENCE_NUMBER', 'ascending'))
 
         sorted_indices = pc.sort_indices(data, sort_keys=sort_keys)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves PyArrow 0.15/Python 3.6 compatibility and re-enables e2e coverage for PK tables.
> 
> - In `KeyValueDataWriter`, stop using `RecordBatch.add_column`; construct new batches via `pa.RecordBatch.from_arrays`, prepend system fields (`_KEY_*`, `_SEQUENCE_NUMBER`, `_VALUE_KIND`), and use `schema.names` checks to avoid 3.6 incompatibilities; update sorting to check `'_SEQUENCE_NUMBER'` via `schema.names`.
> - Tests: remove Python 3.6 skips in Java (`JavaPyE2ETest.testReadPkTable`) and Python (`test_py_write_read_pk_table`), keeping `@EnabledIfSystemProperty("run.e2e.tests", "true")`; minor test read/print adjustments remain unchanged functionally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7760003b69ee2b77ce364db2e9f78aa2047606f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->