### PR TITLE
Pr 7014 latest

### DIFF
--- a/paimon-python/dev/lint-python.sh
+++ b/paimon-python/dev/lint-python.sh
@@ -107,7 +107,7 @@ function collect_checks() {
 function get_all_supported_checks() {
     _OLD_IFS=$IFS
     IFS=$'\n'
-    SUPPORT_CHECKS=("flake8_check" "pytest_torch_check" "pytest_check" "mixed_check") # control the calling sequence
+    SUPPORT_CHECKS=("flake8_check" "pytest_check" "pytest_torch_check" "mixed_check") # control the calling sequence
     for fun in $(declare -F); do
         if [[ `regexp_match "$fun" "_check$"` = true ]]; then
             check_name="${fun:11}"

--- a/paimon-python/pypaimon/read/reader/field_bunch.py
+++ b/paimon-python/pypaimon/read/reader/field_bunch.py
@@ -82,11 +82,6 @@ class BlobBunch(FieldBunch):
                         "Blob file with overlapping row id should have decreasing sequence number."
                     )
                 return
-            elif first_row_id > self.expected_next_first_row_id:
-                raise ValueError(
-                    f"Blob file first row id should be continuous, expect "
-                    f"{self.expected_next_first_row_id} but got {first_row_id}"
-                )
 
             if file.schema_id != self._files[0].schema_id:
                 raise ValueError(

--- a/paimon-python/pypaimon/read/reader/sample_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/sample_batch_reader.py
@@ -1,0 +1,99 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+from typing import Optional
+
+from pyarrow import RecordBatch
+
+from pypaimon.read.reader.format_blob_reader import FormatBlobReader
+from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
+
+
+class SampleBatchReader(RecordBatchReader):
+    """
+    A reader that reads a subset of rows from a data file based on specified sample positions.
+
+    This reader wraps another RecordBatchReader and only returns rows at the specified
+    sample positions, enabling efficient random sampling of data without reading all rows.
+
+    The reader supports two modes:
+    1. For blob readers: Directly reads specific rows by index
+    2. For other readers: Reads batches sequentially and extracts only the sampled rows
+
+    Attributes:
+        reader: The underlying RecordBatchReader to read data from
+        sample_positions: A sorted list of row indices to sample (0-based)
+        sample_idx: Current index in the sample_positions list
+        current_pos: Current absolute row position in the data file
+    """
+
+    def __init__(self, reader, sample_positions):
+        """
+        Initialize the SampleBatchReader.
+
+        Args:
+            reader: The underlying RecordBatchReader to read data from
+            sample_positions: A bitmap of row indices to sample (0-based).
+                            Must be sorted in ascending order for correct behavior.
+        """
+        self.reader = reader
+        self.sample_positions = sample_positions
+        self.sample_idx = 0
+        self.current_pos = 0
+
+    def read_arrow_batch(self) -> Optional[RecordBatch]:
+        """
+        Read the next batch containing sampled rows.
+
+        This method reads data from the underlying reader and returns only the rows
+        at the specified sample positions. The behavior differs based on reader type:
+
+        - For FormatBlobReader: Directly reads individual rows by index
+        - For other readers: Reads batches sequentially and extracts sampled rows
+          using PyArrow's take() method
+        """
+        if self.sample_idx >= len(self.sample_positions):
+            return None
+        if isinstance(self.reader.format_reader, FormatBlobReader):
+            # For blob reader, pass begin_idx and end_idx parameters
+            batch = self.reader.read_arrow_batch(start_idx=self.sample_positions[self.sample_idx],
+                                                 end_idx=self.sample_positions[self.sample_idx] + 1)
+            self.sample_idx += 1
+            return batch
+        else:
+            batch = self.reader.read_arrow_batch()
+            if batch is None:
+                return None
+
+            batch_begin = self.current_pos
+            self.current_pos += batch.num_rows
+            take_idxes = []
+
+            sample_pos = self.sample_positions[self.sample_idx]
+            while batch_begin <= sample_pos < self.current_pos:
+                take_idxes.append(sample_pos - batch_begin)
+                self.sample_idx += 1
+                if self.sample_idx >= len(self.sample_positions):
+                    break
+                sample_pos = self.sample_positions[self.sample_idx]
+
+            if take_idxes:
+                return batch.take(take_idxes)
+            else:  # batch is outside the desired range
+                return self.read_arrow_batch()
+
+    def close(self):
+        self.reader.close()

--- a/paimon-python/pypaimon/read/reader/shard_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/shard_batch_reader.py
@@ -25,6 +25,7 @@ class ShardBatchReader(RecordBatchReader):
     """
     A reader that reads a subset of rows from a data file
     """
+
     def __init__(self, reader, start_pos, end_pos):
         self.reader = reader
         self.start_pos = start_pos
@@ -54,6 +55,83 @@ class ShardBatchReader(RecordBatchReader):
                 return batch.slice(self.start_pos - batch_begin, self.end_pos - self.start_pos)
             elif batch_begin < self.end_pos < self.current_pos:  # batch ends after the desired range
                 return batch.slice(0, self.end_pos - batch_begin)
+            else:  # batch is outside the desired range
+                return self.read_arrow_batch()
+
+    def close(self):
+        self.reader.close()
+
+
+class SampleBatchReader(RecordBatchReader):
+    """
+    A reader that reads a subset of rows from a data file based on specified sample positions.
+
+    This reader wraps another RecordBatchReader and only returns rows at the specified
+    sample positions, enabling efficient random sampling of data without reading all rows.
+
+    The reader supports two modes:
+    1. For blob readers: Directly reads specific rows by index
+    2. For other readers: Reads batches sequentially and extracts only the sampled rows
+
+    Attributes:
+        reader: The underlying RecordBatchReader to read data from
+        sample_positions: A sorted list of row indices to sample (0-based)
+        sample_idx: Current index in the sample_positions list
+        current_pos: Current absolute row position in the data file
+    """
+
+    def __init__(self, reader, sample_positions):
+        """
+        Initialize the SampleBatchReader.
+
+        Args:
+            reader: The underlying RecordBatchReader to read data from
+            sample_positions: A sorted list of row indices to sample (0-based).
+                            Must be sorted in ascending order for correct behavior.
+        """
+        self.reader = reader
+        self.sample_positions = sample_positions
+        self.sample_idx = 0
+        self.current_pos = 0
+
+    def read_arrow_batch(self) -> Optional[RecordBatch]:
+        """
+        Read the next batch containing sampled rows.
+
+        This method reads data from the underlying reader and returns only the rows
+        at the specified sample positions. The behavior differs based on reader type:
+
+        - For FormatBlobReader: Directly reads individual rows by index
+        - For other readers: Reads batches sequentially and extracts sampled rows
+          using PyArrow's take() method
+        """
+        if self.sample_idx >= len(self.sample_positions):
+            return None
+        if isinstance(self.reader.format_reader, FormatBlobReader):
+            # For blob reader, pass begin_idx and end_idx parameters
+            batch = self.reader.read_arrow_batch(start_idx=self.sample_positions[self.sample_idx],
+                                                 end_idx=self.sample_positions[self.sample_idx] + 1)
+            self.sample_idx += 1
+            return batch
+        else:
+            batch = self.reader.read_arrow_batch()
+            if batch is None:
+                return None
+
+            batch_begin = self.current_pos
+            self.current_pos += batch.num_rows
+            take_idxes = []
+
+            sample_pos = self.sample_positions[self.sample_idx]
+            while batch_begin <= sample_pos < self.current_pos:
+                take_idxes.append(sample_pos - batch_begin)
+                self.sample_idx += 1
+                if self.sample_idx >= len(self.sample_positions):
+                    break
+                sample_pos = self.sample_positions[self.sample_idx]
+
+            if take_idxes:
+                return batch.take(take_idxes)
             else:  # batch is outside the desired range
                 return self.read_arrow_batch()
 

--- a/paimon-python/pypaimon/read/reader/shard_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/shard_batch_reader.py
@@ -25,7 +25,6 @@ class ShardBatchReader(RecordBatchReader):
     """
     A reader that reads a subset of rows from a data file
     """
-
     def __init__(self, reader, start_pos, end_pos):
         self.reader = reader
         self.start_pos = start_pos
@@ -55,83 +54,6 @@ class ShardBatchReader(RecordBatchReader):
                 return batch.slice(self.start_pos - batch_begin, self.end_pos - self.start_pos)
             elif batch_begin < self.end_pos < self.current_pos:  # batch ends after the desired range
                 return batch.slice(0, self.end_pos - batch_begin)
-            else:  # batch is outside the desired range
-                return self.read_arrow_batch()
-
-    def close(self):
-        self.reader.close()
-
-
-class SampleBatchReader(RecordBatchReader):
-    """
-    A reader that reads a subset of rows from a data file based on specified sample positions.
-
-    This reader wraps another RecordBatchReader and only returns rows at the specified
-    sample positions, enabling efficient random sampling of data without reading all rows.
-
-    The reader supports two modes:
-    1. For blob readers: Directly reads specific rows by index
-    2. For other readers: Reads batches sequentially and extracts only the sampled rows
-
-    Attributes:
-        reader: The underlying RecordBatchReader to read data from
-        sample_positions: A sorted list of row indices to sample (0-based)
-        sample_idx: Current index in the sample_positions list
-        current_pos: Current absolute row position in the data file
-    """
-
-    def __init__(self, reader, sample_positions):
-        """
-        Initialize the SampleBatchReader.
-
-        Args:
-            reader: The underlying RecordBatchReader to read data from
-            sample_positions: A sorted list of row indices to sample (0-based).
-                            Must be sorted in ascending order for correct behavior.
-        """
-        self.reader = reader
-        self.sample_positions = sample_positions
-        self.sample_idx = 0
-        self.current_pos = 0
-
-    def read_arrow_batch(self) -> Optional[RecordBatch]:
-        """
-        Read the next batch containing sampled rows.
-
-        This method reads data from the underlying reader and returns only the rows
-        at the specified sample positions. The behavior differs based on reader type:
-
-        - For FormatBlobReader: Directly reads individual rows by index
-        - For other readers: Reads batches sequentially and extracts sampled rows
-          using PyArrow's take() method
-        """
-        if self.sample_idx >= len(self.sample_positions):
-            return None
-        if isinstance(self.reader.format_reader, FormatBlobReader):
-            # For blob reader, pass begin_idx and end_idx parameters
-            batch = self.reader.read_arrow_batch(start_idx=self.sample_positions[self.sample_idx],
-                                                 end_idx=self.sample_positions[self.sample_idx] + 1)
-            self.sample_idx += 1
-            return batch
-        else:
-            batch = self.reader.read_arrow_batch()
-            if batch is None:
-                return None
-
-            batch_begin = self.current_pos
-            self.current_pos += batch.num_rows
-            take_idxes = []
-
-            sample_pos = self.sample_positions[self.sample_idx]
-            while batch_begin <= sample_pos < self.current_pos:
-                take_idxes.append(sample_pos - batch_begin)
-                self.sample_idx += 1
-                if self.sample_idx >= len(self.sample_positions):
-                    break
-                sample_pos = self.sample_positions[self.sample_idx]
-
-            if take_idxes:
-                return batch.take(take_idxes)
             else:  # batch is outside the desired range
                 return self.read_arrow_batch()
 

--- a/paimon-python/pypaimon/read/sampled_split.py
+++ b/paimon-python/pypaimon/read/sampled_split.py
@@ -1,0 +1,100 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+from typing import List, Dict
+
+from pypaimon.read.split import Split
+
+
+class SampledSplit(Split):
+    """
+    Wrapper for Split that adds file-level slicing information.
+
+    This is used when a split needs to be further divided at the file level,
+    storing the start and end row indices for each file in shard_file_idx_map.
+
+    Maps file_name -> (start_row, end_row) where:
+    - start_row: starting row index within the file (inclusive)
+    - end_row: ending row index within the file (exclusive)
+    - (-1, -1): file should be skipped entirely
+    """
+
+    def __init__(
+            self,
+            data_split: 'Split',
+            sampled_file_idx_map: Dict[str, List[int]]
+    ):
+        self._data_split = data_split
+        self._sampled_file_idx_map = sampled_file_idx_map
+
+    def data_split(self) -> 'Split':
+        return self._data_split
+
+    def sampled_file_idx_map(self) -> Dict[str, List[int]]:
+        return self._sampled_file_idx_map
+
+    @property
+    def files(self) -> List['DataFileMeta']:
+        return self._data_split.files
+
+    @property
+    def partition(self) -> 'GenericRow':
+        return self._data_split.partition
+
+    @property
+    def bucket(self) -> int:
+        return self._data_split.bucket
+
+    @property
+    def row_count(self) -> int:
+        if not self._sample_file_idx_map:
+            return self._data_split.row_count
+
+        total_rows = 0
+        for file in self._data_split.files:
+            positions = self._sample_file_idx_map[file.file_name]
+            total_rows += len(positions)
+
+        return total_rows
+
+    @property
+    def file_paths(self):
+        return self._data_split.file_paths
+
+    @property
+    def file_size(self):
+        return self._data_split.file_size
+
+    @property
+    def raw_convertible(self):
+        return self._data_split.raw_convertible
+
+    @property
+    def data_deletion_files(self):
+        return self._data_split.data_deletion_files
+
+    def __eq__(self, other):
+        if not isinstance(other, SlicedSplit):
+            return False
+        return (self._data_split == other._data_split and
+                self._shard_file_idx_map == other._shard_file_idx_map)
+
+    def __hash__(self):
+        return hash((id(self._data_split), tuple(sorted(self._shard_file_idx_map.items()))))
+
+    def __repr__(self):
+        return (f"SlicedSplit(data_split={self._data_split}, "
+                f"shard_file_idx_map={self._shard_file_idx_map})")

--- a/paimon-python/pypaimon/read/sampled_split.py
+++ b/paimon-python/pypaimon/read/sampled_split.py
@@ -21,15 +21,16 @@ from pypaimon.read.split import Split
 
 class SampledSplit(Split):
     """
-    Wrapper for Split that adds file-level slicing information.
+    A Split wrapper that contains sampled row indexes for each file.
 
-    This is used when a split needs to be further divided at the file level,
-    storing the start and end row indices for each file in shard_file_idx_map.
+    This class wraps a data split and maintains a mapping from file names to
+    lists of sampled row indexes. It is used for random sampling scenarios where
+    only specific rows from each file need to be read.
 
-    Maps file_name -> (start_row, end_row) where:
-    - start_row: starting row index within the file (inclusive)
-    - end_row: ending row index within the file (exclusive)
-    - (-1, -1): file should be skipped entirely
+    Attributes:
+        _data_split: The underlying data split being wrapped.
+        _sampled_file_idx_map: A dictionary mapping file names to lists of
+            sampled row indexes within each file.
     """
 
     def __init__(
@@ -87,14 +88,14 @@ class SampledSplit(Split):
         return self._data_split.data_deletion_files
 
     def __eq__(self, other):
-        if not isinstance(other, SlicedSplit):
+        if not isinstance(other, SampledSplit):
             return False
         return (self._data_split == other._data_split and
-                self._shard_file_idx_map == other._shard_file_idx_map)
+                self._sampled_file_idx_map == other._sampled_file_idx_map)
 
     def __hash__(self):
-        return hash((id(self._data_split), tuple(sorted(self._shard_file_idx_map.items()))))
+        return hash((id(self._data_split), tuple(sorted(self._sampled_file_idx_map.items()))))
 
     def __repr__(self):
         return (f"SlicedSplit(data_split={self._data_split}, "
-                f"shard_file_idx_map={self._shard_file_idx_map})")
+                f"shard_file_idx_map={self._sampled_file_idx_map})")

--- a/paimon-python/pypaimon/read/sampled_split.py
+++ b/paimon-python/pypaimon/read/sampled_split.py
@@ -14,7 +14,9 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-from typing import List, Dict
+from typing import Dict, List
+
+from pyroaring import BitMap
 
 from pypaimon.read.split import Split
 
@@ -36,7 +38,7 @@ class SampledSplit(Split):
     def __init__(
             self,
             data_split: 'Split',
-            sampled_file_idx_map: Dict[str, List[int]]
+            sampled_file_idx_map: Dict[str, BitMap]
     ):
         self._data_split = data_split
         self._sampled_file_idx_map = sampled_file_idx_map
@@ -44,7 +46,7 @@ class SampledSplit(Split):
     def data_split(self) -> 'Split':
         return self._data_split
 
-    def sampled_file_idx_map(self) -> Dict[str, List[int]]:
+    def sampled_file_idx_map(self) -> Dict[str, BitMap]:
         return self._sampled_file_idx_map
 
     @property
@@ -61,12 +63,12 @@ class SampledSplit(Split):
 
     @property
     def row_count(self) -> int:
-        if not self._sample_file_idx_map:
+        if not self._sampled_file_idx_map:
             return self._data_split.row_count
 
         total_rows = 0
         for file in self._data_split.files:
-            positions = self._sample_file_idx_map[file.file_name]
+            positions = self._sampled_file_idx_map[file.file_name]
             total_rows += len(positions)
 
         return total_rows
@@ -97,5 +99,5 @@ class SampledSplit(Split):
         return hash((id(self._data_split), tuple(sorted(self._sampled_file_idx_map.items()))))
 
     def __repr__(self):
-        return (f"SlicedSplit(data_split={self._data_split}, "
-                f"shard_file_idx_map={self._sampled_file_idx_map})")
+        return (f"SampledSplit(data_split={self._data_split}, "
+                f"sampled_file_idx_map={self._sampled_file_idx_map})")

--- a/paimon-python/pypaimon/read/scanner/append_table_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/append_table_split_generator.py
@@ -15,11 +15,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import random
 from collections import defaultdict
 from typing import List, Dict, Tuple
 
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
+from pypaimon.read.sampled_split import SampledSplit
 from pypaimon.read.scanner.split_generator import AbstractSplitGenerator
 from pypaimon.read.split import Split
 from pypaimon.read.sliced_split import SlicedSplit
@@ -41,13 +43,15 @@ class AppendTableSplitGenerator(AbstractSplitGenerator):
         if self.start_pos_of_this_subtask is not None:
             # shard data range: [plan_start_pos, plan_end_pos)
             partitioned_files, plan_start_pos, plan_end_pos = \
-                self.__filter_by_slice(
+                self._filter_by_slice(
                     partitioned_files,
                     self.start_pos_of_this_subtask,
                     self.end_pos_of_this_subtask
                 )
         elif self.idx_of_this_subtask is not None:
             partitioned_files, plan_start_pos, plan_end_pos = self._filter_by_shard(partitioned_files)
+        elif self.sample_num_rows is not None:
+            partitioned_files, file_positions = self._filter_by_sample(partitioned_files)
 
         def weight_func(f: DataFileMeta) -> int:
             return max(f.file_size, self.open_file_cost)
@@ -68,6 +72,8 @@ class AppendTableSplitGenerator(AbstractSplitGenerator):
 
         if self.start_pos_of_this_subtask is not None or self.idx_of_this_subtask is not None:
             splits = self._wrap_to_sliced_splits(splits, plan_start_pos, plan_end_pos)
+        elif self.sample_num_rows is not None:
+            splits = self._wrap_to_sampled_splits(splits, file_positions)
 
         return splits
 
@@ -76,12 +82,12 @@ class AppendTableSplitGenerator(AbstractSplitGenerator):
         file_end_pos = 0  # end row position of current file in all splits data
 
         for split in splits:
-            shard_file_idx_map = self.__compute_split_file_idx_map(
+            shard_file_idx_map = self._compute_split_file_idx_map(
                 plan_start_pos, plan_end_pos, split, file_end_pos
             )
             file_end_pos = shard_file_idx_map[self.NEXT_POS_KEY]
             del shard_file_idx_map[self.NEXT_POS_KEY]
-            
+
             if shard_file_idx_map:
                 sliced_splits.append(SlicedSplit(split, shard_file_idx_map))
             else:
@@ -90,10 +96,21 @@ class AppendTableSplitGenerator(AbstractSplitGenerator):
         return sliced_splits
 
     @staticmethod
-    def __filter_by_slice(
-        partitioned_files: defaultdict,
-        start_pos: int,
-        end_pos: int
+    def _wrap_to_sampled_splits(splits: List[Split], file_positions: Dict[str, List[int]]) -> List[Split]:
+        # Set sample file positions for each split
+        sampled_splits = []
+        for split in splits:
+            sampled_file_idx_map = {}
+            for file in split.files:
+                sampled_file_idx_map[file.file_name] = file_positions[file.file_name]
+            sampled_splits.append(SampledSplit(split, sampled_file_idx_map))
+        return sampled_splits
+
+    @staticmethod
+    def _filter_by_slice(
+            partitioned_files: defaultdict,
+            start_pos: int,
+            end_pos: int
     ) -> tuple:
         plan_start_pos = 0
         plan_end_pos = 0
@@ -142,21 +159,44 @@ class AppendTableSplitGenerator(AbstractSplitGenerator):
         # Calculate shard range using shared helper
         start_pos, end_pos = self._compute_shard_range(total_row)
 
-        return self.__filter_by_slice(partitioned_files, start_pos, end_pos)
+        return self._filter_by_slice(partitioned_files, start_pos, end_pos)
+
+    def _filter_by_sample(self, partitioned_files) -> (defaultdict, Dict[str, List[int]]):
+        """
+        Randomly sample num_rows data from partitioned_files:
+        1. First use random to generate num_rows indexes
+        2. Iterate through partitioned_files, find the file entries where corresponding indexes are located,
+           add them to filtered_partitioned_files, and for each entry, add indexes to the list
+        """
+        # Calculate total number of rows
+        total_rows = 0
+        for key, file_entries in partitioned_files.items():
+            for entry in file_entries:
+                total_rows += entry.file.row_count
+
+        # Generate random sample indexes
+        sample_indexes = sorted(random.sample(range(total_rows), self.sample_num_rows))
+
+        # Map each sample index to its corresponding file and local index
+        filtered_partitioned_files = defaultdict(list)
+        file_positions = {}  # {file_name: [local_indexes]}
+        self._compute_file_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
+                                          sample_indexes, is_blob=False)
+        return filtered_partitioned_files, file_positions
 
     @staticmethod
-    def __compute_split_file_idx_map(
-        plan_start_pos: int,
-        plan_end_pos: int,
-        split: Split,
-        file_end_pos: int
+    def _compute_split_file_idx_map(
+            plan_start_pos: int,
+            plan_end_pos: int,
+            split: Split,
+            file_end_pos: int
     ) -> Dict[str, Tuple[int, int]]:
         """
         Compute file index map for a split, determining which rows to read from each file.
 
         """
         shard_file_idx_map = {}
-        
+
         for file in split.files:
             file_begin_pos = file_end_pos  # Starting row position of current file in all data
             file_end_pos += file.row_count  # Update to row position after current file
@@ -165,7 +205,7 @@ class AppendTableSplitGenerator(AbstractSplitGenerator):
             file_range = AppendTableSplitGenerator._compute_file_range(
                 plan_start_pos, plan_end_pos, file_begin_pos, file.row_count
             )
-            
+
             if file_range is not None:
                 shard_file_idx_map[file.file_name] = file_range
 

--- a/paimon-python/pypaimon/read/scanner/append_table_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/append_table_split_generator.py
@@ -182,9 +182,9 @@ class AppendTableSplitGenerator(AbstractSplitGenerator):
         # Map each sample index to its corresponding file and local index
         filtered_partitioned_files = defaultdict(list)
         file_positions = {}  # {file_name: BitMap of local_indexes}
-        file_positions = self._compute_file_sample_idx_map(partitioned_files, filtered_partitioned_files,
-                                                           file_positions,
-                                                           sample_indexes, is_blob=False)
+        self._compute_file_sample_idx_map(partitioned_files, filtered_partitioned_files,
+                                          file_positions,
+                                          sample_indexes, is_blob=False)
         return filtered_partitioned_files, file_positions
 
     @staticmethod

--- a/paimon-python/pypaimon/read/scanner/append_table_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/append_table_split_generator.py
@@ -84,7 +84,7 @@ class AppendTableSplitGenerator(AbstractSplitGenerator):
         file_end_pos = 0  # end row position of current file in all splits data
 
         for split in splits:
-            shard_file_idx_map = self._compute_split_file_idx_map(
+            shard_file_idx_map = self._compute_split_shard_file_idx_map(
                 plan_start_pos, plan_end_pos, split, file_end_pos
             )
             file_end_pos = shard_file_idx_map[self.NEXT_POS_KEY]
@@ -182,12 +182,13 @@ class AppendTableSplitGenerator(AbstractSplitGenerator):
         # Map each sample index to its corresponding file and local index
         filtered_partitioned_files = defaultdict(list)
         file_positions = {}  # {file_name: BitMap of local_indexes}
-        self._compute_file_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
-                                          sample_indexes, is_blob=False)
+        file_positions = self._compute_file_sample_idx_map(partitioned_files, filtered_partitioned_files,
+                                                           file_positions,
+                                                           sample_indexes, is_blob=False)
         return filtered_partitioned_files, file_positions
 
     @staticmethod
-    def _compute_split_file_idx_map(
+    def _compute_split_shard_file_idx_map(
             plan_start_pos: int,
             plan_end_pos: int,
             split: Split,

--- a/paimon-python/pypaimon/read/scanner/append_table_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/append_table_split_generator.py
@@ -19,6 +19,8 @@ import random
 from collections import defaultdict
 from typing import List, Dict, Tuple
 
+from pyroaring import BitMap
+
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.read.sampled_split import SampledSplit
@@ -96,7 +98,7 @@ class AppendTableSplitGenerator(AbstractSplitGenerator):
         return sliced_splits
 
     @staticmethod
-    def _wrap_to_sampled_splits(splits: List[Split], file_positions: Dict[str, List[int]]) -> List[Split]:
+    def _wrap_to_sampled_splits(splits: List[Split], file_positions: Dict[str, BitMap]) -> List[Split]:
         # Set sample file positions for each split
         sampled_splits = []
         for split in splits:
@@ -179,7 +181,7 @@ class AppendTableSplitGenerator(AbstractSplitGenerator):
 
         # Map each sample index to its corresponding file and local index
         filtered_partitioned_files = defaultdict(list)
-        file_positions = {}  # {file_name: [local_indexes]}
+        file_positions = {}  # {file_name: BitMap of local_indexes}
         self._compute_file_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
                                           sample_indexes, is_blob=False)
         return filtered_partitioned_files, file_positions

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import random
 from collections import defaultdict
 from typing import List, Optional, Dict, Tuple
 
@@ -22,6 +23,7 @@ from pypaimon.globalindex.indexed_split import IndexedSplit
 from pypaimon.globalindex.range import Range
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
+from pypaimon.read.sampled_split import SampledSplit
 from pypaimon.read.scanner.split_generator import AbstractSplitGenerator
 from pypaimon.read.split import Split
 from pypaimon.read.sliced_split import SlicedSplit
@@ -33,15 +35,14 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
     """
 
     def __init__(
-        self,
-        table,
-        target_split_size: int,
-        open_file_cost: int,
-        deletion_files_map=None,
-        row_ranges: Optional[List] = None,
-        score_getter=None
+            self,
+            table,
+            target_split_size: int,
+            open_file_cost: int,
+            row_ranges: Optional[List] = None,
+            score_getter=None
     ):
-        super().__init__(table, target_split_size, open_file_cost, deletion_files_map)
+        super().__init__(table, target_split_size, open_file_cost)
         self.row_ranges = row_ranges
         self.score_getter = score_getter
 
@@ -49,6 +50,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         """
         Create splits for data evolution tables.
         """
+
         def sort_key(manifest_entry: ManifestEntry) -> tuple:
             first_row_id = (
                 manifest_entry.file.first_row_id
@@ -59,10 +61,8 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
             max_seq = manifest_entry.file.max_sequence_number
             return first_row_id, is_blob, -max_seq
 
-        sorted_entries = sorted(file_entries, key=sort_key)
-
         partitioned_files = defaultdict(list)
-        for entry in sorted_entries:
+        for entry in file_entries:
             partitioned_files[(tuple(entry.partition.values), entry.bucket)].append(entry)
 
         plan_start_pos = 0
@@ -71,7 +71,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         if self.start_pos_of_this_subtask is not None:
             # shard data range: [plan_start_pos, plan_end_pos)
             partitioned_files, plan_start_pos, plan_end_pos = \
-                self._filter_by_row_range(
+                self._filter_by_slice(
                     partitioned_files,
                     self.start_pos_of_this_subtask,
                     self.end_pos_of_this_subtask
@@ -79,6 +79,8 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         elif self.idx_of_this_subtask is not None:
             # shard data range: [plan_start_pos, plan_end_pos)
             partitioned_files, plan_start_pos, plan_end_pos = self._filter_by_shard(partitioned_files)
+        elif self.sample_num_rows is not None:
+            partitioned_files, file_positions = self._filter_by_sample(partitioned_files)
 
         def weight_func(file_list: List[DataFileMeta]) -> int:
             return max(sum(f.file_size for f in file_list), self.open_file_cost)
@@ -87,7 +89,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         for key, sorted_entries_list in partitioned_files.items():
             if not sorted_entries_list:
                 continue
-
+            sorted_entries_list = sorted(sorted_entries_list, key=sort_key)
             data_files: List[DataFileMeta] = [e.file for e in sorted_entries_list]
 
             # Split files by firstRowId for data evolution
@@ -110,6 +112,8 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
         if self.start_pos_of_this_subtask is not None or self.idx_of_this_subtask is not None:
             splits = self._wrap_to_sliced_splits(splits, plan_start_pos, plan_end_pos)
+        elif self.sample_num_rows is not None:
+            splits = self._wrap_to_sampled_splits(splits, file_positions)
 
         # Wrap splits with IndexedSplit if row_ranges is provided
         if self.row_ranges:
@@ -132,7 +136,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
             )
             file_end_pos = shard_file_idx_map[self.NEXT_POS_KEY]
             del shard_file_idx_map[self.NEXT_POS_KEY]
-            
+
             if shard_file_idx_map:
                 sliced_splits.append(SlicedSplit(split, shard_file_idx_map))
             else:
@@ -140,11 +144,21 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
         return sliced_splits
 
-    def _filter_by_row_range(
-        self,
-        partitioned_files: defaultdict,
-        start_pos: int,
-        end_pos: int
+    def _wrap_to_sampled_splits(self, splits: List[Split], file_positions: Dict[str, List[int]]) -> List[Split]:
+        # Set sample file positions for each split
+        sampled_splits = []
+        for split in splits:
+            sampled_file_idx_map = {}
+            for file in split.files:
+                sampled_file_idx_map[file.file_name] = file_positions[file.file_name]
+            sampled_splits.append(SampledSplit(split, sampled_file_idx_map))
+        return sampled_splits
+
+    def _filter_by_slice(
+            self,
+            partitioned_files: defaultdict,
+            start_pos: int,
+            end_pos: int
     ) -> tuple:
         """
         Filter file entries by row range for data evolution tables.
@@ -203,7 +217,33 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         # Calculate shard range using shared helper
         start_pos, end_pos = self._compute_shard_range(total_row)
 
-        return self._filter_by_row_range(partitioned_files, start_pos, end_pos)
+        return self._filter_by_slice(partitioned_files, start_pos, end_pos)
+
+    def _filter_by_sample(self, partitioned_files) -> (defaultdict, Dict[str, List[int]]):
+        """
+        Randomly sample num_rows data from partitioned_files:
+        1. First use random to generate num_rows indexes
+        2. Iterate through partitioned_files, find the file entries where corresponding indexes are located,
+           add them to filtered_partitioned_files, and for each entry, add indexes to the list
+        """
+        # Calculate total number of rows
+        total_rows = 0
+        for key, file_entries in partitioned_files.items():
+            for entry in file_entries:
+                if not self._is_blob_file(entry.file.file_name):
+                    total_rows += entry.file.row_count
+        # Generate random sample indexes
+        sample_indexes = sorted(random.sample(range(total_rows), self.sample_num_rows))
+
+        # Map each sample index to its corresponding file and local index
+        filtered_partitioned_files = defaultdict(list)
+        file_positions = {}  # {file_name: [local_indexes]}
+        self._compute_file_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
+                                          sample_indexes, is_blob=False)
+        self._compute_file_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
+                                          sample_indexes, is_blob=True)
+
+        return filtered_partitioned_files, file_positions
 
     def _split_by_row_id(self, files: List[DataFileMeta]) -> List[List[DataFileMeta]]:
         """
@@ -250,11 +290,11 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         return split_by_row_id
 
     def _compute_split_file_idx_map(
-        self,
-        plan_start_pos: int,
-        plan_end_pos: int,
-        split: Split,
-        file_end_pos: int
+            self,
+            plan_start_pos: int,
+            plan_end_pos: int,
+            split: Split,
+            file_end_pos: int
     ) -> Dict[str, Tuple[int, int]]:
         """
         Compute file index map for a split, determining which rows to read from each file.
@@ -262,14 +302,14 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         For blob files (which may be rolled), the range is calculated based on each file's first_row_id.
         """
         shard_file_idx_map = {}
-        
+
         # Find the first non-blob file to determine the row range for this split
         data_file = None
         for file in split.files:
             if not self._is_blob_file(file.file_name):
                 data_file = file
                 break
-        
+
         if data_file is None:
             # No data file, skip this split
             shard_file_idx_map[self.NEXT_POS_KEY] = file_end_pos
@@ -284,7 +324,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         data_file_range = self._compute_file_range(
             plan_start_pos, plan_end_pos, file_begin_pos, data_file.row_count
         )
-        
+
         # Apply ranges to each file in the split
         for file in split.files:
             if self._is_blob_file(file.file_name):
@@ -301,15 +341,15 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                     # Blob's position relative to data file start
                     blob_rel_start = blob_first_row_id - data_file_first_row_id
                     blob_rel_end = blob_rel_start + file.row_count
-                    
+
                     # Shard range relative to data file start
                     shard_start = data_file_range[0]
                     shard_end = data_file_range[1]
-                    
+
                     # Intersect blob's range with shard range
                     intersect_start = max(blob_rel_start, shard_start)
                     intersect_end = min(blob_rel_end, shard_end)
-                    
+
                     if intersect_start >= intersect_end:
                         # Blob file is completely outside shard range
                         shard_file_idx_map[file.file_name] = (-1, -1)

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -133,7 +133,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         for split in splits:
             # Compute file index map for both data and blob files
             # Blob files share the same row position tracking as data files
-            shard_file_idx_map = self._compute_split_file_idx_map(
+            shard_file_idx_map = self._compute_split_shard_file_idx_map(
                 plan_start_pos, plan_end_pos, split, file_end_pos
             )
             file_end_pos = shard_file_idx_map[self.NEXT_POS_KEY]
@@ -291,7 +291,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
         return split_by_row_id
 
-    def _compute_split_file_idx_map(
+    def _compute_split_shard_file_idx_map(
             self,
             plan_start_pos: int,
             plan_end_pos: int,

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -19,6 +19,8 @@ import random
 from collections import defaultdict
 from typing import List, Optional, Dict, Tuple
 
+from pyroaring import BitMap
+
 from pypaimon.globalindex.indexed_split import IndexedSplit
 from pypaimon.globalindex.range import Range
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
@@ -144,7 +146,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
         return sliced_splits
 
-    def _wrap_to_sampled_splits(self, splits: List[Split], file_positions: Dict[str, List[int]]) -> List[Split]:
+    def _wrap_to_sampled_splits(self, splits: List[Split], file_positions: Dict[str, BitMap]) -> List[Split]:
         # Set sample file positions for each split
         sampled_splits = []
         for split in splits:
@@ -237,7 +239,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
         # Map each sample index to its corresponding file and local index
         filtered_partitioned_files = defaultdict(list)
-        file_positions = {}  # {file_name: [local_indexes]}
+        file_positions = {}  # {file_name: BitMap of local_indexes}
         self._compute_file_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,
                                           sample_indexes, is_blob=False)
         self._compute_file_sample_idx_map(partitioned_files, filtered_partitioned_files, file_positions,

--- a/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
@@ -40,11 +40,11 @@ from pypaimon.manifest.simple_stats_evolutions import SimpleStatsEvolutions
 
 class FullStartingScanner(StartingScanner):
     def __init__(
-            self,
-            table,
-            predicate: Optional[Predicate],
-            limit: Optional[int],
-            vector_search: Optional['VectorSearch'] = None
+        self,
+        table,
+        predicate: Optional[Predicate],
+        limit: Optional[int],
+        vector_search: Optional['VectorSearch'] = None
     ):
         from pypaimon.table.file_store_table import FileStoreTable
 
@@ -121,7 +121,6 @@ class FullStartingScanner(StartingScanner):
             return Plan([])
         # Get deletion files map if deletion vectors are enabled.
         # {partition-bucket -> {filename -> DeletionFile}}
-        deletion_files_map: dict[tuple, dict[str, DeletionFile]] = {}
         if self.deletion_vectors_enabled:
             latest_snapshot = self.snapshot_manager.get_latest_snapshot()
             # Extract unique partition-bucket pairs from file entries
@@ -129,8 +128,7 @@ class FullStartingScanner(StartingScanner):
             for entry in file_entries:
                 buckets.add((tuple(entry.partition.values), entry.bucket))
             deletion_files_map = self._scan_dv_index(latest_snapshot, buckets)
-
-        self.split_generator.deletion_files_map = deletion_files_map
+            self.split_generator.deletion_files_map = deletion_files_map
 
         # Generate splits
         splits = self.split_generator.create_splits(file_entries)

--- a/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
@@ -66,13 +66,6 @@ class FullStartingScanner(StartingScanner):
         # Get split target size and open file cost from table options
         self.target_split_size = options.source_split_target_size()
         self.open_file_cost = options.source_split_open_file_cost()
-        # for shard
-        self.idx_of_this_subtask = None
-        self.number_of_para_subtasks = None
-        self.start_pos_of_this_subtask = None
-        self.end_pos_of_this_subtask = None
-        # for sample
-        self.sample_num_rows = None
 
         self.only_read_real_buckets = options.bucket() == BucketMode.POSTPONE_BUCKET.value
         self.data_evolution = options.data_evolution_enabled()

--- a/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/full_starting_scanner.py
@@ -16,9 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import os
-import random
-from collections import defaultdict
-from typing import Callable, List, Optional, Dict, Set
 from typing import List, Optional, Dict, Set
 
 from pypaimon.common.predicate import Predicate
@@ -43,11 +40,11 @@ from pypaimon.manifest.simple_stats_evolutions import SimpleStatsEvolutions
 
 class FullStartingScanner(StartingScanner):
     def __init__(
-        self,
-        table,
-        predicate: Optional[Predicate],
-        limit: Optional[int],
-        vector_search: Optional['VectorSearch'] = None
+            self,
+            table,
+            predicate: Optional[Predicate],
+            limit: Optional[int],
+            vector_search: Optional['VectorSearch'] = None
     ):
         from pypaimon.table.file_store_table import FileStoreTable
 
@@ -76,8 +73,6 @@ class FullStartingScanner(StartingScanner):
         self.end_pos_of_this_subtask = None
         # for sample
         self.sample_num_rows = None
-        self.sample_indexes = None
-        self.file_positions = None
 
         self.only_read_real_buckets = options.bucket() == BucketMode.POSTPONE_BUCKET.value
         self.data_evolution = options.data_evolution_enabled()
@@ -90,6 +85,35 @@ class FullStartingScanner(StartingScanner):
             schema_fields_func,
             self.table.table_schema.id
         )
+
+        # Create appropriate split generator based on table type
+        if self.table.is_primary_key_table:
+            self.split_generator = PrimaryKeyTableSplitGenerator(
+                self.table,
+                self.target_split_size,
+                self.open_file_cost,
+            )
+        elif self.data_evolution:
+            global_index_result = self._eval_global_index()
+            row_ranges = None
+            score_getter = None
+            if global_index_result is not None:
+                row_ranges = global_index_result.results().to_range_list()
+                if isinstance(global_index_result, VectorSearchGlobalIndexResult):
+                    score_getter = global_index_result.score_getter()
+            self.split_generator = DataEvolutionSplitGenerator(
+                self.table,
+                self.target_split_size,
+                self.open_file_cost,
+                row_ranges,
+                score_getter
+            )
+        else:
+            self.split_generator = AppendTableSplitGenerator(
+                self.table,
+                self.target_split_size,
+                self.open_file_cost,
+            )
 
     def scan(self) -> Plan:
         file_entries = self.plan_files()
@@ -106,46 +130,10 @@ class FullStartingScanner(StartingScanner):
                 buckets.add((tuple(entry.partition.values), entry.bucket))
             deletion_files_map = self._scan_dv_index(latest_snapshot, buckets)
 
-        # Create appropriate split generator based on table type
-        if self.table.is_primary_key_table:
-            split_generator = PrimaryKeyTableSplitGenerator(
-                self.table,
-                self.target_split_size,
-                self.open_file_cost,
-                deletion_files_map
-            )
-        elif self.data_evolution:
-            global_index_result = self._eval_global_index()
-            row_ranges = None
-            score_getter = None
-            if global_index_result is not None:
-                row_ranges = global_index_result.results().to_range_list()
-                if isinstance(global_index_result, VectorSearchGlobalIndexResult):
-                    score_getter = global_index_result.score_getter()
-            split_generator = DataEvolutionSplitGenerator(
-                self.table,
-                self.target_split_size,
-                self.open_file_cost,
-                deletion_files_map,
-                row_ranges,
-                score_getter
-            )
-        else:
-            split_generator = AppendTableSplitGenerator(
-                self.table,
-                self.target_split_size,
-                self.open_file_cost,
-                deletion_files_map
-            )
-
-        # Configure sharding if needed
-        if self.idx_of_this_subtask is not None:
-            split_generator.with_shard(self.idx_of_this_subtask, self.number_of_para_subtasks)
-        elif self.start_pos_of_this_subtask is not None:
-            split_generator.with_slice(self.start_pos_of_this_subtask, self.end_pos_of_this_subtask)
+        self.split_generator.deletion_files_map = deletion_files_map
 
         # Generate splits
-        splits = split_generator.create_splits(file_entries)
+        splits = self.split_generator.create_splits(file_entries)
 
         splits = self._apply_push_down_limit(splits)
         return Plan(splits)
@@ -230,29 +218,15 @@ class FullStartingScanner(StartingScanner):
         )
 
     def with_shard(self, idx_of_this_subtask: int, number_of_para_subtasks: int) -> 'FullStartingScanner':
-        if idx_of_this_subtask >= number_of_para_subtasks:
-            raise ValueError("idx_of_this_subtask must be less than number_of_para_subtasks")
-        if self.start_pos_of_this_subtask is not None:
-            raise Exception("with_shard and with_slice cannot be used simultaneously")
-        self.idx_of_this_subtask = idx_of_this_subtask
-        self.number_of_para_subtasks = number_of_para_subtasks
+        self.split_generator.with_shard(idx_of_this_subtask, number_of_para_subtasks)
         return self
 
     def with_slice(self, start_pos: int, end_pos: int) -> 'FullStartingScanner':
-        if start_pos >= end_pos:
-            raise ValueError("start_pos must be less than end_pos")
-        if self.idx_of_this_subtask is not None:
-            raise Exception("with_slice and with_shard cannot be used simultaneously")
-        self.start_pos_of_this_subtask = start_pos
-        self.end_pos_of_this_subtask = end_pos
+        self.split_generator.with_slice(start_pos, end_pos)
         return self
 
     def with_sample(self, num_rows: int) -> 'FullStartingScanner':
-        if self.idx_of_this_subtask is not None:
-            raise Exception("with_sample and with_shard cannot be used simultaneously now")
-        if self.start_pos_of_this_subtask is not None:
-            raise Exception("with_sample and with_slice cannot be used simultaneously now")
-        self.sample_num_rows = num_rows
+        self.split_generator.with_sample(num_rows)
         return self
 
     def _apply_push_down_limit(self, splits: List[DataSplit]) -> List[DataSplit]:

--- a/paimon-python/pypaimon/read/scanner/primary_key_table_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/primary_key_table_split_generator.py
@@ -36,9 +36,8 @@ class PrimaryKeyTableSplitGenerator(AbstractSplitGenerator):
             table,
             target_split_size: int,
             open_file_cost: int,
-            deletion_files_map=None
     ):
-        super().__init__(table, target_split_size, open_file_cost, deletion_files_map)
+        super().__init__(table, target_split_size, open_file_cost)
         self.deletion_vectors_enabled = table.options.deletion_vectors_enabled()
         self.merge_engine = table.options.merge_engine()
 

--- a/paimon-python/pypaimon/read/scanner/split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/split_generator.py
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from abc import ABC, abstractmethod
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Dict
 
 from pyroaring import BitMap
 
@@ -268,6 +268,7 @@ class AbstractSplitGenerator(ABC):
                 # Early exit if we've processed all sample indexes
             if sample_idx >= len(sample_indexes):
                 break
+        return file_positions
 
     @staticmethod
     def _compute_file_range(

--- a/paimon-python/pypaimon/read/scanner/split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/split_generator.py
@@ -220,8 +220,8 @@ class AbstractSplitGenerator(ABC):
         else:
             num_row = base_rows_per_shard
             start_pos = (
-                    remainder * (base_rows_per_shard + 1) +
-                    (self.idx_of_this_subtask - remainder) * base_rows_per_shard
+                remainder * (base_rows_per_shard + 1) +
+                (self.idx_of_this_subtask - remainder) * base_rows_per_shard
             )
 
         end_pos = start_pos + num_row

--- a/paimon-python/pypaimon/read/scanner/split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/split_generator.py
@@ -220,8 +220,8 @@ class AbstractSplitGenerator(ABC):
         else:
             num_row = base_rows_per_shard
             start_pos = (
-                remainder * (base_rows_per_shard + 1) +
-                (self.idx_of_this_subtask - remainder) * base_rows_per_shard
+                    remainder * (base_rows_per_shard + 1) +
+                    (self.idx_of_this_subtask - remainder) * base_rows_per_shard
             )
 
         end_pos = start_pos + num_row
@@ -268,7 +268,6 @@ class AbstractSplitGenerator(ABC):
                 # Early exit if we've processed all sample indexes
             if sample_idx >= len(sample_indexes):
                 break
-        return file_positions
 
     @staticmethod
     def _compute_file_range(

--- a/paimon-python/pypaimon/read/scanner/split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/split_generator.py
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from abc import ABC, abstractmethod
-from typing import Callable, List, Optional, Dict, Tuple
+from typing import Callable, List, Optional, Tuple
 
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
@@ -30,27 +30,28 @@ class AbstractSplitGenerator(ABC):
     """
     Abstract base class for generating splits.
     """
-    
+
     # Special key for tracking file end position in split file index map
     NEXT_POS_KEY = '_next_pos'
 
     def __init__(
-        self,
-        table,
-        target_split_size: int,
-        open_file_cost: int,
-        deletion_files_map: Optional[Dict] = None
+            self,
+            table,
+            target_split_size: int,
+            open_file_cost: int,
     ):
         self.table = table
         self.target_split_size = target_split_size
         self.open_file_cost = open_file_cost
-        self.deletion_files_map = deletion_files_map or {}
-        
+        self.deletion_files_map = {}
+
         # Shard configuration
         self.idx_of_this_subtask = None
         self.number_of_para_subtasks = None
         self.start_pos_of_this_subtask = None
         self.end_pos_of_this_subtask = None
+
+        self.sample_num_rows = None
 
     def with_shard(self, idx_of_this_subtask: int, number_of_para_subtasks: int):
         """Configure sharding for parallel processing."""
@@ -72,6 +73,14 @@ class AbstractSplitGenerator(ABC):
         self.end_pos_of_this_subtask = end_pos
         return self
 
+    def with_sample(self, num_rows: int):
+        if self.idx_of_this_subtask is not None:
+            raise Exception("with_sample and with_shard cannot be used simultaneously now")
+        if self.start_pos_of_this_subtask is not None:
+            raise Exception("with_sample and with_slice cannot be used simultaneously now")
+        self.sample_num_rows = num_rows
+        return self
+
     @abstractmethod
     def create_splits(self, file_entries: List[ManifestEntry]) -> List[Split]:
         """
@@ -80,11 +89,11 @@ class AbstractSplitGenerator(ABC):
         pass
 
     def _build_split_from_pack(
-        self,
-        packed_files: List[List[DataFileMeta]],
-        file_entries: List[ManifestEntry],
-        for_primary_key_split: bool,
-        use_optimized_path: bool = False
+            self,
+            packed_files: List[List[DataFileMeta]],
+            file_entries: List[ManifestEntry],
+            for_primary_key_split: bool,
+            use_optimized_path: bool = False
     ) -> List[Split]:
         """
         Build splits from packed files.
@@ -136,10 +145,10 @@ class AbstractSplitGenerator(ABC):
         return splits
 
     def _get_deletion_files_for_split(
-        self,
-        data_files: List[DataFileMeta],
-        partition: GenericRow,
-        bucket: int
+            self,
+            data_files: List[DataFileMeta],
+            partition: GenericRow,
+            bucket: int
     ) -> Optional[List[DeletionFile]]:
         """Get deletion files for the given data files in a split."""
         if not self.deletion_files_map:
@@ -170,9 +179,9 @@ class AbstractSplitGenerator(ABC):
 
     @staticmethod
     def _pack_for_ordered(
-        items: List,
-        weight_func: Callable,
-        target_weight: int
+            items: List,
+            weight_func: Callable,
+            target_weight: int
     ) -> List[List]:
         """Pack items into groups based on target weight."""
         packed = []
@@ -216,12 +225,54 @@ class AbstractSplitGenerator(ABC):
         end_pos = start_pos + num_row
         return start_pos, end_pos
 
+    def _compute_file_sample_idx_map(self, partitioned_files, filtered_partitioned_files, file_positions,
+                                     sample_indexes, is_blob):
+        current_row = 0
+        sample_idx = 0
+
+        for key, file_entries in partitioned_files.items():
+            filtered_entries = []
+            for entry in file_entries:
+                if not is_blob and self._is_blob_file(entry.file.file_name):
+                    continue
+                if is_blob and not self._is_blob_file(entry.file.file_name):
+                    continue
+                file_start_row = current_row
+                file_end_row = current_row + entry.file.row_count
+
+                # Find all sample indexes that fall within this file
+                local_indexes = []
+                while sample_idx < len(sample_indexes) and sample_indexes[sample_idx] < file_end_row:
+                    if sample_indexes[sample_idx] >= file_start_row:
+                        # Convert global index to local index within this file
+                        local_index = sample_indexes[sample_idx] - file_start_row
+                        local_indexes.append(local_index)
+                    sample_idx += 1
+
+                # If this file contains any sampled rows, include it
+                if local_indexes:
+                    filtered_entries.append(entry)
+                    file_positions[entry.file.file_name] = local_indexes
+
+                current_row = file_end_row
+
+                # Early exit if we've processed all sample indexes
+                if sample_idx >= len(sample_indexes):
+                    break
+
+            if filtered_entries:
+                filtered_partitioned_files[key] = filtered_partitioned_files.get(key, []) + filtered_entries
+
+                # Early exit if we've processed all sample indexes
+            if sample_idx >= len(sample_indexes):
+                break
+
     @staticmethod
     def _compute_file_range(
-        plan_start_pos: int,
-        plan_end_pos: int,
-        file_begin_pos: int,
-        file_row_count: int
+            plan_start_pos: int,
+            plan_end_pos: int,
+            file_begin_pos: int,
+            file_row_count: int
     ) -> Optional[Tuple[int, int]]:
         """
         Compute the row range to read from a file given shard range and file position.

--- a/paimon-python/pypaimon/read/scanner/split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/split_generator.py
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from abc import ABC, abstractmethod
-from typing import Callable, List, Optional, Tuple, Dict
+from typing import Callable, List, Optional, Tuple
 
 from pyroaring import BitMap
 

--- a/paimon-python/pypaimon/read/split.py
+++ b/paimon-python/pypaimon/read/split.py
@@ -57,11 +57,6 @@ class Split(ABC):
 
 
 class DataSplit(Split):
-    """
-    Implementation of Split for native Python reading.
-
-    This is equivalent to Java's DataSplit.
-    """
 
     def __init__(
         self,

--- a/paimon-python/pypaimon/read/split.py
+++ b/paimon-python/pypaimon/read/split.py
@@ -18,8 +18,6 @@
 
 from abc import ABC, abstractmethod
 from typing import List, Optional
-from dataclasses import dataclass, field
-from typing import List, Optional, Dict
 
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.table.row.generic_row import GenericRow

--- a/paimon-python/pypaimon/read/split.py
+++ b/paimon-python/pypaimon/read/split.py
@@ -18,6 +18,8 @@
 
 from abc import ABC, abstractmethod
 from typing import List, Optional
+from dataclasses import dataclass, field
+from typing import List, Optional, Dict
 
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.table.row.generic_row import GenericRow

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -374,7 +374,7 @@ class SplitRead(ABC):
 class RawFileSplitRead(SplitRead):
     def raw_reader_supplier(self, file: DataFileMeta, dv_factory: Optional[Callable] = None) -> Optional[RecordReader]:
         read_fields = self._get_final_read_data_fields()
-        file_batch_reader = self._create_file_reader(file, read_fields, row_tracking_enabled=True)
+        file_batch_reader = self._create_file_reader(file, read_fields)
         if file_batch_reader is None:
             return None
         dv = dv_factory() if dv_factory else None

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -48,7 +48,8 @@ from pypaimon.read.reader.iface.record_reader import RecordReader
 from pypaimon.read.reader.key_value_unwrap_reader import \
     KeyValueUnwrapRecordReader
 from pypaimon.read.reader.key_value_wrap_reader import KeyValueWrapReader
-from pypaimon.read.reader.shard_batch_reader import ShardBatchReader, SampleBatchReader
+from pypaimon.read.reader.sample_batch_reader import SampleBatchReader
+from pypaimon.read.reader.shard_batch_reader import ShardBatchReader
 from pypaimon.read.reader.sort_merge_reader import SortMergeReaderWithMinHeap
 from pypaimon.read.sampled_split import SampledSplit
 from pypaimon.read.split import Split

--- a/paimon-python/pypaimon/read/table_scan.py
+++ b/paimon-python/pypaimon/read/table_scan.py
@@ -90,3 +90,12 @@ class TableScan:
     def with_slice(self, start_pos, end_pos) -> 'TableScan':
         self.starting_scanner.with_slice(start_pos, end_pos)
         return self
+
+    def with_sample(self, num_rows: int) -> 'TableScan':
+        """Sample the table with the given number of rows.
+
+        params:
+            num_rows: The number of rows to sample.
+        """
+        self.starting_scanner.with_sample(num_rows)
+        return self

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -2567,6 +2567,207 @@ class DataBlobWriterTest(unittest.TestCase):
 
         self.assertEqual(actual, expected)
 
+    def test_data_blob_writer_with_sample(self):
+        """Test DataBlobWriter with mixed data types in blob column."""
+
+        # Create schema with blob column
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('type', pa.string()),
+            ('data', pa.large_binary()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true'
+            }
+        )
+        self.catalog.create_table('test_db.with_sample', schema, False)
+        table = self.catalog.get_table('test_db.with_sample')
+
+        # Use proper table API to create writer
+        write_builder = table.new_batch_write_builder()
+        blob_writer = write_builder.new_write()
+
+        # Test data with different types of blob content
+        test_data = pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'type': ['text', 'json', 'binary', 'image', 'pdf'],
+            'data': [
+                b'This is text content',
+                b'{"key": "value", "number": 42}',
+                b'\x00\x01\x02\x03\xff\xfe\xfd',
+                b'PNG_IMAGE_DATA_PLACEHOLDER',
+                b'%PDF-1.4\nPDF_CONTENT_PLACEHOLDER'
+            ]
+        }, schema=pa_schema)
+
+        # Write mixed data
+        total_rows = 0
+        for batch in test_data.to_batches():
+            blob_writer.write_arrow_batch(batch)
+            total_rows += batch.num_rows
+
+        # Test prepare commit
+        commit_messages = blob_writer.prepare_commit()
+        # Create commit and commit the data
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        blob_writer.close()
+
+        # Read data back using table API
+        read_builder = table.new_read_builder()
+        table_scan = read_builder.new_scan().with_sample(2)
+        table_read = read_builder.new_read()
+        splits = table_scan.plan().splits()
+        actual = table_read.to_arrow(splits)
+        expected_ids = set(test_data['id'].to_pylist())
+        actual_ids = set(actual['id'].to_pylist())
+        self.assertEqual(2, actual.num_rows, "Should have 2 rows")
+        self.assertTrue(actual_ids.issubset(expected_ids),
+                        f"Actual user_ids {actual_ids} should be subset of written ids {expected_ids}")
+
+    def test_blob_write_read_large_data_with_rolling_with_sample(self):
+        """
+        Test writing and reading large blob data with file rolling and sample.
+
+        Test workflow:
+        - Creates a table with blob column and 10MB target file size
+        - Writes 4 batches of 40 records each (160 total records)
+        - Each record contains a 3MB blob
+        - Random sample 12 records
+        - Verifies blob data integrity and size
+        """
+
+        # Create schema with blob column
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('record_id_of_batch', pa.int32()),
+            ('metadata', pa.string()),
+            ('large_blob', pa.large_binary()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'blob.target-file-size': '10MB'
+            }
+        )
+        self.catalog.create_table('test_db.with_rolling_with_sample', schema, False)
+        table = self.catalog.get_table('test_db.with_rolling_with_sample')
+
+        # Create large blob data
+        large_blob_size = 3 * 1024 * 1024
+        blob_pattern = b'LARGE_BLOB_PATTERN_' + b'X' * 1024  # ~1KB pattern
+        pattern_size = len(blob_pattern)
+        repetitions = large_blob_size // pattern_size
+        large_blob_data = blob_pattern * repetitions
+
+        actual_size = len(large_blob_data)
+        print(f"Created blob data: {actual_size:,} bytes ({actual_size / (1024 * 1024):.2f} MB)")
+        # Write 4 batches of 40 records
+        for i in range(4):
+            write_builder = table.new_batch_write_builder()
+            writer = write_builder.new_write()
+            # Write 40 records
+            for record_id in range(40):
+                test_data = pa.Table.from_pydict({
+                    'id': [i * 40 + record_id + 1],  # Unique ID for each row
+                    'record_id_of_batch': [record_id],
+                    'metadata': [f'Large blob batch {record_id + 1}'],
+                    'large_blob': [large_blob_data]
+                }, schema=pa_schema)
+                writer.write_arrow(test_data)
+
+            commit_messages = writer.prepare_commit()
+            commit = write_builder.new_commit()
+            commit.commit(commit_messages)
+            writer.close()
+
+        # Read data back
+        read_builder = table.new_read_builder()
+        table_scan = read_builder.new_scan().with_sample(12)
+        table_read = read_builder.new_read()
+        result = table_read.to_arrow(table_scan.plan().splits())
+
+        # Verify the data
+        self.assertEqual(result.num_rows, 12, "Should have 12 rows")
+        self.assertEqual(result.num_columns, 4, "Should have 4 columns")
+
+        # Verify blob data integrity
+        blob_data = result.column('large_blob').to_pylist()
+        self.assertEqual(len(blob_data), 12, "Should have 54 blob records")
+
+    def test_blob_write_read_large_data_volums_with_rolling_with_sample(self):
+        """
+        Test writing and reading large blob data with file rolling and sample.
+        Test workflow:
+        - Creates a table with blob column and 10MB target file size
+        - Writes 10000 records of 5KB blob data each
+        - Random sample 1000 records
+        - Verifies data size
+        """
+        # Create schema with blob column
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('batch_id', pa.int32()),
+            ('metadata', pa.string()),
+            ('large_blob', pa.large_binary()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'blob.target-file-size': '10MB'
+            }
+        )
+        self.catalog.create_table('test_db.large_rolling_with_sample', schema, False)
+        table = self.catalog.get_table('test_db.large_rolling_with_sample')
+
+        # Create large blob data
+        large_blob_size = 5 * 1024  #
+        blob_pattern = b'LARGE_BLOB_PATTERN_' + b'X' * 1024  # ~1KB pattern
+        pattern_size = len(blob_pattern)
+        repetitions = large_blob_size // pattern_size
+        large_blob_data = blob_pattern * repetitions
+
+        actual_size = len(large_blob_data)
+        print(f"Created blob data: {actual_size:,} bytes ({actual_size / (1024 * 1024):.2f} MB)")
+        # Write 10000 records of data
+        num_row = 10000
+        expected = pa.Table.from_pydict({
+            'id': [i for i in range(1, num_row + 1)],
+            'batch_id': [11] * num_row,
+            'metadata': [f'Large blob batch {11}'] * num_row,
+            'large_blob': [i.to_bytes(2, byteorder='little') + large_blob_data for i in range(num_row)]
+        }, schema=pa_schema)
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(expected)
+
+        commit_messages = writer.prepare_commit()
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        writer.close()
+
+        # Read data back
+        read_builder = table.new_read_builder()
+        table_scan = read_builder.new_scan().with_sample(1000)
+        table_read = read_builder.new_read()
+        actual = table_read.to_arrow(table_scan.plan().splits())
+
+        # Verify the data
+        actual_ids = set(actual['id'].to_pylist())
+        expected_ids = set(list(range(1, num_row + 1)))
+        self.assertEqual(1000, actual.num_rows, "Should have 1000 rows")
+        self.assertTrue(actual_ids.issubset(expected_ids))
+
     def test_concurrent_blob_writes_with_retry(self):
         """Test concurrent blob writes to verify retry mechanism works correctly."""
         import threading


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces efficient row-level sampling and related reader/split support, with refactors to split generation and DV wiring.
> 
> - New `with_sample(num_rows)` on `TableScan`/`FullStartingScanner` producing `SampledSplit` with per-file `BitMap` positions
> - New `SampleBatchReader` to select rows by index; `SplitRead` now handles `SampledSplit` alongside `SlicedSplit`
> - `AppendTableSplitGenerator` and `DataEvolutionSplitGenerator` support sampling: compute sampled positions, wrap splits, and unify helper methods (method renames to `_filter_by_slice`, `_compute_split_shard_file_idx_map`, etc.)
> - `FullStartingScanner` now owns a `split_generator`, injects deletion vector maps into it, and exposes shard/slice/sample passthroughs
> - `PrimaryKeyTableSplitGenerator`/`DataEvolutionSplitGenerator` constructors simplified (DV map moved out)
> - Relaxed blob bunch continuity check in `field_bunch.py` (removed strict first-row-id continuity error)
> - Tests added for sampling across REST, Ray Data, and blob scenarios (including large/rolling files)
> - Dev: run order of checks in `lint-python.sh` adjusted to execute `pytest_check` before `pytest_torch_check`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bce0491064f131dc081d3c5832cd341fa57994fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->