### PR TITLE
[python] fix data-evolution row count double-counting issue

### DIFF
--- a/paimon-python/pypaimon/globalindex/indexed_split.py
+++ b/paimon-python/pypaimon/globalindex/indexed_split.py
@@ -76,6 +76,9 @@ class IndexedSplit(Split):
         """
         return sum(r.count() for r in self._row_ranges)
 
+    def merged_row_count(self):
+        return self.row_count
+
     # Delegate other properties to data_split
 
     @property

--- a/paimon-python/pypaimon/read/datasource/ray_datasource.py
+++ b/paimon-python/pypaimon/read/datasource/ray_datasource.py
@@ -171,8 +171,15 @@ class RayDatasource(Datasource):
             for split in chunk_splits:
                 if predicate is None:
                     # Only estimate rows if no predicate (predicate filtering changes row count)
-                    if hasattr(split, 'row_count') and split.row_count > 0:
-                        total_rows += split.row_count
+                    row_count = None
+                    if hasattr(split, 'merged_row_count'):
+                        merged_count = split.merged_row_count()
+                        if merged_count is not None:
+                            row_count = merged_count
+                    if row_count is None and hasattr(split, 'row_count') and split.row_count > 0:
+                        row_count = split.row_count
+                    if row_count is not None and row_count > 0:
+                        total_rows += row_count
                 if hasattr(split, 'file_size') and split.file_size > 0:
                     total_size += split.file_size
 

--- a/paimon-python/pypaimon/read/split.py
+++ b/paimon-python/pypaimon/read/split.py
@@ -120,73 +120,83 @@ class DataSplit(Split):
         self._row_count = row_count
 
     def merged_row_count(self) -> Optional[int]:
-        if not self.raw_convertible:
-            return None
-        
-        # In data evolution scenario, files with the same first_row_id represent the same logical row.
-        # We need to count each first_row_id only once to get the actual row count.
-        if len(self._files) > 1:
-            first_row_ids = [f.first_row_id for f in self._files if f.first_row_id is not None]
-            if len(first_row_ids) != len(set(first_row_ids)):
-                # Multiple files with the same first_row_id indicates data evolution scenario
-                # Calculate actual row count by counting each first_row_id only once
-                # Use the row_count from the first non-blob file for each first_row_id
-                row_count_by_first_row_id = {}
-                for file in self._files:
-                    if file.first_row_id is not None:
-                        if file.first_row_id not in row_count_by_first_row_id:
-                            # Prefer non-blob file's row_count for accuracy
-                            if not file.file_name.endswith('.blob'):
-                                row_count_by_first_row_id[file.first_row_id] = file.row_count
-                # Fill in any missing first_row_ids with the first file's row_count
-                for file in self._files:
-                    if file.first_row_id is not None and file.first_row_id not in row_count_by_first_row_id:
-                        row_count_by_first_row_id[file.first_row_id] = file.row_count
-                
-                # Sum up row counts for each unique first_row_id
-                actual_row_count = sum(row_count_by_first_row_id.values())
-                
-                # Account for deletion files if present
-                # Note: deletion files in data evolution may need special handling
-                if self.data_deletion_files is not None:
-                    if not all(
-                        f is None or f.cardinality is not None
-                        for f in self.data_deletion_files
-                    ):
-                        return None
-                    
-                    # Subtract deletion counts
-                    for i, deletion_file in enumerate(self.data_deletion_files):
-                        if deletion_file is not None and deletion_file.cardinality is not None:
-                            if i < len(self._files):
-                                file = self._files[i]
-                                if file.first_row_id is not None:
-                                    # Only subtract once per first_row_id
-                                    if file.first_row_id in row_count_by_first_row_id:
-                                        actual_row_count -= deletion_file.cardinality
-                                        # Remove from dict to avoid double subtraction
-                                        del row_count_by_first_row_id[file.first_row_id]
-                
-                return actual_row_count
-        
-        if self.data_deletion_files is not None:
-            if not all(
-                f is None or f.cardinality is not None
-                for f in self.data_deletion_files
-            ):
-                return None
-        
+        """
+        Return the merged row count of data files. For example, when the delete vector is enabled in
+        the primary key table, the number of rows that have been deleted will be subtracted from the
+        returned result. In the Data Evolution mode of the Append table, the actual number of rows
+        will be returned.
+        """
+        if self._raw_merged_row_count_available():
+            return self._raw_merged_row_count()
+        if self._data_evolution_row_count_available():
+            return self._data_evolution_merged_row_count()
+        return None
+
+    def _raw_merged_row_count_available(self) -> bool:
+        return self.raw_convertible and (
+            self.data_deletion_files is None
+            or all(f is None or f.cardinality is not None for f in self.data_deletion_files)
+        )
+
+    def _raw_merged_row_count(self) -> int:
         sum_rows = 0
         for i, file in enumerate(self._files):
-            deletion_file = (
-                None if self.data_deletion_files is None
-                else self.data_deletion_files[i] if i < len(self.data_deletion_files)
-                else None
-            )
+            deletion_file = None
+            if self.data_deletion_files is not None and i < len(self.data_deletion_files):
+                deletion_file = self.data_deletion_files[i]
             
             if deletion_file is None:
                 sum_rows += file.row_count
             elif deletion_file.cardinality is not None:
                 sum_rows += file.row_count - deletion_file.cardinality
+        
+        return sum_rows
+
+    def _data_evolution_row_count_available(self) -> bool:
+        for file in self._files:
+            if file.first_row_id is None:
+                return False
+        return True
+
+    def _data_evolution_merged_row_count(self) -> int:
+        if not self._files:
+            return 0
+        
+        file_ranges = []
+        for file in self._files:
+            if file.first_row_id is not None and file.row_count > 0:
+                start = file.first_row_id
+                end = file.first_row_id + file.row_count - 1
+                file_ranges.append((file, start, end))
+        
+        if not file_ranges:
+            return 0
+        
+        file_ranges.sort(key=lambda x: (x[1], x[2]))
+        
+        groups = []
+        current_group = [file_ranges[0]]
+        current_end = file_ranges[0][2]
+        
+        for file_range in file_ranges[1:]:
+            file, start, end = file_range
+            if start <= current_end:
+                current_group.append(file_range)
+                if end > current_end:
+                    current_end = end
+            else:
+                groups.append(current_group)
+                current_group = [file_range]
+                current_end = end
+        
+        if current_group:
+            groups.append(current_group)
+        
+        sum_rows = 0
+        for group in groups:
+            max_count = 0
+            for file, _, _ in group:
+                max_count = max(max_count, file.row_count)
+            sum_rows += max_count
         
         return sum_rows


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes row counting for data-evolution reads and adds a unified way to estimate effective rows across readers.
> 
> - Introduces `merged_row_count()` on `Split`, implemented by `DataSplit`, `SlicedSplit`, and `IndexedSplit`; handles delete vectors, overlapping row-id ranges (data evolution), slicing, and returns None when unverifiable
> - In `DataSplit`, computes merged count without double-counting; in `SlicedSplit`, adjusts for shard file slicing; `IndexedSplit` delegates to row-range size
> - `DataEvolutionSplitGenerator` now builds `DataSplit` directly with `raw_convertible` (true only when each packed range has exactly one file) and attaches deletion files; refactors packing path
> - `RayDatasource` prefers `merged_row_count()` for per-task `num_rows` estimation when no predicate
> - Tests extended: validate `merged_row_count()` invariants (including sliced splits), update large-blob rolling assertions, and add Ray dataset read for blob descriptors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8b3d434e04eff88523463ae01171ab69726877f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->