### PR TITLE
Pr 7090

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/IndexedSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/IndexedSplit.java
@@ -35,6 +35,7 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 /** Indexed split for global index. */
 public class IndexedSplit implements Split {
@@ -69,6 +70,11 @@ public class IndexedSplit implements Split {
     @Override
     public long rowCount() {
         return rowRanges.stream().mapToLong(r -> r.to - r.from + 1).sum();
+    }
+
+    @Override
+    public OptionalLong mergedRowCount() {
+        return OptionalLong.of(rowCount());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
@@ -63,6 +63,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -249,6 +250,7 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
 
     /** Split for fallback read. */
     public interface FallbackSplit extends Split {
+
         boolean isFallback();
 
         Split wrapped();
@@ -280,6 +282,11 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
         @Override
         public long rowCount() {
             return split.rowCount();
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return split.mergedRowCount();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatDataSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatDataSplit.java
@@ -25,6 +25,7 @@ import org.apache.paimon.table.source.Split;
 import javax.annotation.Nullable;
 
 import java.util.Objects;
+import java.util.OptionalLong;
 
 /** {@link FormatDataSplit} for format table. */
 public class FormatDataSplit implements Split {
@@ -83,6 +84,11 @@ public class FormatDataSplit implements Split {
     @Override
     public long rowCount() {
         return -1;
+    }
+
+    @Override
+    public OptionalLong mergedRowCount() {
+        return OptionalLong.empty();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/object/ObjectTableImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/object/ObjectTableImpl.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static org.apache.paimon.data.BinaryString.fromString;
 
@@ -188,6 +189,11 @@ public class ObjectTableImpl implements ReadonlyTable, ObjectTable {
         @Override
         public int hashCode() {
             return Objects.hash(location);
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ChainSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ChainSplit.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 /**
  * A split describes chain table read scope. It follows DataSplit's custom serialization pattern and
@@ -85,6 +86,11 @@ public class ChainSplit implements Split {
             sum += file.rowCount();
         }
         return sum;
+    }
+
+    @Override
+    public OptionalLong mergedRowCount() {
+        return OptionalLong.empty();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
@@ -55,7 +55,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.paimon.io.DataFilePathFactory.INDEX_PATH_SUFFIX;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
-import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** Input splits. Needed by most batch computation engines. */
 public class DataSplit implements Split {
@@ -143,17 +142,30 @@ public class DataSplit implements Split {
         return rowCount;
     }
 
-    /** Whether it is possible to calculate the merged row count. */
-    public boolean mergedRowCountAvailable() {
-        return rawConvertible
+    @Override
+    public OptionalLong mergedRowCount() {
+        if (rawConvertible
                 && (dataDeletionFiles == null
                         || dataDeletionFiles.stream()
-                                .allMatch(f -> f == null || f.cardinality() != null));
-    }
-
-    public long mergedRowCount() {
-        checkState(mergedRowCountAvailable());
-        return partialMergedRowCount();
+                                .allMatch(f -> f == null || f.cardinality() != null))) {
+            long sum = 0L;
+            List<RawFile> rawFiles = convertToRawFiles().orElse(null);
+            if (rawFiles != null) {
+                for (int i = 0; i < rawFiles.size(); i++) {
+                    RawFile rawFile = rawFiles.get(i);
+                    DeletionFile deletionFile =
+                            dataDeletionFiles == null ? null : dataDeletionFiles.get(i);
+                    Long cardinality = deletionFile == null ? null : deletionFile.cardinality();
+                    if (deletionFile == null) {
+                        sum += rawFile.rowCount();
+                    } else if (cardinality != null) {
+                        sum += rawFile.rowCount() - cardinality;
+                    }
+                }
+            }
+            return OptionalLong.of(sum);
+        }
+        return OptionalLong.empty();
     }
 
     public Object minValue(int fieldIndex, DataField dataField, SimpleStatsEvolutions evolutions) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static org.apache.paimon.table.source.PushDownUtils.minmaxAvailable;
 
@@ -144,10 +145,10 @@ public class DataTableBatchScan extends AbstractDataTableScan {
 
         List<Split> limitedSplits = new ArrayList<>();
         for (DataSplit dataSplit : splits) {
-            if (dataSplit.rawConvertible()) {
-                long partialMergedRowCount = dataSplit.partialMergedRowCount();
+            OptionalLong mergedRowCount = dataSplit.mergedRowCount();
+            if (mergedRowCount.isPresent()) {
                 limitedSplits.add(dataSplit);
-                scannedRowCount += partialMergedRowCount;
+                scannedRowCount += mergedRowCount.getAsLong();
                 if (scannedRowCount >= pushDownLimit) {
                     SnapshotReader.Plan newPlan =
                             new PlanImpl(plan.watermark(), plan.snapshotId(), limitedSplits);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/QueryAuthSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/QueryAuthSplit.java
@@ -22,6 +22,8 @@ import org.apache.paimon.catalog.TableQueryAuthResult;
 
 import javax.annotation.Nullable;
 
+import java.util.OptionalLong;
+
 /** A wrapper class for {@link Split} that adds query authorization information. */
 public class QueryAuthSplit implements Split {
 
@@ -47,5 +49,10 @@ public class QueryAuthSplit implements Split {
     @Override
     public long rowCount() {
         return split.rowCount();
+    }
+
+    @Override
+    public OptionalLong mergedRowCount() {
+        return split.mergedRowCount();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/Split.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/Split.java
@@ -23,6 +23,7 @@ import org.apache.paimon.annotation.Public;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * An input split for reading.
@@ -32,7 +33,19 @@ import java.util.Optional;
 @Public
 public interface Split extends Serializable {
 
+    /**
+     * The row count in files, may be duplicated, such as in the primary key table and the
+     * Data-Evolution Append table.
+     */
     long rowCount();
+
+    /**
+     * Return the merged row count of data files. For example, when the delete vector is enabled in
+     * the primary key table, the number of rows that have been deleted will be subtracted from the
+     * returned result. In the Data Evolution mode of the Append table, the actual number of rows
+     * will be returned.
+     */
+    OptionalLong mergedRowCount();
 
     /**
      * If all files in this split can be read without merging, returns an {@link Optional} wrapping

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AggregationFieldsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AggregationFieldsTable.java
@@ -53,6 +53,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.function.Function;
 
 import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
@@ -159,6 +160,11 @@ public class AggregationFieldsTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return Objects.hash(location);
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AllPartitionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AllPartitionsTable.java
@@ -52,6 +52,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 /** This is a system table to display all the database-table-partitions. */
 public class AllPartitionsTable implements ReadonlyTable {
@@ -179,6 +180,11 @@ public class AllPartitionsTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return Objects.hash(rows);
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AllTableOptionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AllTableOptionsTable.java
@@ -50,6 +50,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 /**
  * This is a system table to display all the database-table properties.
@@ -157,6 +158,11 @@ public class AllTableOptionsTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return Objects.hash(allOptions);
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AllTablesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AllTablesTable.java
@@ -52,6 +52,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 import static org.apache.paimon.CoreOptions.TYPE;
 import static org.apache.paimon.rest.responses.AuditRESTResponse.FIELD_CREATED_AT;
@@ -199,6 +200,11 @@ public class AllTablesTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return Objects.hash(rows);
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BranchesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BranchesTable.java
@@ -65,6 +65,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
 
@@ -149,6 +150,7 @@ public class BranchesTable implements ReadonlyTable {
     }
 
     private static class BranchesSplit extends SingletonSplit {
+
         private static final long serialVersionUID = 1L;
 
         private final Path location;
@@ -176,6 +178,11 @@ public class BranchesTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return Objects.hash(location);
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
@@ -57,6 +57,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 
 import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
 
@@ -146,6 +147,11 @@ public class BucketsTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return 1;
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/CatalogOptionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/CatalogOptionsTable.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 
 import static org.apache.paimon.utils.SerializationUtils.newStringType;
 
@@ -147,6 +148,11 @@ public class CatalogOptionsTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return catalogOptions.hashCode();
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ConsumersTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ConsumersTable.java
@@ -53,6 +53,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
 
@@ -157,6 +158,11 @@ public class ConsumersTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return Objects.hash(location);
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
@@ -78,6 +78,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -282,6 +283,11 @@ public class FilesTable implements ReadonlyTable {
                 scan.withLevelFilter(level -> true);
             }
             return scan.plan();
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
@@ -60,6 +60,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 
 import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
 
@@ -158,6 +159,11 @@ public class ManifestsTable implements ReadonlyTable {
                 return true;
             }
             return o != null && getClass() == o.getClass();
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/OptionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/OptionsTable.java
@@ -48,6 +48,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
 import static org.apache.paimon.utils.SerializationUtils.newStringType;
@@ -149,6 +150,11 @@ public class OptionsTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return Objects.hash(location);
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
@@ -72,6 +72,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
@@ -165,6 +166,11 @@ public class PartitionsTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return 1;
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SchemasTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SchemasTable.java
@@ -73,6 +73,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -171,6 +172,11 @@ public class SchemasTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return 0;
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
@@ -71,6 +71,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
 
@@ -194,6 +195,11 @@ public class SnapshotsTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return Objects.hash(location);
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/StatisticTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/StatisticTable.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
 
@@ -155,6 +156,11 @@ public class StatisticTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return Objects.hash(location);
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/TableIndexesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/TableIndexesTable.java
@@ -62,6 +62,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 
 import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
 import static org.apache.paimon.utils.SerializationUtils.newStringType;
@@ -153,6 +154,11 @@ public class TableIndexesTable implements ReadonlyTable {
                 return true;
             }
             return o != null && getClass() == o.getClass();
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/TagsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/TagsTable.java
@@ -67,6 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.TreeMap;
 
 import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
@@ -187,6 +188,11 @@ public class TagsTable implements ReadonlyTable {
         @Override
         public int hashCode() {
             return Objects.hash(location);
+        }
+
+        @Override
+        public OptionalLong mergedRowCount() {
+            return OptionalLong.empty();
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/DataSplitCompatibleTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/DataSplitCompatibleTest.java
@@ -67,14 +67,11 @@ public class DataSplitCompatibleTest {
         List<DataFileMeta> dataFiles =
                 Arrays.asList(newDataFile(1000L), newDataFile(2000L), newDataFile(3000L));
         DataSplit split = newDataSplit(false, dataFiles, null);
-        assertThat(split.partialMergedRowCount()).isEqualTo(0L);
-        assertThat(split.mergedRowCountAvailable()).isEqualTo(false);
+        assertThat(split.mergedRowCount()).isEmpty();
 
         // rawConvertible without deletion files
         split = newDataSplit(true, dataFiles, null);
-        assertThat(split.partialMergedRowCount()).isEqualTo(6000L);
-        assertThat(split.mergedRowCountAvailable()).isEqualTo(true);
-        assertThat(split.mergedRowCount()).isEqualTo(6000L);
+        assertThat(split.mergedRowCount()).hasValue(6000L);
 
         // rawConvertible with deletion files without cardinality
         ArrayList<DeletionFile> deletionFiles = new ArrayList<>();
@@ -82,8 +79,7 @@ public class DataSplitCompatibleTest {
         deletionFiles.add(new DeletionFile("p", 1, 2, null));
         deletionFiles.add(new DeletionFile("p", 1, 2, 100L));
         split = newDataSplit(true, dataFiles, deletionFiles);
-        assertThat(split.partialMergedRowCount()).isEqualTo(3900L);
-        assertThat(split.mergedRowCountAvailable()).isEqualTo(false);
+        assertThat(split.mergedRowCount()).isEmpty();
 
         // rawConvertible with deletion files with cardinality
         deletionFiles = new ArrayList<>();
@@ -91,9 +87,7 @@ public class DataSplitCompatibleTest {
         deletionFiles.add(new DeletionFile("p", 1, 2, 200L));
         deletionFiles.add(new DeletionFile("p", 1, 2, 100L));
         split = newDataSplit(true, dataFiles, deletionFiles);
-        assertThat(split.partialMergedRowCount()).isEqualTo(5700L);
-        assertThat(split.mergedRowCountAvailable()).isEqualTo(true);
-        assertThat(split.mergedRowCount()).isEqualTo(5700L);
+        assertThat(split.mergedRowCount()).hasValue(5700L);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
@@ -37,7 +37,6 @@ import org.apache.paimon.table.BucketSpec;
 import org.apache.paimon.table.DataTable;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
-import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.utils.Projection;
 
@@ -354,13 +353,11 @@ public abstract class BaseDataTableSource extends FlinkTableSource
                         .splits();
         long countPushed = 0;
         for (Split s : splits) {
-            if (!(s instanceof DataSplit)) {
+            OptionalLong mergedRowCount = s.mergedRowCount();
+            if (!mergedRowCount.isPresent()) {
                 return false;
             }
-            OptionalLong mergedRowCount = s.mergedRowCount();
-            if (mergedRowCount.isPresent()) {
-                countPushed += mergedRowCount.getAsLong();
-            }
+            countPushed += mergedRowCount.getAsLong();
         }
 
         this.countPushed = countPushed;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
@@ -66,6 +66,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -356,12 +357,10 @@ public abstract class BaseDataTableSource extends FlinkTableSource
             if (!(s instanceof DataSplit)) {
                 return false;
             }
-            DataSplit split = (DataSplit) s;
-            if (!split.mergedRowCountAvailable()) {
-                return false;
+            OptionalLong mergedRowCount = s.mergedRowCount();
+            if (mergedRowCount.isPresent()) {
+                countPushed += mergedRowCount.getAsLong();
             }
-
-            countPushed += split.mergedRowCount();
         }
 
         this.countPushed = countPushed;

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/aggregate/AggFuncEvaluator.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/aggregate/AggFuncEvaluator.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.types.{DataType, LongType}
 import org.apache.spark.unsafe.types.UTF8String
 
 trait AggFuncEvaluator[T] {
+
   def update(dataSplit: DataSplit): Unit
 
   def result(): T
@@ -42,7 +43,7 @@ class CountStarEvaluator extends AggFuncEvaluator[Long] {
   private var _result: Long = 0L
 
   override def update(dataSplit: DataSplit): Unit = {
-    _result += dataSplit.mergedRowCount()
+    _result += dataSplit.mergedRowCount().getAsLong
   }
 
   val a: Int = 1;

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/aggregate/AggregatePushDownUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/aggregate/AggregatePushDownUtils.scala
@@ -70,7 +70,7 @@ object AggregatePushDownUtils {
     }
     val dataSplits = splits.map(_.asInstanceOf[DataSplit])
 
-    if (!dataSplits.forall(_.mergedRowCountAvailable())) {
+    if (!dataSplits.forall(_.mergedRowCount().isPresent)) {
       return None
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new `OptionalLong mergedRowCount()` in `Split` and refactors planning/pushdown logic to consume it.
> 
> - Core: Implement `mergedRowCount` in `DataSplit` (handles raw/deletion-vector logic) and `IndexedSplit` (returns `rowCount`); most other `Split` types return `OptionalLong.empty()`
> - Remove `DataSplit.mergedRowCountAvailable` and `partialMergedRowCount`; update `DataTableBatchScan` limit pushdown to use `OptionalLong`
> - Wrapper splits (`FallbackSplitImpl`, `QueryAuthSplit`) delegate `mergedRowCount`
> - Connectors: Flink `BaseDataTableSource` aggregate pushdown now sums `Split.mergedRowCount`; Spark `CountStarEvaluator` and `AggregatePushDownUtils` updated accordingly
> - Tests: Adjust `DataSplitCompatibleTest` to assert presence/emptiness of `mergedRowCount`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81505da312fbe75241eca572c154c7cd3f7610bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->