### PR TITLE
[python] introduce minRowId and maxRowId to ManifestList file

### DIFF
--- a/paimon-python/pypaimon/manifest/manifest_list_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_list_manager.py
@@ -79,6 +79,12 @@ class ManifestListManager:
                 num_deleted_files=record['_NUM_DELETED_FILES'],
                 partition_stats=partition_stats,
                 schema_id=record['_SCHEMA_ID'],
+                min_bucket=record.get('_MIN_BUCKET'),
+                max_bucket=record.get('_MAX_BUCKET'),
+                min_level=record.get('_MIN_LEVEL'),
+                max_level=record.get('_MAX_LEVEL'),
+                min_row_id=record.get('_MIN_ROW_ID'),
+                max_row_id=record.get('_MAX_ROW_ID'),
             )
             manifest_files.append(manifest_file_meta)
 
@@ -99,6 +105,12 @@ class ManifestListManager:
                     "_NULL_COUNTS": meta.partition_stats.null_counts,
                 },
                 "_SCHEMA_ID": meta.schema_id,
+                "_MIN_BUCKET": meta.min_bucket,
+                "_MAX_BUCKET": meta.max_bucket,
+                "_MIN_LEVEL": meta.min_level,
+                "_MAX_LEVEL": meta.max_level,
+                "_MIN_ROW_ID": meta.min_row_id,
+                "_MAX_ROW_ID": meta.max_row_id,
             }
             avro_records.append(avro_record)
 

--- a/paimon-python/pypaimon/manifest/schema/manifest_file_meta.py
+++ b/paimon-python/pypaimon/manifest/schema/manifest_file_meta.py
@@ -17,6 +17,7 @@
 ################################################################################
 
 from dataclasses import dataclass
+from typing import Optional
 
 from pypaimon.manifest.schema.simple_stats import (PARTITION_STATS_SCHEMA,
                                                    SimpleStats)
@@ -30,6 +31,12 @@ class ManifestFileMeta:
     num_deleted_files: int
     partition_stats: SimpleStats
     schema_id: int
+    min_bucket: Optional[int] = None
+    max_bucket: Optional[int] = None
+    min_level: Optional[int] = None
+    max_level: Optional[int] = None
+    min_row_id: Optional[int] = None
+    max_row_id: Optional[int] = None
 
 
 MANIFEST_FILE_META_SCHEMA = {
@@ -43,5 +50,11 @@ MANIFEST_FILE_META_SCHEMA = {
         {"name": "_NUM_DELETED_FILES", "type": "long"},
         {"name": "_PARTITION_STATS", "type": PARTITION_STATS_SCHEMA},
         {"name": "_SCHEMA_ID", "type": "long"},
+        {"name": "_MIN_BUCKET", "type": ["null", "int"], "default": None},
+        {"name": "_MAX_BUCKET", "type": ["null", "int"], "default": None},
+        {"name": "_MIN_LEVEL", "type": ["null", "int"], "default": None},
+        {"name": "_MAX_LEVEL", "type": ["null", "int"], "default": None},
+        {"name": "_MIN_ROW_ID", "type": ["null", "long"], "default": None},
+        {"name": "_MAX_ROW_ID", "type": ["null", "long"], "default": None},
     ]
 }

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -339,7 +339,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
             file_ranges = []
             for file in split.files:
                 first_row_id = file.first_row_id
