### PR TITLE
Pr 7077 review

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -381,7 +381,7 @@ public class JavaPyE2ETest {
                             read,
                             splits,
                             row -> DataFormatTestUtil.toStringNoRowKind(row, table.rowType()));
-            System.out.println("Result: " + res);
+            System.out.println("Result for " + format + " : " + res);
             assertThat(res)
                     .containsExactlyInAnyOrder(
                             "1, Apple, Fruit, 1.5, 1970-01-01T00:16:40, 1970-01-01T00:33:20",

--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -114,6 +114,8 @@ public class JavaPyE2ETest {
                             .column("name", DataTypes.STRING())
                             .column("category", DataTypes.STRING())
                             .column("value", DataTypes.DOUBLE())
+                            .column("ts", DataTypes.TIMESTAMP())
+                            .column("ts_ltz", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
                             .partitionKeys("category")
                             .option("dynamic-partition-overwrite", "false")
                             .option("file.format", format)
@@ -126,12 +128,12 @@ public class JavaPyE2ETest {
             try (StreamTableWrite write = fileStoreTable.newWrite(commitUser);
                     InnerTableCommit commit = fileStoreTable.newCommit(commitUser)) {
 
-                write.write(createRow4Cols(1, "Apple", "Fruit", 1.5));
-                write.write(createRow4Cols(2, "Banana", "Fruit", 0.8));
-                write.write(createRow4Cols(3, "Carrot", "Vegetable", 0.6));
-                write.write(createRow4Cols(4, "Broccoli", "Vegetable", 1.2));
-                write.write(createRow4Cols(5, "Chicken", "Meat", 5.0));
-                write.write(createRow4Cols(6, "Beef", "Meat", 8.0));
+                write.write(createRow6Cols(1, "Apple", "Fruit", 1.5, 1000000L, 2000000L));
+                write.write(createRow6Cols(2, "Banana", "Fruit", 0.8, 1000001L, 2000001L));
+                write.write(createRow6Cols(3, "Carrot", "Vegetable", 0.6, 1000002L, 2000002L));
+                write.write(createRow6Cols(4, "Broccoli", "Vegetable", 1.2, 1000003L, 2000003L));
+                write.write(createRow6Cols(5, "Chicken", "Meat", 5.0, 1000004L, 2000004L));
+                write.write(createRow6Cols(6, "Beef", "Meat", 8.0, 1000005L, 2000005L));
 
                 commit.commit(0, write.prepareCommit(true, 0));
             }
@@ -146,12 +148,12 @@ public class JavaPyE2ETest {
                             row -> DataFormatTestUtil.toStringNoRowKind(row, table.rowType()));
             assertThat(res)
                     .containsExactlyInAnyOrder(
-                            "1, Apple, Fruit, 1.5",
-                            "2, Banana, Fruit, 0.8",
-                            "3, Carrot, Vegetable, 0.6",
-                            "4, Broccoli, Vegetable, 1.2",
-                            "5, Chicken, Meat, 5.0",
-                            "6, Beef, Meat, 8.0");
+                            "1, Apple, Fruit, 1.5, 1970-01-01T00:16:40, 1970-01-01T00:33:20",
+                            "2, Banana, Fruit, 0.8, 1970-01-01T00:16:40.001, 1970-01-01T00:33:20.001",
+                            "3, Carrot, Vegetable, 0.6, 1970-01-01T00:16:40.002, 1970-01-01T00:33:20.002",
+                            "4, Broccoli, Vegetable, 1.2, 1970-01-01T00:16:40.003, 1970-01-01T00:33:20.003",
+                            "5, Chicken, Meat, 5.0, 1970-01-01T00:16:40.004, 1970-01-01T00:33:20.004",
+                            "6, Beef, Meat, 8.0, 1970-01-01T00:16:40.005, 1970-01-01T00:33:20.005");
         }
     }
 
@@ -185,6 +187,8 @@ public class JavaPyE2ETest {
                             .column("name", DataTypes.STRING())
                             .column("category", DataTypes.STRING())
                             .column("value", DataTypes.DOUBLE())
+                            .column("ts", DataTypes.TIMESTAMP())
+                            .column("ts_ltz", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
                             .primaryKey("id")
                             .partitionKeys("category")
                             .option("dynamic-partition-overwrite", "false")
@@ -199,12 +203,12 @@ public class JavaPyE2ETest {
             try (StreamTableWrite write = fileStoreTable.newWrite(commitUser);
                     InnerTableCommit commit = fileStoreTable.newCommit(commitUser)) {
 
-                write.write(createRow4Cols(1, "Apple", "Fruit", 1.5));
-                write.write(createRow4Cols(2, "Banana", "Fruit", 0.8));
-                write.write(createRow4Cols(3, "Carrot", "Vegetable", 0.6));
-                write.write(createRow4Cols(4, "Broccoli", "Vegetable", 1.2));
-                write.write(createRow4Cols(5, "Chicken", "Meat", 5.0));
-                write.write(createRow4Cols(6, "Beef", "Meat", 8.0));
+                write.write(createRow6Cols(1, "Apple", "Fruit", 1.5, 1000000L, 2000000L));
+                write.write(createRow6Cols(2, "Banana", "Fruit", 0.8, 1000001L, 2000001L));
+                write.write(createRow6Cols(3, "Carrot", "Vegetable", 0.6, 1000002L, 2000002L));
+                write.write(createRow6Cols(4, "Broccoli", "Vegetable", 1.2, 1000003L, 2000003L));
+                write.write(createRow6Cols(5, "Chicken", "Meat", 5.0, 1000004L, 2000004L));
+                write.write(createRow6Cols(6, "Beef", "Meat", 8.0, 1000005L, 2000005L));
 
                 commit.commit(0, write.prepareCommit(true, 0));
             }
@@ -219,12 +223,12 @@ public class JavaPyE2ETest {
                             row -> DataFormatTestUtil.toStringNoRowKind(row, table.rowType()));
             assertThat(res)
                     .containsExactlyInAnyOrder(
-                            "1, Apple, Fruit, 1.5",
-                            "2, Banana, Fruit, 0.8",
-                            "3, Carrot, Vegetable, 0.6",
-                            "4, Broccoli, Vegetable, 1.2",
-                            "5, Chicken, Meat, 5.0",
-                            "6, Beef, Meat, 8.0");
+                            "1, Apple, Fruit, 1.5, 1970-01-01T00:16:40, 1970-01-01T00:33:20",
+                            "2, Banana, Fruit, 0.8, 1970-01-01T00:16:40.001, 1970-01-01T00:33:20.001",
+                            "3, Carrot, Vegetable, 0.6, 1970-01-01T00:16:40.002, 1970-01-01T00:33:20.002",
+                            "4, Broccoli, Vegetable, 1.2, 1970-01-01T00:16:40.003, 1970-01-01T00:33:20.003",
+                            "5, Chicken, Meat, 5.0, 1970-01-01T00:16:40.004, 1970-01-01T00:33:20.004",
+                            "6, Beef, Meat, 8.0, 1970-01-01T00:16:40.005, 1970-01-01T00:33:20.005");
         }
     }
 
@@ -380,12 +384,12 @@ public class JavaPyE2ETest {
             System.out.println("Result: " + res);
             assertThat(res)
                     .containsExactlyInAnyOrder(
-                            "1, Apple, Fruit, 1.5",
-                            "2, Banana, Fruit, 0.8",
-                            "3, Carrot, Vegetable, 0.6",
-                            "4, Broccoli, Vegetable, 1.2",
-                            "5, Chicken, Meat, 5.0",
-                            "6, Beef, Meat, 8.0");
+                            "1, Apple, Fruit, 1.5, 1970-01-01T00:16:40, 1970-01-01T00:33:20",
+                            "2, Banana, Fruit, 0.8, 1970-01-01T00:16:40.001, 1970-01-01T00:33:20.001",
+                            "3, Carrot, Vegetable, 0.6, 1970-01-01T00:16:40.002, 1970-01-01T00:33:20.002",
+                            "4, Broccoli, Vegetable, 1.2, 1970-01-01T00:16:40.003, 1970-01-01T00:33:20.003",
+                            "5, Chicken, Meat, 5.0, 1970-01-01T00:16:40.004, 1970-01-01T00:33:20.004",
+                            "6, Beef, Meat, 8.0, 1970-01-01T00:16:40.005, 1970-01-01T00:33:20.005");
         }
     }
 