-                if first_row_id is not None:
+                if first_row_id is not None and file.row_count > 0:
                     file_ranges.append(Range(
                         first_row_id,
                         first_row_id + file.row_count - 1

--- a/paimon-python/pypaimon/tests/manifest/manifest_entry_identifier_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_entry_identifier_test.py
@@ -37,7 +37,7 @@ class ManifestEntryIdentifierTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tempdir = tempfile.mkdtemp()
-        cls.catalog = FileSystemCatalog(Options({CatalogOptions.WAREHOUSE.key(): cls.tempdir}))
+        cls.catalog: FileSystemCatalog = FileSystemCatalog(Options({CatalogOptions.WAREHOUSE.key(): cls.tempdir}))
         cls.catalog.create_database('default', False)
 
     def setUp(self):

--- a/paimon-python/pypaimon/tests/manifest/manifest_file_meta_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_file_meta_test.py
@@ -372,4 +372,3 @@ class ManifestFileMetaTest(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/paimon-python/pypaimon/tests/manifest/manifest_file_meta_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_file_meta_test.py
@@ -1,0 +1,375 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+import os
+import tempfile
+import unittest
+
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.manifest.manifest_list_manager import ManifestListManager
+from pypaimon.manifest.manifest_file_manager import ManifestFileManager
+from pypaimon.manifest.schema.manifest_file_meta import ManifestFileMeta
+from pypaimon.manifest.schema.manifest_entry import ManifestEntry
+from pypaimon.data.timestamp import Timestamp
+
+
+class ManifestFileMetaTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        cls.warehouse = os.path.join(cls.tempdir, 'warehouse')
+        cls.catalog = CatalogFactory.create({
+            'warehouse': cls.warehouse
+        })
+        cls.catalog.create_database('default', False)
+
+    def setUp(self):
+        try:
+            table_identifier = self.catalog.identifier('default', 'test_table')
+            table_path = self.catalog.get_table_path(table_identifier)
+            if self.catalog.file_io.exists(table_path):
+                self.catalog.file_io.delete(table_path, recursive=True)
+        except Exception:
+            pass
+
+    def test_min_max_row_id_null_without_row_tracking(self):
+        pa_schema = pa.schema([('id', pa.int32()), ('value', pa.string())])
+        schema = Schema.from_pyarrow_schema(pa_schema, options={})
+        self.catalog.create_table('default.test_table', schema, False)
+        table = self.catalog.get_table('default.test_table')
+
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        data = pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'value': ['a', 'b', 'c']
+        }, schema=pa_schema)
+        table_write.write_arrow(data)
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+
+        manifest_list_manager = ManifestListManager(table)
+        latest_snapshot = table.snapshot_manager().get_latest_snapshot()
+        manifest_files = manifest_list_manager.read_all(latest_snapshot)
+
+        self.assertGreater(len(manifest_files), 0)
+        for manifest in manifest_files:
+            self.assertIsNone(manifest.min_row_id, "minRowId should be null when row tracking is disabled")
+            self.assertIsNone(manifest.max_row_id, "maxRowId should be null when row tracking is disabled")
+
+    def test_min_max_row_id_calculation_with_row_tracking(self):
+        pa_schema = pa.schema([('id', pa.int32()), ('value', pa.string())])
+        schema = Schema.from_pyarrow_schema(pa_schema, options={
+            'row-tracking.enabled': 'true',
+            'data-evolution.enabled': 'true'
+        })
+        self.catalog.create_table('default.test_row_tracking', schema, False)
+        table = self.catalog.get_table('default.test_row_tracking')
+
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        data1 = pa.Table.from_pydict({
+            'id': [1, 2],
+            'value': ['a', 'b']
+        }, schema=pa_schema)
+        table_write.write_arrow(data1)
+        commit_messages = table_write.prepare_commit()
+        for msg in commit_messages:
+            for file in msg.new_files:
+                file.first_row_id = 0
+        table_commit.commit(commit_messages)
+        table_write.close()
+        table_commit.close()
+
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        data2 = pa.Table.from_pydict({
+            'id': [3, 4],
+            'value': ['c', 'd']
+        }, schema=pa_schema)
+        table_write.write_arrow(data2)
+        commit_messages = table_write.prepare_commit()
+        for msg in commit_messages:
+            for file in msg.new_files:
+                file.first_row_id = 2
+        table_commit.commit(commit_messages)
+        table_write.close()
+        table_commit.close()
+
+        manifest_list_manager = ManifestListManager(table)
+        latest_snapshot = table.snapshot_manager().get_latest_snapshot()
+        manifest_files = manifest_list_manager.read_all(latest_snapshot)
+
+        self.assertEqual(len(manifest_files), 2)
+
+        manifest1 = manifest_files[0]
+        self.assertEqual(manifest1.min_row_id, 0)
+        self.assertEqual(manifest1.max_row_id, 1)
+
+        manifest2 = manifest_files[1]
+        self.assertEqual(manifest2.min_row_id, 2)
+        self.assertEqual(manifest2.max_row_id, 3)
+
+    def test_min_max_row_id_with_mixed_entries(self):
+        pa_schema = pa.schema([('id', pa.int32()), ('value', pa.string())])
+        schema = Schema.from_pyarrow_schema(pa_schema, options={
+            'row-tracking.enabled': 'true',
+            'data-evolution.enabled': 'true'
+        })
+        self.catalog.create_table('default.test_mixed', schema, False)
+        table = self.catalog.get_table('default.test_mixed')
+
+        manifest_file_manager = ManifestFileManager(table)
+
+        entry1 = self._create_entry_with_row_id(table, "file1.parquet", bucket=0, level=0, first_row_id=0, row_count=2)
+        entry2 = self._create_entry_with_row_id(table, "file2.parquet", bucket=0, level=0, first_row_id=2, row_count=2)
+
+        manifest_file_name = "manifest-test-mixed"
+        manifest_file_manager.write(manifest_file_name, [entry1, entry2])
+
+        manifest_file_path = f"{manifest_file_manager.manifest_path}/{manifest_file_name}"
+        file_size = table.file_io.get_file_size(manifest_file_path)
+
+        min_bucket = min(entry1.bucket, entry2.bucket)
+        max_bucket = max(entry1.bucket, entry2.bucket)
+        min_level = min(entry1.file.level, entry2.file.level)
+        max_level = max(entry1.file.level, entry2.file.level)
+        min_row_id = min(entry1.file.first_row_id, entry2.file.first_row_id)
+        max_row_id = max(
+            entry1.file.first_row_id + entry1.file.row_count - 1,
+            entry2.file.first_row_id + entry2.file.row_count - 1
+        )
+
+        from pypaimon.manifest.schema.simple_stats import SimpleStats
+        partition_stats = SimpleStats.empty_stats()
+
+        manifest_file_meta = ManifestFileMeta(
+            file_name=manifest_file_name,
+            file_size=file_size,
+            num_added_files=2,
+            num_deleted_files=0,
+            partition_stats=partition_stats,
+            schema_id=0,
+            min_bucket=min_bucket,
+            max_bucket=max_bucket,
+            min_level=min_level,
+            max_level=max_level,
+            min_row_id=min_row_id,
+            max_row_id=max_row_id
+        )
+
+        self.assertEqual(manifest_file_meta.min_bucket, 0)
+        self.assertEqual(manifest_file_meta.max_bucket, 0)
+        self.assertEqual(manifest_file_meta.min_level, 0)
+        self.assertEqual(manifest_file_meta.max_level, 0)
+        self.assertEqual(manifest_file_meta.min_row_id, 0)
+        self.assertEqual(manifest_file_meta.max_row_id, 3)  # max(0+2-1, 2+2-1) = max(1, 3) = 3
+
+    def test_min_max_row_id_null_when_any_entry_missing_first_row_id(self):
+        pa_schema = pa.schema([('id', pa.int32()), ('value', pa.string())])
+        schema = Schema.from_pyarrow_schema(pa_schema, options={
+            'row-tracking.enabled': 'true',
+            'data-evolution.enabled': 'true'
+        })
+        self.catalog.create_table('default.test_null_mixed', schema, False)
+        table = self.catalog.get_table('default.test_null_mixed')
+
+        manifest_file_manager = ManifestFileManager(table)
+
+        entry1 = self._create_entry_with_row_id(table, "file1.parquet", bucket=0, level=0, first_row_id=0, row_count=2)
+        entry2 = self._create_entry_without_row_id(table, "file2.parquet", bucket=0, level=0, row_count=2)
+
+        manifest_file_name = "manifest-test-null-mixed"
+        manifest_file_manager.write(manifest_file_name, [entry1, entry2])
+
+        manifest_file_path = f"{manifest_file_manager.manifest_path}/{manifest_file_name}"
+        file_size = table.file_io.get_file_size(manifest_file_path)
+
+        from pypaimon.manifest.schema.simple_stats import SimpleStats
+        partition_stats = SimpleStats.empty_stats()
+
+        manifest_file_meta = ManifestFileMeta(
+            file_name=manifest_file_name,
+            file_size=file_size,
+            num_added_files=2,
+            num_deleted_files=0,
+            partition_stats=partition_stats,
+            schema_id=0,
+            min_bucket=0,
+            max_bucket=0,
+            min_level=0,
+            max_level=0,
+            min_row_id=None,
+            max_row_id=None
+        )
+
+        self.assertIsNone(manifest_file_meta.min_row_id)
+        self.assertIsNone(manifest_file_meta.max_row_id)
+
+    def test_backward_compatibility_read_old_manifest_list(self):
+        pa_schema = pa.schema([('id', pa.int32()), ('value', pa.string())])
+        schema = Schema.from_pyarrow_schema(pa_schema, options={})
+        self.catalog.create_table('default.test_backward', schema, False)
+        table = self.catalog.get_table('default.test_backward')
+
+        manifest_list_manager = ManifestListManager(table)
+
+        from pypaimon.manifest.schema.simple_stats import SimpleStats
+        partition_stats = SimpleStats.empty_stats()
+
+        old_manifest_meta = ManifestFileMeta(
+            file_name="old-manifest.avro",
+            file_size=1024,
+            num_added_files=1,
+            num_deleted_files=0,
+            partition_stats=partition_stats,
+            schema_id=0
+        )
+
+        manifest_list_manager.write("manifest-list-old", [old_manifest_meta])
+
+        read_manifests = manifest_list_manager.read("manifest-list-old")
+
+        self.assertEqual(len(read_manifests), 1)
+        read_manifest = read_manifests[0]
+        self.assertIsNone(read_manifest.min_bucket)
+        self.assertIsNone(read_manifest.max_bucket)
+        self.assertIsNone(read_manifest.min_level)
+        self.assertIsNone(read_manifest.max_level)
+        self.assertIsNone(read_manifest.min_row_id)
+        self.assertIsNone(read_manifest.max_row_id)
+
+    def test_manifest_file_meta_schema_includes_new_fields(self):
+        from pypaimon.manifest.schema.manifest_file_meta import MANIFEST_FILE_META_SCHEMA
+
+        fields = {field["name"]: field for field in MANIFEST_FILE_META_SCHEMA["fields"]}
+
+        self.assertIn("_MIN_BUCKET", fields)
+        self.assertIn("_MAX_BUCKET", fields)
+        self.assertIn("_MIN_LEVEL", fields)
+        self.assertIn("_MAX_LEVEL", fields)
+        self.assertIn("_MIN_ROW_ID", fields)
+        self.assertIn("_MAX_ROW_ID", fields)
+
+        self.assertEqual(fields["_MIN_BUCKET"]["type"], ["null", "int"])
+        self.assertEqual(fields["_MAX_BUCKET"]["type"], ["null", "int"])
+        self.assertEqual(fields["_MIN_LEVEL"]["type"], ["null", "int"])
+        self.assertEqual(fields["_MAX_LEVEL"]["type"], ["null", "int"])
+        self.assertEqual(fields["_MIN_ROW_ID"]["type"], ["null", "long"])
+        self.assertEqual(fields["_MAX_ROW_ID"]["type"], ["null", "long"])
+
+        self.assertIsNone(fields["_MIN_BUCKET"].get("default"))
+        self.assertIsNone(fields["_MAX_BUCKET"].get("default"))
+        self.assertIsNone(fields["_MIN_LEVEL"].get("default"))
+        self.assertIsNone(fields["_MAX_LEVEL"].get("default"))
+        self.assertIsNone(fields["_MIN_ROW_ID"].get("default"))
+        self.assertIsNone(fields["_MAX_ROW_ID"].get("default"))
+
+    def test_write_and_read_manifest_file_meta_with_new_fields(self):
+        pa_schema = pa.schema([('id', pa.int32()), ('value', pa.string())])
+        schema = Schema.from_pyarrow_schema(pa_schema, options={})
+        self.catalog.create_table('default.test_write_read', schema, False)
+        table = self.catalog.get_table('default.test_write_read')
+
+        manifest_list_manager = ManifestListManager(table)
+
+        from pypaimon.manifest.schema.simple_stats import SimpleStats
+        partition_stats = SimpleStats.empty_stats()
+
+        manifest_file_meta = ManifestFileMeta(
+            file_name="test-manifest.avro",
+            file_size=2048,
+            num_added_files=3,
+            num_deleted_files=1,
+            partition_stats=partition_stats,
+            schema_id=1,
+            min_bucket=0,
+            max_bucket=2,
+            min_level=0,
+            max_level=1,
+            min_row_id=10,
+            max_row_id=25
+        )
+
+        manifest_list_manager.write("manifest-list-test", [manifest_file_meta])
+
+        read_manifests = manifest_list_manager.read("manifest-list-test")
+
+        self.assertEqual(len(read_manifests), 1)
+        read_manifest = read_manifests[0]
+
+        self.assertEqual(read_manifest.file_name, "test-manifest.avro")
+        self.assertEqual(read_manifest.file_size, 2048)
+        self.assertEqual(read_manifest.num_added_files, 3)
+        self.assertEqual(read_manifest.num_deleted_files, 1)
+        self.assertEqual(read_manifest.schema_id, 1)
+        self.assertEqual(read_manifest.min_bucket, 0)
+        self.assertEqual(read_manifest.max_bucket, 2)
+        self.assertEqual(read_manifest.min_level, 0)
+        self.assertEqual(read_manifest.max_level, 1)
+        self.assertEqual(read_manifest.min_row_id, 10)
+        self.assertEqual(read_manifest.max_row_id, 25)
+
+    def _create_entry_with_row_id(self, table, file_name, bucket, level, first_row_id, row_count):
+        from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+        from pypaimon.manifest.schema.simple_stats import SimpleStats
+        from pypaimon.table.row.generic_row import GenericRow
+
+        file_meta = DataFileMeta(
+            file_name=file_name,
+            file_size=1024,
+            row_count=row_count,
+            min_key=GenericRow([], []),
+            max_key=GenericRow([], []),
+            key_stats=SimpleStats.empty_stats(),
+            value_stats=SimpleStats.empty_stats(),
+            min_sequence_number=1,
+            max_sequence_number=100,
+            schema_id=0,
+            level=level,
+            extra_files=[],
+            creation_time=Timestamp.from_epoch_millis(1234567890),
+            delete_row_count=0,
+            embedded_index=None,
+            file_source=None,
+            value_stats_cols=None,
+            external_path=None,
+            first_row_id=first_row_id,
+            write_cols=None
+        )
+
+        return ManifestEntry(
+            kind=0,  # ADD
+            partition=GenericRow([], []),
+            bucket=bucket,
+            total_buckets=1,
+            file=file_meta
+        )
+
+    def _create_entry_without_row_id(self, table, file_name, bucket, level, row_count):
+        return self._create_entry_with_row_id(table, file_name, bucket, level, None, row_count)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/paimon-python/pypaimon/tests/manifest/manifest_schema_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_schema_test.py
@@ -103,7 +103,9 @@ class ManifestSchemaTest(unittest.TestCase):
         # Check that all expected fields are present
         expected_fields = [
             "_VERSION", "_FILE_NAME", "_FILE_SIZE", "_NUM_ADDED_FILES",
-            "_NUM_DELETED_FILES", "_PARTITION_STATS", "_SCHEMA_ID"
+            "_NUM_DELETED_FILES", "_PARTITION_STATS", "_SCHEMA_ID",
+            "_MIN_BUCKET", "_MAX_BUCKET", "_MIN_LEVEL", "_MAX_LEVEL",
+            "_MIN_ROW_ID", "_MAX_ROW_ID"
         ]
 
         for field_name in expected_fields:
@@ -117,6 +119,13 @@ class ManifestSchemaTest(unittest.TestCase):
         self.assertEqual(field_map["_NUM_DELETED_FILES"]["type"], "long")
         self.assertEqual(field_map["_PARTITION_STATS"]["type"], PARTITION_STATS_SCHEMA)
         self.assertEqual(field_map["_SCHEMA_ID"]["type"], "long")
+        # New fields added in PR 6661
+        self.assertEqual(field_map["_MIN_BUCKET"]["type"], ["null", "int"])
+        self.assertEqual(field_map["_MAX_BUCKET"]["type"], ["null", "int"])
+        self.assertEqual(field_map["_MIN_LEVEL"]["type"], ["null", "int"])
+        self.assertEqual(field_map["_MAX_LEVEL"]["type"], ["null", "int"])
+        self.assertEqual(field_map["_MIN_ROW_ID"]["type"], ["null", "long"])
+        self.assertEqual(field_map["_MAX_ROW_ID"]["type"], ["null", "long"])
 
     def test_schema_references(self):
         """Test that schema references are correctly used."""

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -251,13 +251,14 @@ class FileStoreCommit:
                     max_row_id = None
                 else:
                     row_count = entry.file.row_count
-                    end_row_id = first_row_id + row_count - 1
-                    if min_row_id is None:
-                        min_row_id = first_row_id
-                        max_row_id = end_row_id
-                    else:
-                        min_row_id = min(min_row_id, first_row_id)
-                        max_row_id = max(max_row_id, end_row_id)
+                    if row_count > 0:
+                        end_row_id = first_row_id + row_count - 1
+                        if min_row_id is None:
+                            min_row_id = first_row_id
+                            max_row_id = end_row_id
+                        else:
+                            min_row_id = min(min_row_id, first_row_id)
+                            max_row_id = max(max_row_id, end_row_id)
         
         try:
             self.manifest_file_manager.write(new_manifest_file, commit_entries)

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -216,6 +216,14 @@ class FileStoreCommit:
             # Assign row IDs to new files and get the next row ID for the snapshot
             commit_entries, next_row_id = self._assign_row_tracking_meta(first_row_id_start, commit_entries)
 
+        min_bucket = None
+        max_bucket = None
+        min_level = None
+        max_level = None
+        min_row_id = None
+        max_row_id = None
+        row_id_stats_valid = True
+        
         for entry in commit_entries:
             if entry.kind == 0:
                 added_file_count += 1
@@ -223,6 +231,34 @@ class FileStoreCommit:
             else:
                 deleted_file_count += 1
                 delta_record_count -= entry.file.row_count
+            
+            if min_bucket is None:
+                min_bucket = entry.bucket
+                max_bucket = entry.bucket
+                min_level = entry.file.level
+                max_level = entry.file.level
+            else:
+                min_bucket = min(min_bucket, entry.bucket)
+                max_bucket = max(max_bucket, entry.bucket)
+                min_level = min(min_level, entry.file.level)
+                max_level = max(max_level, entry.file.level)
+            
+            if row_id_stats_valid:
+                first_row_id = entry.file.first_row_id
+                if first_row_id is None:
+                    row_id_stats_valid = False
+                    min_row_id = None
+                    max_row_id = None
+                else:
+                    row_count = entry.file.row_count
+                    end_row_id = first_row_id + row_count - 1
+                    if min_row_id is None:
+                        min_row_id = first_row_id
+                        max_row_id = end_row_id
+                    else:
+                        min_row_id = min(min_row_id, first_row_id)
+                        max_row_id = max(max_row_id, end_row_id)
+        
         try:
             self.manifest_file_manager.write(new_manifest_file, commit_entries)
             # TODO: implement noConflictsOrFail logic
@@ -250,6 +286,12 @@ class FileStoreCommit:
                     null_counts=partition_null_counts,
                 ),
                 schema_id=self.table.table_schema.id,