@@ -417,9 +421,15 @@ public class JavaPyE2ETest {
                 FileIOFinder.find(tablePath), tablePath, tableSchema, CatalogEnvironment.empty());
     }
 
-    private static InternalRow createRow4Cols(int id, String name, String category, double value) {
+    private static InternalRow createRow6Cols(
+            int id, String name, String category, double value, long ts, long tsLtz) {
         return GenericRow.of(
-                id, BinaryString.fromString(name), BinaryString.fromString(category), value);
+                id,
+                BinaryString.fromString(name),
+                BinaryString.fromString(category),
+                value,
+                org.apache.paimon.data.Timestamp.fromEpochMillis(ts),
+                org.apache.paimon.data.Timestamp.fromEpochMillis(tsLtz));
     }
 
     protected GenericRow createRow3Cols(Object... values) {

--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -382,6 +382,9 @@ public class JavaPyE2ETest {
                             splits,
                             row -> DataFormatTestUtil.toStringNoRowKind(row, table.rowType()));
             System.out.println("Result for " + format + " : " + res);
+            assertThat(table.rowType().getFieldTypes().get(4)).isEqualTo(DataTypes.TIMESTAMP());
+            assertThat(table.rowType().getFieldTypes().get(5))
+                    .isEqualTo(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE());
             assertThat(res)
                     .containsExactlyInAnyOrder(
                             "1, Apple, Fruit, 1.5, 1970-01-01T00:16:40, 1970-01-01T00:33:20",

--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -124,7 +124,7 @@ public class JavaPyE2ETest {
             FileStoreTable fileStoreTable = (FileStoreTable) table;
 
             try (StreamTableWrite write = fileStoreTable.newWrite(commitUser);
-                 InnerTableCommit commit = fileStoreTable.newCommit(commitUser)) {
+                    InnerTableCommit commit = fileStoreTable.newCommit(commitUser)) {
 
                 write.write(createRow4Cols(1, "Apple", "Fruit", 1.5));
                 write.write(createRow4Cols(2, "Banana", "Fruit", 0.8));
@@ -158,69 +158,74 @@ public class JavaPyE2ETest {
     @Test
     @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
     public void testReadAppendTable() throws Exception {
-        Identifier identifier = identifier("mixed_test_append_tablep");
-        Table table = catalog.getTable(identifier);
-        FileStoreTable fileStoreTable = (FileStoreTable) table;
-        List<Split> splits =
-                new ArrayList<>(fileStoreTable.newSnapshotReader().read().dataSplits());
-        TableRead read = fileStoreTable.newRead();
-        List<String> res =
-                getResult(
-                        read,
-                        splits,
-                        row -> DataFormatTestUtil.toStringNoRowKind(row, table.rowType()));
-        System.out.println(res);
+        for (String format : Arrays.asList("parquet", "orc", "avro")) {
+            Identifier identifier = identifier("mixed_test_append_tablep_" + format);
+            Table table = catalog.getTable(identifier);
+            FileStoreTable fileStoreTable = (FileStoreTable) table;
+            List<Split> splits =
+                    new ArrayList<>(fileStoreTable.newSnapshotReader().read().dataSplits());
+            TableRead read = fileStoreTable.newRead();
+            List<String> res =
+                    getResult(
+                            read,
+                            splits,
+                            row -> DataFormatTestUtil.toStringNoRowKind(row, table.rowType()));
+            System.out.println(res);
+        }
     }
 
     @Test
     @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
     public void testJavaWriteReadPkTable() throws Exception {
-        Identifier identifier = identifier("mixed_test_pk_tablej");
-        Schema schema =
-                Schema.newBuilder()
-                        .column("id", DataTypes.INT())
-                        .column("name", DataTypes.STRING())
-                        .column("category", DataTypes.STRING())
-                        .column("value", DataTypes.DOUBLE())
-                        .primaryKey("id")
-                        .partitionKeys("category")
-                        .option("dynamic-partition-overwrite", "false")
-                        .option("bucket", "2")
-                        .build();
+        for (String format : Arrays.asList("parquet", "orc", "avro")) {
+            Identifier identifier = identifier("mixed_test_pk_tablej_" + format);
+            Schema schema =
+                    Schema.newBuilder()
+                            .column("id", DataTypes.INT())
+                            .column("name", DataTypes.STRING())
+                            .column("category", DataTypes.STRING())
+                            .column("value", DataTypes.DOUBLE())
+                            .primaryKey("id")
+                            .partitionKeys("category")
+                            .option("dynamic-partition-overwrite", "false")
+                            .option("bucket", "2")
+                            .option("file.format", format)
+                            .build();
 
-        catalog.createTable(identifier, schema, true);
-        Table table = catalog.getTable(identifier);
-        FileStoreTable fileStoreTable = (FileStoreTable) table;
+            catalog.createTable(identifier, schema, true);
+            Table table = catalog.getTable(identifier);
+            FileStoreTable fileStoreTable = (FileStoreTable) table;
 
-        try (StreamTableWrite write = fileStoreTable.newWrite(commitUser);
-                InnerTableCommit commit = fileStoreTable.newCommit(commitUser)) {
+            try (StreamTableWrite write = fileStoreTable.newWrite(commitUser);
+                    InnerTableCommit commit = fileStoreTable.newCommit(commitUser)) {
 
-            write.write(createRow4Cols(1, "Apple", "Fruit", 1.5));
-            write.write(createRow4Cols(2, "Banana", "Fruit", 0.8));
-            write.write(createRow4Cols(3, "Carrot", "Vegetable", 0.6));
-            write.write(createRow4Cols(4, "Broccoli", "Vegetable", 1.2));
-            write.write(createRow4Cols(5, "Chicken", "Meat", 5.0));
-            write.write(createRow4Cols(6, "Beef", "Meat", 8.0));
+                write.write(createRow4Cols(1, "Apple", "Fruit", 1.5));
+                write.write(createRow4Cols(2, "Banana", "Fruit", 0.8));
+                write.write(createRow4Cols(3, "Carrot", "Vegetable", 0.6));
+                write.write(createRow4Cols(4, "Broccoli", "Vegetable", 1.2));
+                write.write(createRow4Cols(5, "Chicken", "Meat", 5.0));
+                write.write(createRow4Cols(6, "Beef", "Meat", 8.0));
 
-            commit.commit(0, write.prepareCommit(true, 0));
+                commit.commit(0, write.prepareCommit(true, 0));
+            }
+
+            List<Split> splits =
+                    new ArrayList<>(fileStoreTable.newSnapshotReader().read().dataSplits());
+            TableRead read = fileStoreTable.newRead();
+            List<String> res =
+                    getResult(
+                            read,
+                            splits,
+                            row -> DataFormatTestUtil.toStringNoRowKind(row, table.rowType()));
+            assertThat(res)
+                    .containsExactlyInAnyOrder(
+                            "1, Apple, Fruit, 1.5",
+                            "2, Banana, Fruit, 0.8",
+                            "3, Carrot, Vegetable, 0.6",
+                            "4, Broccoli, Vegetable, 1.2",
+                            "5, Chicken, Meat, 5.0",
+                            "6, Beef, Meat, 8.0");
         }
-
-        List<Split> splits =
-                new ArrayList<>(fileStoreTable.newSnapshotReader().read().dataSplits());
-        TableRead read = fileStoreTable.newRead();
-        List<String> res =
-                getResult(
-                        read,
-                        splits,
-                        row -> DataFormatTestUtil.toStringNoRowKind(row, table.rowType()));
-        assertThat(res)
-                .containsExactlyInAnyOrder(
-                        "1, Apple, Fruit, 1.5",
-                        "2, Banana, Fruit, 0.8",
-                        "3, Carrot, Vegetable, 0.6",
-                        "4, Broccoli, Vegetable, 1.2",
-                        "5, Chicken, Meat, 5.0",
-                        "6, Beef, Meat, 8.0");
     }
 
     @Test

--- a/paimon-python/dev/requirements-dev.txt
+++ b/paimon-python/dev/requirements-dev.txt
@@ -23,3 +23,4 @@ flake8==4.0.1
 pytest~=7.0
 ray==2.48.0
 requests
+parameterized

--- a/paimon-python/dev/run_mixed_tests.sh
+++ b/paimon-python/dev/run_mixed_tests.sh
@@ -60,18 +60,18 @@ cleanup_warehouse() {
 
 # Function to run Java test
 run_java_write_test() {
-    echo -e "${YELLOW}=== Step 1: Running Java Write Tests (Parquet + Lance) ===${NC}"
+    echo -e "${YELLOW}=== Step 1: Running Java Write Tests (Parquet/Orc/Avro + Lance) ===${NC}"
 
     cd "$PROJECT_ROOT"
 
-    # Run the Java test method for parquet format
-    echo "Running Maven test for JavaPyE2ETest.testJavaWriteReadPkTable (Parquet)..."
+    # Run the Java test method for Parquet/Orc/Avro format
+    echo "Running Maven test for JavaPyE2ETest.testJavaWriteReadPkTable (Parquet/Orc/Avro)..."
     echo "Note: Maven may download dependencies on first run, this may take a while..."
     local parquet_result=0
     if mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testJavaWriteReadPkTable -pl paimon-core -Drun.e2e.tests=true; then
-        echo -e "${GREEN}✓ Java write parquet test completed successfully${NC}"
+        echo -e "${GREEN}✓ Java write Parquet/Orc/Avro test completed successfully${NC}"
     else
-        echo -e "${RED}✗ Java write parquet test failed${NC}"
+        echo -e "${RED}✗ Java write Parquet/Orc/Avro test failed${NC}"
         parquet_result=1
     fi
 
@@ -102,7 +102,7 @@ run_python_read_test() {
 
     cd "$PAIMON_PYTHON_DIR"
 
-    # Run the parameterized Python test method (runs for both parquet and lance)
+    # Run the parameterized Python test method (runs for both Parquet/Orc/Avro and Lance)
     echo "Running Python test for JavaPyReadWriteTest.test_read_pk_table..."
     if python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest -k "test_read_pk_table" -v; then
         echo -e "${GREEN}✓ Python test completed successfully${NC}"
@@ -121,7 +121,7 @@ run_python_write_test() {
 
     cd "$PAIMON_PYTHON_DIR"
 
-    # Run the parameterized Python test method for writing data (runs for both parquet and lance)
+    # Run the parameterized Python test method for writing data (runs for both Parquet/Orc/Avro and Lance)
     echo "Running Python test for JavaPyReadWriteTest.test_py_write_read_pk_table (Python Write)..."
     if python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest -k "test_py_write_read_pk_table" -v; then
         echo -e "${GREEN}✓ Python write test completed successfully${NC}"
@@ -134,21 +134,21 @@ run_python_write_test() {
 
 # Function to run Java Read test for Python-Write-Java-Read scenario
 run_java_read_test() {
-    echo -e "${YELLOW}=== Step 4: Running Java Read Test (JavaPyE2ETest.testReadPkTable for parquet, JavaPyLanceE2ETest.testReadPkTableLance for lance) ===${NC}"
+    echo -e "${YELLOW}=== Step 4: Running Java Read Test (JavaPyE2ETest.testReadPkTable for Parquet/Orc/Avro, JavaPyLanceE2ETest.testReadPkTableLance for Lance) ===${NC}"
 
     cd "$PROJECT_ROOT"
 
     PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "unknown")
     echo "Detected Python version: $PYTHON_VERSION"
 
-    # Run Java test for parquet format in paimon-core
-    echo "Running Maven test for JavaPyE2ETest.testReadPkTable (Java Read Parquet)..."
+    # Run Java test for Parquet/Orc/Avro format in paimon-core
+    echo "Running Maven test for JavaPyE2ETest.testReadPkTable (Java Read Parquet/Orc/Avro)..."
     echo "Note: Maven may download dependencies on first run, this may take a while..."
     local parquet_result=0
     if mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testReadPkTable -pl paimon-core -Drun.e2e.tests=true -Dpython.version="$PYTHON_VERSION"; then
-        echo -e "${GREEN}✓ Java read parquet test completed successfully${NC}"
+        echo -e "${GREEN}✓ Java read Parquet/Orc/Avro test completed successfully${NC}"
     else
-        echo -e "${RED}✗ Java read parquet test failed${NC}"
+        echo -e "${RED}✗ Java read Parquet/Orc/Avro test failed${NC}"
         parquet_result=1
     fi
 
@@ -293,7 +293,7 @@ main() {
         echo ""
     fi
 
-    # Run Java read test (handles both parquet and lance)
+    # Run Java read test (handles both Parquet/Orc/Avro and Lance)
     if ! run_java_read_test; then
         java_read_result=1
     fi
@@ -314,9 +314,9 @@ main() {
     echo -e "${YELLOW}=== Test Results Summary ===${NC}"
 
     if [[ $java_write_result -eq 0 ]]; then
-        echo -e "${GREEN}✓ Java Write Test (Parquet + Lance): PASSED${NC}"
+        echo -e "${GREEN}✓ Java Write Test (Parquet/Orc/Avro + Lance): PASSED${NC}"
     else
-        echo -e "${RED}✗ Java Write Test (Parquet + Lance): FAILED${NC}"
+        echo -e "${RED}✗ Java Write Test (Parquet/Orc/Avro + Lance): FAILED${NC}"
     fi
 
     if [[ $python_read_result -eq 0 ]]; then
@@ -332,9 +332,9 @@ main() {
     fi
 
     if [[ $java_read_result -eq 0 ]]; then
-        echo -e "${GREEN}✓ Java Read Test (Parquet + Lance): PASSED${NC}"
+        echo -e "${GREEN}✓ Java Read Test (Parquet/Orc/Avro + Lance): PASSED${NC}"
     else
-        echo -e "${RED}✗ Java Read Test (Parquet + Lance): FAILED${NC}"
+        echo -e "${RED}✗ Java Read Test (Parquet/Orc/Avro + Lance): FAILED${NC}"
     fi
 
     if [[ $pk_dv_result -eq 0 ]]; then

--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -597,12 +597,20 @@ class PyarrowFieldParser:
             return {"type": "int", "logicalType": "date"}
         elif pyarrow.types.is_timestamp(field_type):
             unit = field_type.unit
-            if unit == 'us':
-                return {"type": "long", "logicalType": "timestamp-micros"}
-            elif unit == 'ms':
-                return {"type": "long", "logicalType": "timestamp-millis"}
+            if field_type.tz is None:
+                if unit == 'us':
+                    return {"type": "long", "logicalType": "local-timestamp-micros"}
+                elif unit == 'ms':
+                    return {"type": "long", "logicalType": "local-timestamp-millis"}
+                else:
+                    return {"type": "long", "logicalType": "local-timestamp-micros"}
             else:
-                return {"type": "long", "logicalType": "timestamp-micros"}
+                if unit == 'us':
+                    return {"type": "long", "logicalType": "timestamp-micros"}
+                elif unit == 'ms':
+                    return {"type": "long", "logicalType": "timestamp-millis"}
+                else:
+                    return {"type": "long", "logicalType": "timestamp-micros"}
         elif pyarrow.types.is_list(field_type) or pyarrow.types.is_large_list(field_type):
             value_field = field_type.value_field
             return {

--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -608,7 +608,7 @@ class PyarrowFieldParser:
 
     @staticmethod
     def to_avro_schema(pyarrow_schema: Union[pyarrow.Schema, pyarrow.StructType],
-                       name: str = "Root",
+                       name: str = "Root2",
                        namespace: str = "pyarrow.avro"
                        ) -> Dict[str, Any]:
         fields = []

--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -569,7 +569,8 @@ class PyarrowFieldParser:
         return fields
 
     @staticmethod
-    def to_avro_type(field_type: pyarrow.DataType, field_name: str, parent_name: str = "record") -> Union[str, Dict[str, Any]]:
+    def to_avro_type(field_type: pyarrow.DataType, field_name: str,
+                     parent_name: str = "record") -> Union[str, Dict[str, Any]]:
         if pyarrow.types.is_integer(field_type):
             if (pyarrow.types.is_signed_integer(field_type) and field_type.bit_width <= 32) or \
                (pyarrow.types.is_unsigned_integer(field_type) and field_type.bit_width < 32):

--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -436,9 +436,6 @@ class PyarrowFieldParser:
             if type_name.startswith('TIMESTAMP'):
                 is_ltz = type_name.startswith('TIMESTAMP_LTZ') or 'WITH LOCAL TIME ZONE' in type_name
                 tz = 'UTC' if is_ltz else None
-                
-                if type_name == 'TIMESTAMP' or type_name == 'TIMESTAMP_LTZ':
-                    return pyarrow.timestamp('us', tz=tz)  # default to 6
 
                 match = re.fullmatch(r'TIMESTAMP(?:_LTZ)?\((\d+)\)(?: WITH LOCAL TIME ZONE)?', type_name)
                 if match:
@@ -451,6 +448,8 @@ class PyarrowFieldParser:
                         return pyarrow.timestamp('us', tz=tz)
                     elif 7 <= precision <= 9:
                         return pyarrow.timestamp('ns', tz=tz)
+
+                return pyarrow.timestamp('us', tz=tz)  # default to 6
             elif type_name == 'DATE':
                 return pyarrow.date32()
             if type_name.startswith('TIME'):

--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -437,9 +437,7 @@ class PyarrowFieldParser:
                 is_ltz = type_name.startswith('TIMESTAMP_LTZ') or 'WITH LOCAL TIME ZONE' in type_name
                 tz = 'UTC' if is_ltz else None
                 
-                if type_name == 'TIMESTAMP':
-                    return pyarrow.timestamp('us', tz=tz)  # default to 6
-                elif type_name == 'TIMESTAMP_LTZ':
+                if type_name == 'TIMESTAMP' or type_name == 'TIMESTAMP_LTZ':
                     return pyarrow.timestamp('us', tz=tz)  # default to 6
 
                 match = re.fullmatch(r'TIMESTAMP(?:_LTZ)?\((\d+)\)(?: WITH LOCAL TIME ZONE)?', type_name)

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -195,7 +195,7 @@ class JavaPyReadWriteTest(unittest.TestCase):
     def test_read_pk_table(self, file_format):
         # Skip ORC format for Python < 3.8 due to pyarrow limitation with TIMESTAMP_INSTANT
         if sys.version_info[:2] < (3, 8) and file_format == 'orc':
-            self.skipTest(f"Skipping ORC format for Python < 3.8 (pyarrow does not support TIMESTAMP_INSTANT)")
+            self.skipTest("Skipping ORC format for Python < 3.8 (pyarrow does not support TIMESTAMP_INSTANT)")
         
         table_name = f'default.mixed_test_pk_tablej_{file_format}'
         table = self.catalog.get_table(table_name)

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -35,9 +35,9 @@ else:
 
 def get_file_format_params():
     if sys.version_info[:2] == (3, 6):
-        return [('parquet',)]
+        return [('parquet',), ('orc',), ('avro',)]
     else:
-        return [('parquet',), ('lance',)]
+        return [('parquet',), ('orc',), ('avro',), ('lance',)]
 
 
 class JavaPyReadWriteTest(unittest.TestCase):
@@ -165,10 +165,7 @@ class JavaPyReadWriteTest(unittest.TestCase):
     def test_read_pk_table(self, file_format):
         # For parquet, read from Java-written table (no format suffix)
         # For lance, read from Java-written table (with format suffix)
-        if file_format == 'parquet':
-            table_name = 'default.mixed_test_pk_tablej'
-        else:
-            table_name = f'default.mixed_test_pk_tablej_{file_format}'
+        table_name = f'default.mixed_test_pk_tablej_{file_format}'
         table = self.catalog.get_table(table_name)
         read_builder = table.new_read_builder()
         table_scan = read_builder.new_scan()

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -50,7 +50,8 @@ class JavaPyReadWriteTest(unittest.TestCase):
         })
         cls.catalog.create_database('default', True)
 
-    def test_py_write_read_append_table(self):
+    @parameterized.expand(get_file_format_params())
+    def test_py_write_read_append_table(self, file_format):
         pa_schema = pa.schema([
             ('id', pa.int32()),
             ('name', pa.string()),
@@ -61,11 +62,11 @@ class JavaPyReadWriteTest(unittest.TestCase):
         schema = Schema.from_pyarrow_schema(
             pa_schema,
             partition_keys=['category'],
-            options={'dynamic-partition-overwrite': 'false'}
+            options={'dynamic-partition-overwrite': 'false', 'file.format': file_format}
         )
 
         self.catalog.create_table('default.mixed_test_append_tablep', schema, False)
-        table = self.catalog.get_table('default.mixed_test_append_tablep')
+        table = self.catalog.get_table('default.mixed_test_append_tablep_' + file_format)
 
         initial_data = pd.DataFrame({
             'id': [1, 2, 3, 4, 5, 6],
@@ -95,8 +96,9 @@ class JavaPyReadWriteTest(unittest.TestCase):
         actual_names = set(initial_result['name'].tolist())
         self.assertEqual(actual_names, expected_names)
 
-    def test_read_append_table(self):
-        table = self.catalog.get_table('default.mixed_test_append_tablej')
+    @parameterized.expand(get_file_format_params())
+    def test_read_append_table(self, file_format):
+        table = self.catalog.get_table('default.mixed_test_append_tablej_' + file_format)
         read_builder = table.new_read_builder()
         table_scan = read_builder.new_scan()
         table_read = read_builder.new_read()

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -65,8 +65,9 @@ class JavaPyReadWriteTest(unittest.TestCase):
             options={'dynamic-partition-overwrite': 'false', 'file.format': file_format}
         )
 
-        self.catalog.create_table('default.mixed_test_append_tablep', schema, False)
-        table = self.catalog.get_table('default.mixed_test_append_tablep_' + file_format)
+        table_name = f'default.mixed_test_append_tablep_{file_format}'
+        self.catalog.create_table(table_name, schema, False)
+        table = self.catalog.get_table(table_name)
 
         initial_data = pd.DataFrame({
             'id': [1, 2, 3, 4, 5, 6],

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -56,7 +56,9 @@ class JavaPyReadWriteTest(unittest.TestCase):
             ('id', pa.int32()),
             ('name', pa.string()),
             ('category', pa.string()),
-            ('value', pa.float64())
+            ('value', pa.float64()),
+            ('ts', pa.timestamp('us')),
+            ('ts_ltz', pa.timestamp('us', tz='UTC'))
         ])
 
         schema = Schema.from_pyarrow_schema(
@@ -73,7 +75,9 @@ class JavaPyReadWriteTest(unittest.TestCase):
             'id': [1, 2, 3, 4, 5, 6],
             'name': ['Apple', 'Banana', 'Carrot', 'Broccoli', 'Chicken', 'Beef'],
             'category': ['Fruit', 'Fruit', 'Vegetable', 'Vegetable', 'Meat', 'Meat'],
-            'value': [1.5, 0.8, 0.6, 1.2, 5.0, 8.0]
+            'value': [1.5, 0.8, 0.6, 1.2, 5.0, 8.0],
+            'ts': pd.to_datetime([1000000, 1000001, 1000002, 1000003, 1000004, 1000005], unit='ms'),
+            'ts_ltz': pd.to_datetime([2000000, 2000001, 2000002, 2000003, 2000004, 2000005], unit='ms', utc=True)
         })
         # Write initial data
         write_builder = table.new_batch_write_builder()
@@ -112,7 +116,9 @@ class JavaPyReadWriteTest(unittest.TestCase):
             ('id', pa.int32()),
             ('name', pa.string()),
             ('category', pa.string()),
-            ('value', pa.float64())
+            ('value', pa.float64()),
+            ('ts', pa.timestamp('us')),
+            ('ts_ltz', pa.timestamp('us', tz='UTC'))
         ])
 
         table_name = f'default.mixed_test_pk_tablep_{file_format}'
@@ -142,7 +148,9 @@ class JavaPyReadWriteTest(unittest.TestCase):
             'id': [1, 2, 3, 4, 5, 6],
             'name': ['Apple', 'Banana', 'Carrot', 'Broccoli', 'Chicken', 'Beef'],
             'category': ['Fruit', 'Fruit', 'Vegetable', 'Vegetable', 'Meat', 'Meat'],
-            'value': [1.5, 0.8, 0.6, 1.2, 5.0, 8.0]
+            'value': [1.5, 0.8, 0.6, 1.2, 5.0, 8.0],
+            'ts': pd.to_datetime([1000000, 1000001, 1000002, 1000003, 1000004, 1000005], unit='ms'),
+            'ts_ltz': pd.to_datetime([2000000, 2000001, 2000002, 2000003, 2000004, 2000005], unit='ms', utc=True)
         })
         write_builder = table.new_batch_write_builder()
         table_write = write_builder.new_write()

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -112,14 +112,23 @@ class JavaPyReadWriteTest(unittest.TestCase):
 
     @parameterized.expand(get_file_format_params())
     def test_py_write_read_pk_table(self, file_format):
-        pa_schema = pa.schema([
-            ('id', pa.int32()),
-            ('name', pa.string()),
-            ('category', pa.string()),
-            ('value', pa.float64()),
-            ('ts', pa.timestamp('us')),
-            ('ts_ltz', pa.timestamp('us', tz='UTC'))
-        ])
+        # Lance format doesn't support timestamp, so exclude timestamp columns
+        if file_format == 'lance':
+            pa_schema = pa.schema([
+                ('id', pa.int32()),
+                ('name', pa.string()),
+                ('category', pa.string()),
+                ('value', pa.float64())
+            ])
+        else:
+            pa_schema = pa.schema([
+                ('id', pa.int32()),
+                ('name', pa.string()),
+                ('category', pa.string()),
+                ('value', pa.float64()),
+                ('ts', pa.timestamp('us')),
+                ('ts_ltz', pa.timestamp('us', tz='UTC'))
+            ])
 
         table_name = f'default.mixed_test_pk_tablep_{file_format}'
         schema = Schema.from_pyarrow_schema(
@@ -145,14 +154,23 @@ class JavaPyReadWriteTest(unittest.TestCase):
         self.catalog.create_table(table_name, schema, False)
         table = self.catalog.get_table(table_name)
 
-        initial_data = pd.DataFrame({
-            'id': [1, 2, 3, 4, 5, 6],
-            'name': ['Apple', 'Banana', 'Carrot', 'Broccoli', 'Chicken', 'Beef'],
-            'category': ['Fruit', 'Fruit', 'Vegetable', 'Vegetable', 'Meat', 'Meat'],
-            'value': [1.5, 0.8, 0.6, 1.2, 5.0, 8.0],
-            'ts': pd.to_datetime([1000000, 1000001, 1000002, 1000003, 1000004, 1000005], unit='ms'),
-            'ts_ltz': pd.to_datetime([2000000, 2000001, 2000002, 2000003, 2000004, 2000005], unit='ms', utc=True)
-        })
+        # Lance format doesn't support timestamp, so exclude timestamp columns
+        if file_format == 'lance':
+            initial_data = pd.DataFrame({
+                'id': [1, 2, 3, 4, 5, 6],
+                'name': ['Apple', 'Banana', 'Carrot', 'Broccoli', 'Chicken', 'Beef'],
+                'category': ['Fruit', 'Fruit', 'Vegetable', 'Vegetable', 'Meat', 'Meat'],
+                'value': [1.5, 0.8, 0.6, 1.2, 5.0, 8.0]
+            })
+        else:
+            initial_data = pd.DataFrame({
+                'id': [1, 2, 3, 4, 5, 6],
+                'name': ['Apple', 'Banana', 'Carrot', 'Broccoli', 'Chicken', 'Beef'],
+                'category': ['Fruit', 'Fruit', 'Vegetable', 'Vegetable', 'Meat', 'Meat'],
+                'value': [1.5, 0.8, 0.6, 1.2, 5.0, 8.0],
+                'ts': pd.to_datetime([1000000, 1000001, 1000002, 1000003, 1000004, 1000005], unit='ms'),
+                'ts_ltz': pd.to_datetime([2000000, 2000001, 2000002, 2000003, 2000004, 2000005], unit='ms', utc=True)
+            })
         write_builder = table.new_batch_write_builder()
         table_write = write_builder.new_write()
         table_commit = write_builder.new_commit()

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -129,7 +129,8 @@ class JavaPyReadWriteTest(unittest.TestCase):
             options={
                 'dynamic-partition-overwrite': 'false',
                 'bucket': '2',
-                'file.format': file_format
+                'file.format': file_format,
+                "orc.timestamp-ltz.legacy.type": "false"
             }
         )
 

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -175,8 +175,6 @@ class JavaPyReadWriteTest(unittest.TestCase):
 
     @parameterized.expand(get_file_format_params())
     def test_read_pk_table(self, file_format):
-        # For parquet, read from Java-written table (no format suffix)
-        # For lance, read from Java-written table (with format suffix)
         table_name = f'default.mixed_test_pk_tablej_{file_format}'
         table = self.catalog.get_table(table_name)
         read_builder = table.new_read_builder()

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -193,6 +193,10 @@ class JavaPyReadWriteTest(unittest.TestCase):
 
     @parameterized.expand(get_file_format_params())
     def test_read_pk_table(self, file_format):
+        # Skip ORC format for Python < 3.8 due to pyarrow limitation with TIMESTAMP_INSTANT
+        if sys.version_info[:2] < (3, 8) and file_format == 'orc':
+            self.skipTest(f"Skipping ORC format for Python < 3.8 (pyarrow does not support TIMESTAMP_INSTANT)")
+        
         table_name = f'default.mixed_test_pk_tablej_{file_format}'
         table = self.catalog.get_table(table_name)
         read_builder = table.new_read_builder()

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -187,6 +187,9 @@ class JavaPyReadWriteTest(unittest.TestCase):
 
         # Verify data
         self.assertEqual(len(res), 6)
+        if file_format != "lance":
+            self.assertEqual(table.fields[4].type.type, "TIMESTAMP(6)")
+            self.assertEqual(table.fields[5].type.type, "TIMESTAMP(6) WITH LOCAL TIME ZONE")
         # Data order may vary due to partitioning/bucketing, so compare as sets
         expected_names = {'Apple', 'Banana', 'Carrot', 'Broccoli', 'Chicken', 'Beef'}
         actual_names = set(res['name'].tolist())


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds cross-format (Parquet/ORC/Avro) coverage and proper timestamp handling across Java and Python.
> 
> - Java tests now parameterize append/pk table write/read over `parquet|orc|avro`, add `ts` and `ts_ltz` columns, validate values and types, and introduce `createRow6Cols` helper
> - Python E2E tests parameterized over `parquet|orc|avro|lance` (timestamps excluded for `lance`), verify field types, and skip ORC on older Python; add ORC option `"orc.timestamp-ltz.legacy.type": "false"`
> - Python schema layer: map Paimon `TIMESTAMP`/`TIMESTAMP_LTZ` to PyArrow with timezone (`UTC` for LTZ), convert PyArrow timestamps back to `TIMESTAMP`/`TIMESTAMP_LTZ`, and generate Avro with `local-timestamp-*` vs `timestamp-*`; improved nested naming and namespace
> - Test tooling: `run_mixed_tests.sh` messaging updated to include all formats; dev requirements add `parameterized`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10cc9799ce03667ab7b395e58c2f9f997833ec2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->