+                min_bucket=min_bucket,
+                max_bucket=max_bucket,
+                min_level=min_level,
+                max_level=max_level,
+                min_row_id=min_row_id,
+                max_row_id=max_row_id,
             )
             self.manifest_list_manager.write(delta_manifest_list, [new_manifest_file_meta])
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces additional bounds to manifest metadata and integrates them into read/write paths to improve scan efficiency.
> 
> - Extend `ManifestFileMeta` schema with optional `_MIN_BUCKET`, `_MAX_BUCKET`, `_MIN_LEVEL`, `_MAX_LEVEL`, `_MIN_ROW_ID`, `_MAX_ROW_ID`; update `ManifestListManager` read/write accordingly
> - In `FileStoreCommit`, compute and persist these bounds for each new manifest (rowId bounds only when all files have valid firstRowId and row_count > 0)
> - In `FullStartingScanner`, cache global index results and row ranges, and prefilter manifest files by overlapping `min_row_id`/`max_row_id`; pass ranges/scores to `DataEvolutionSplitGenerator`
> - In `DataEvolutionSplitGenerator`, ignore zero-row files when forming ranges for `IndexedSplit`
> - Add comprehensive tests for schema fields, read/write, backward compatibility, and rowId min/max behavior; minor typing cleanup in an existing test
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee5cc2ef445b1e914b867a12de660cce101263ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->