### PR TITLE
[python/hotfix] fix faiss-cpu version define and make faiss-cpu optional

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -177,111 +177,124 @@ jobs:
           chmod +x paimon-python/dev/lint-python.sh
           ./paimon-python/dev/lint-python.sh -i pytest_torch
 
-  # Per-Python requirement check (all versions) + Ray version test (3.10 only).
+  # One job: check dev/requirements.txt on each Python version in sequence, then Ray version test on 3.10.
   requirement_version_compatible_test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ '3.6.15', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
-    container: "python:${{ matrix.python-version }}-slim"
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
       - name: Install system dependencies
-        shell: bash
         run: |
-          apt-get update && apt-get install -y --no-install-recommends \
-            build-essential git curl \
-            && rm -rf /var/lib/apt/lists/*
-      - name: Install build deps for source-built packages (e.g. PyArrow on 3.12/3.13)
-        if: matrix.python-version == '3.12' || matrix.python-version == '3.13'
-        run: |
-          apt-get update && apt-get install -y --no-install-recommends cmake \
-            && rm -rf /var/lib/apt/lists/*
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+            build-essential git curl cmake \
+            && sudo rm -rf /var/lib/apt/lists/*
 
-      - name: Verify Python version
-        run: python --version
-
-      - name: Verify dev/requirements.txt can be resolved
-        shell: bash
+      - name: Verify dev/requirements.txt on Python 3.6
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.6'
+      - name: Resolve requirements (3.6)
         run: |
-          cd paimon-python
-          python -m pip install --upgrade pip
+          cd paimon-python && python -m pip install --upgrade pip
           TEMP_DIR=$(mktemp -d)
-          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || {
-            echo "ERROR: Failed to resolve dependencies from dev/requirements.txt"
-            rm -rf "$TEMP_DIR"
-            exit 1
-          }
-          rm -rf "$TEMP_DIR"
-          echo "✓ dev/requirements.txt can be resolved on Python ${{ matrix.python-version }}"
+          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || { rm -rf "$TEMP_DIR"; exit 1; }
+          rm -rf "$TEMP_DIR" && echo "✓ dev/requirements.txt OK on Python 3.6"
 
+      - name: Verify dev/requirements.txt on Python 3.8
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+      - name: Resolve requirements (3.8)
+        run: |
+          cd paimon-python && python -m pip install --upgrade pip
+          TEMP_DIR=$(mktemp -d)
+          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || { rm -rf "$TEMP_DIR"; exit 1; }
+          rm -rf "$TEMP_DIR" && echo "✓ dev/requirements.txt OK on Python 3.8"
+
+      - name: Verify dev/requirements.txt on Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Resolve requirements (3.9)
+        run: |
+          cd paimon-python && python -m pip install --upgrade pip
+          TEMP_DIR=$(mktemp -d)
+          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || { rm -rf "$TEMP_DIR"; exit 1; }
+          rm -rf "$TEMP_DIR" && echo "✓ dev/requirements.txt OK on Python 3.9"
+
+      - name: Verify dev/requirements.txt on Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Resolve requirements (3.10)
+        run: |
+          cd paimon-python && python -m pip install --upgrade pip
+          TEMP_DIR=$(mktemp -d)
+          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || { rm -rf "$TEMP_DIR"; exit 1; }
+          rm -rf "$TEMP_DIR" && echo "✓ dev/requirements.txt OK on Python 3.10"
+
+      - name: Verify dev/requirements.txt on Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Resolve requirements (3.11)
+        run: |
+          cd paimon-python && python -m pip install --upgrade pip
+          TEMP_DIR=$(mktemp -d)
+          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || { rm -rf "$TEMP_DIR"; exit 1; }
+          rm -rf "$TEMP_DIR" && echo "✓ dev/requirements.txt OK on Python 3.11"
+
+      - name: Verify dev/requirements.txt on Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Resolve requirements (3.12)
+        run: |
+          cd paimon-python && python -m pip install --upgrade pip
+          TEMP_DIR=$(mktemp -d)
+          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || { rm -rf "$TEMP_DIR"; exit 1; }
+          rm -rf "$TEMP_DIR" && echo "✓ dev/requirements.txt OK on Python 3.12"
+
+      - name: Verify dev/requirements.txt on Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Resolve requirements (3.13)
+        run: |
+          cd paimon-python && python -m pip install --upgrade pip
+          TEMP_DIR=$(mktemp -d)
+          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || { rm -rf "$TEMP_DIR"; exit 1; }
+          rm -rf "$TEMP_DIR" && echo "✓ dev/requirements.txt OK on Python 3.13"
+
+      - name: Setup Python 3.10 for Ray test
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - name: Install base Python dependencies
-        if: matrix.python-version == '3.10'
-        shell: bash
         run: |
           python -m pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           python -m pip install --no-cache-dir \
-            pyroaring \
-            readerwriterlock==1.0.9 \
-            fsspec==2024.3.1 \
-            cachetools==5.3.3 \
-            ossfs==2023.12.0 \
-            fastavro==1.11.1 \
-            pyarrow==16.0.0 \
-            zstandard==0.24.0 \
-            polars==1.32.0 \
-            duckdb==1.3.2 \
-            numpy==1.24.3 \
-            pandas==2.0.3 \
-            cramjam \
-            pytest~=7.0 \
-            py4j==0.10.9.9 \
-            requests \
-            parameterized==0.9.0 \
-            packaging
-
-      - name: Test requirement version compatibility
-        if: matrix.python-version == '3.10'
-        shell: bash
+            pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 \
+            fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 \
+            numpy==1.24.3 pandas==2.0.3 cramjam pytest~=7.0 py4j==0.10.9.9 requests \
+            parameterized==0.9.0 packaging
+      - name: Test Ray version compatibility
         run: |
           cd paimon-python
-
-          # Test Ray version compatibility
           echo "=========================================="
           echo "Testing Ray version compatibility"
           echo "=========================================="
           for ray_version in 2.44.0 2.48.0 2.53.0; do
             echo "Testing Ray version: $ray_version"
-
-            # Install specific Ray version
             python -m pip install --no-cache-dir -q ray==$ray_version
-
-            # Verify Ray version
             python -c "import ray; print(f'Ray version: {ray.__version__}')"
             python -c "from packaging.version import parse; import ray; assert parse(ray.__version__) == parse('$ray_version'), f'Expected Ray $ray_version, got {ray.__version__}'"
-
-            # Run tests
             python -m pytest pypaimon/tests/ray_data_test.py::RayDataTest -v --tb=short || {
-              echo "Tests failed for Ray $ray_version"
-              exit 1
+              echo "Tests failed for Ray $ray_version"; python -m pip uninstall -y ray; exit 1;
             }
-
-            # Uninstall Ray to avoid conflicts
             python -m pip uninstall -y ray
           done
-
-          # Add other dependency version tests here in the future
-          # Example:
-          # echo "=========================================="
-          # echo "Testing PyArrow version compatibility"
-          # echo "=========================================="
-          # for pyarrow_version in 16.0.0 17.0.0 18.0.0; do
-          #   ...
-          # done
         env:
           PYTHONPATH: ${{ github.workspace }}/paimon-python

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -138,9 +138,9 @@ jobs:
           else
             python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu
-            # Python 3.8: no wheels for ray 2.48+, fastavro 1.11+, zstandard 0.24+, polars 1.32+; use last 3.8-compatible
-            if [[ "${{ matrix.python-version }}" == "3.8" ]]; then RAY_VER=2.10.0; FASTAVRO_VER=1.9.7; ZSTD_VER=0.23.0; POLARS_VER=1.8.2; else RAY_VER=2.48.0; FASTAVRO_VER=1.11.1; ZSTD_VER=0.24.0; POLARS_VER=1.32.0; fi
-            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==$RAY_VER fastavro==$FASTAVRO_VER pyarrow==16.0.0 zstandard==$ZSTD_VER polars==$POLARS_VER duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
+            # Python 3.8: no wheels for ray 2.48+, fastavro 1.11+, zstandard 0.24+, polars 1.32+, pylance 0.39+; use last 3.8-compatible
+            if [[ "${{ matrix.python-version }}" == "3.8" ]]; then RAY_VER=2.10.0; FASTAVRO_VER=1.9.7; ZSTD_VER=0.23.0; POLARS_VER=1.8.2; PYLANCE_VER=0.10.15; else RAY_VER=2.48.0; FASTAVRO_VER=1.11.1; ZSTD_VER=0.24.0; POLARS_VER=1.32.0; PYLANCE_VER=0.39.0; fi
+            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==$RAY_VER fastavro==$FASTAVRO_VER pyarrow==16.0.0 zstandard==$ZSTD_VER polars==$POLARS_VER duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==$PYLANCE_VER cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
           fi
           df -h
       - name: Run lint-python.sh

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -138,9 +138,9 @@ jobs:
           else
             python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu
-            # Python 3.8: no wheels for ray 2.48+ and fastavro 1.11+; use last 3.8-compatible versions
-            if [[ "${{ matrix.python-version }}" == "3.8" ]]; then RAY_VER=2.10.0; FASTAVRO_VER=1.9.7; else RAY_VER=2.48.0; FASTAVRO_VER=1.11.1; fi
-            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==$RAY_VER fastavro==$FASTAVRO_VER pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
+            # Python 3.8: no wheels for ray 2.48+, fastavro 1.11+, zstandard 0.24+; use last 3.8-compatible
+            if [[ "${{ matrix.python-version }}" == "3.8" ]]; then RAY_VER=2.10.0; FASTAVRO_VER=1.9.7; ZSTD_VER=0.23.0; else RAY_VER=2.48.0; FASTAVRO_VER=1.11.1; ZSTD_VER=0.24.0; fi
+            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==$RAY_VER fastavro==$FASTAVRO_VER pyarrow==16.0.0 zstandard==$ZSTD_VER polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
           fi
           df -h
       - name: Run lint-python.sh

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -31,7 +31,6 @@ on:
       - '.github/workflows/paimon-python-checks.yml'
 
 env:
-  PYTHON_VERSIONS: "['3.6.15', '3.10']"
   JDK_VERSION: 8
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
 
@@ -52,8 +51,9 @@ jobs:
     needs: build_native
     container: "python:${{ matrix.python-version }}-slim"
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ '3.6.15', '3.10' ]
+        python-version: [ '3.6.15', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
       - name: Checkout code
@@ -131,6 +131,10 @@ jobs:
             python -m pip install --upgrade pip==21.3.1
             python --version
             python -m pip install --no-cache-dir pyroaring readerwriterlock==1.0.9 'fsspec==2021.10.1' 'cachetools==4.2.4' 'ossfs==2021.8.0' pyarrow==6.0.1 pandas==1.1.5 'polars==0.9.12' 'fastavro==1.4.7' zstandard==0.19.0 dataclasses==0.8.0 flake8 pytest py4j==0.10.9.9 requests parameterized==0.8.1 faiss-cpu==1.7.2 2>&1 >/dev/null
+          elif [[ "${{ matrix.python-version }}" == "3.12" ]] || [[ "${{ matrix.python-version }}" == "3.13" ]]; then
+            python -m pip install --upgrade pip
+            pip install torch --index-url https://download.pytorch.org/whl/cpu
+            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.48.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 'faiss-cpu>=1.10,<2'
           else
             python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu
@@ -261,38 +265,3 @@ jobs:
           # done
         env:
           PYTHONPATH: ${{ github.workspace }}/paimon-python
-
-  # Verify dev/requirements.txt can be installed on multiple Python versions.
-  # Catches version constraints that have no wheel for a given Python (e.g. faiss-cpu 1.7.4 on 3.12).
-  # Runs without Java/native build so we can cheaply test many versions.
-  verify-requirements-txt:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Verify dev/requirements.txt on Python ${{ matrix.python-version }}
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          cd paimon-python
-          # Resolve and install to a temp dir; same logic as former lint-python step
-          TEMP_DIR=$(mktemp -d)
-          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || {
-            echo "ERROR: dev/requirements.txt failed on Python ${{ matrix.python-version }}."
-            echo "Check that every dependency has a wheel or sdist for this Python version."
-            rm -rf "$TEMP_DIR"
-            exit 1
-          }
-          rm -rf "$TEMP_DIR"
-          echo "✓ dev/requirements.txt OK on Python ${{ matrix.python-version }}"

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -190,17 +190,6 @@ jobs:
             build-essential git curl cmake \
             && sudo rm -rf /var/lib/apt/lists/*
 
-      - name: Verify dev/requirements.txt on Python 3.6
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.6'
-      - name: Resolve requirements (3.6)
-        run: |
-          cd paimon-python && python -m pip install --upgrade pip
-          TEMP_DIR=$(mktemp -d)
-          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || { rm -rf "$TEMP_DIR"; exit 1; }
-          rm -rf "$TEMP_DIR" && echo "✓ dev/requirements.txt OK on Python 3.6"
-
       - name: Verify dev/requirements.txt on Python 3.8
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -46,14 +46,40 @@ jobs:
       platform: linux-amd64
       jdk-version: '8'
 
-  lint-python:
+  check-requirements:
     runs-on: ubuntu-latest
-    needs: build_native
-    container: "python:${{ matrix.python-version }}-slim"
     strategy:
       fail-fast: false
       matrix:
         python-version: [ '3.6.15', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
+    container: "python:${{ matrix.python-version }}-slim"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Verify Python version
+        run: python --version
+      - name: Install build deps for source-built packages
+        run: |
+          apt-get update && apt-get install -y --no-install-recommends cmake build-essential \
+            && rm -rf /var/lib/apt/lists/*
+      - name: Verify dev/requirements.txt can be resolved
+        shell: bash
+        run: |
+          cd paimon-python
+          python -m pip install --upgrade pip
+          TEMP_DIR=$(mktemp -d)
+          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || {
+            echo "ERROR: Failed to resolve dependencies from dev/requirements.txt"
+            rm -rf "$TEMP_DIR"
+            exit 1
+          }
+          rm -rf "$TEMP_DIR"
+          echo "✓ dev/requirements.txt can be resolved on Python ${{ matrix.python-version }}"
+
+  lint-python:
+    runs-on: ubuntu-latest
+    needs: build_native
+    container: "python:3.10-slim"
 
     steps:
       - name: Checkout code
@@ -88,20 +114,6 @@ jobs:
       - name: Verify Python version
         run: python --version
 
-      - name: Verify requirements.txt dependencies can be installed
-        shell: bash
-        run: |
-          cd paimon-python
-          python -m pip install --upgrade pip
-          TEMP_DIR=$(mktemp -d)
-          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || {
-            echo "ERROR: Failed to resolve dependencies from dev/requirements.txt"
-            rm -rf "$TEMP_DIR"
-            exit 1
-          }
-          rm -rf "$TEMP_DIR"
-          echo "✓ dev/requirements.txt can be resolved on this Python"
-
       - name: Download native library artifact
         uses: actions/download-artifact@v7
         with:
@@ -127,21 +139,9 @@ jobs:
         shell: bash
         run: |
           df -h
-          if [[ "${{ matrix.python-version }}" == "3.6.15" ]]; then
-            python -m pip install --upgrade pip==21.3.1
-            python --version
-            python -m pip install --no-cache-dir pyroaring readerwriterlock==1.0.9 'fsspec==2021.10.1' 'cachetools==4.2.4' 'ossfs==2021.8.0' pyarrow==6.0.1 pandas==1.1.5 'polars==0.9.12' 'fastavro==1.4.7' zstandard==0.19.0 dataclasses==0.8.0 flake8 pytest py4j==0.10.9.9 requests parameterized==0.8.1 faiss-cpu==1.7.2 2>&1 >/dev/null
-          elif [[ "${{ matrix.python-version }}" == "3.12" ]] || [[ "${{ matrix.python-version }}" == "3.13" ]]; then
-            python -m pip install --upgrade pip
-            pip install torch --index-url https://download.pytorch.org/whl/cpu
-            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.48.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 'numpy>=1.26' 'pandas>=2.1' pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 'faiss-cpu>=1.10,<2'
-          else
-            python -m pip install --upgrade pip
-            pip install torch --index-url https://download.pytorch.org/whl/cpu
-            # Python 3.8: pin versions compatible with each other (pylance 0.10.15 needs pyarrow<15.0.1)
-            if [[ "${{ matrix.python-version }}" == "3.8" ]]; then RAY_VER=2.10.0; FASTAVRO_VER=1.9.7; ZSTD_VER=0.23.0; POLARS_VER=1.8.2; PYLANCE_VER=0.10.15; PYARROW_VER=15.0.0; else RAY_VER=2.48.0; FASTAVRO_VER=1.11.1; ZSTD_VER=0.24.0; POLARS_VER=1.32.0; PYLANCE_VER=0.39.0; PYARROW_VER=16.0.0; fi
-            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==$RAY_VER fastavro==$FASTAVRO_VER pyarrow==$PYARROW_VER zstandard==$ZSTD_VER polars==$POLARS_VER duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==$PYLANCE_VER cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
-          fi
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.48.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
           df -h
       - name: Run lint-python.sh
         shell: bash

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -138,9 +138,9 @@ jobs:
           else
             python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu
-            # Python 3.8: no wheels for ray 2.48+, fastavro 1.11+, zstandard 0.24+, polars 1.32+, pylance 0.39+; use last 3.8-compatible
-            if [[ "${{ matrix.python-version }}" == "3.8" ]]; then RAY_VER=2.10.0; FASTAVRO_VER=1.9.7; ZSTD_VER=0.23.0; POLARS_VER=1.8.2; PYLANCE_VER=0.10.15; else RAY_VER=2.48.0; FASTAVRO_VER=1.11.1; ZSTD_VER=0.24.0; POLARS_VER=1.32.0; PYLANCE_VER=0.39.0; fi
-            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==$RAY_VER fastavro==$FASTAVRO_VER pyarrow==16.0.0 zstandard==$ZSTD_VER polars==$POLARS_VER duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==$PYLANCE_VER cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
+            # Python 3.8: pin versions compatible with each other (pylance 0.10.15 needs pyarrow<15.0.1)
+            if [[ "${{ matrix.python-version }}" == "3.8" ]]; then RAY_VER=2.10.0; FASTAVRO_VER=1.9.7; ZSTD_VER=0.23.0; POLARS_VER=1.8.2; PYLANCE_VER=0.10.15; PYARROW_VER=15.0.0; else RAY_VER=2.48.0; FASTAVRO_VER=1.11.1; ZSTD_VER=0.24.0; POLARS_VER=1.32.0; PYLANCE_VER=0.39.0; PYARROW_VER=16.0.0; fi
+            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==$RAY_VER fastavro==$FASTAVRO_VER pyarrow==$PYARROW_VER zstandard==$ZSTD_VER polars==$POLARS_VER duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==$PYLANCE_VER cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
           fi
           df -h
       - name: Run lint-python.sh

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -138,9 +138,9 @@ jobs:
           else
             python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu
-            # Python 3.8: no wheels for ray 2.48+, fastavro 1.11+, zstandard 0.24+; use last 3.8-compatible
-            if [[ "${{ matrix.python-version }}" == "3.8" ]]; then RAY_VER=2.10.0; FASTAVRO_VER=1.9.7; ZSTD_VER=0.23.0; else RAY_VER=2.48.0; FASTAVRO_VER=1.11.1; ZSTD_VER=0.24.0; fi
-            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==$RAY_VER fastavro==$FASTAVRO_VER pyarrow==16.0.0 zstandard==$ZSTD_VER polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
+            # Python 3.8: no wheels for ray 2.48+, fastavro 1.11+, zstandard 0.24+, polars 1.32+; use last 3.8-compatible
+            if [[ "${{ matrix.python-version }}" == "3.8" ]]; then RAY_VER=2.10.0; FASTAVRO_VER=1.9.7; ZSTD_VER=0.23.0; POLARS_VER=1.8.2; else RAY_VER=2.48.0; FASTAVRO_VER=1.11.1; ZSTD_VER=0.24.0; POLARS_VER=1.32.0; fi
+            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==$RAY_VER fastavro==$FASTAVRO_VER pyarrow==16.0.0 zstandard==$ZSTD_VER polars==$POLARS_VER duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
           fi
           df -h
       - name: Run lint-python.sh

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -138,9 +138,9 @@ jobs:
           else
             python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu
-            # Ray 2.48+ has no wheel for Python 3.8; use 2.10.0 for 3.8 only
-            if [[ "${{ matrix.python-version }}" == "3.8" ]]; then RAY_VER=2.10.0; else RAY_VER=2.48.0; fi
-            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==$RAY_VER fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
+            # Python 3.8: no wheels for ray 2.48+ and fastavro 1.11+; use last 3.8-compatible versions
+            if [[ "${{ matrix.python-version }}" == "3.8" ]]; then RAY_VER=2.10.0; FASTAVRO_VER=1.9.7; else RAY_VER=2.48.0; FASTAVRO_VER=1.11.1; fi
+            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==$RAY_VER fastavro==$FASTAVRO_VER pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
           fi
           df -h
       - name: Run lint-python.sh

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -134,7 +134,7 @@ jobs:
           elif [[ "${{ matrix.python-version }}" == "3.12" ]] || [[ "${{ matrix.python-version }}" == "3.13" ]]; then
             python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu
-            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.48.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 'faiss-cpu>=1.10,<2'
+            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.48.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 'numpy>=1.26' 'pandas>=2.1' pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 'faiss-cpu>=1.10,<2'
           else
             python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -46,40 +46,15 @@ jobs:
       platform: linux-amd64
       jdk-version: '8'
 
-  check-requirements:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ '3.6.15', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
-    container: "python:${{ matrix.python-version }}-slim"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Verify Python version
-        run: python --version
-      - name: Install build deps for source-built packages
-        run: |
-          apt-get update && apt-get install -y --no-install-recommends cmake build-essential \
-            && rm -rf /var/lib/apt/lists/*
-      - name: Verify dev/requirements.txt can be resolved
-        shell: bash
-        run: |
-          cd paimon-python
-          python -m pip install --upgrade pip
-          TEMP_DIR=$(mktemp -d)
-          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || {
-            echo "ERROR: Failed to resolve dependencies from dev/requirements.txt"
-            rm -rf "$TEMP_DIR"
-            exit 1
-          }
-          rm -rf "$TEMP_DIR"
-          echo "✓ dev/requirements.txt can be resolved on Python ${{ matrix.python-version }}"
-
+  # Lint + test on 3.6 and 3.10 only (not every Python version).
   lint-python:
     runs-on: ubuntu-latest
     needs: build_native
-    container: "python:3.10-slim"
+    container: "python:${{ matrix.python-version }}-slim"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.6.15', '3.10' ]
 
     steps:
       - name: Checkout code
@@ -114,6 +89,20 @@ jobs:
       - name: Verify Python version
         run: python --version
 
+      - name: Verify requirements.txt dependencies can be installed
+        shell: bash
+        run: |
+          cd paimon-python
+          python -m pip install --upgrade pip
+          TEMP_DIR=$(mktemp -d)
+          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || {
+            echo "ERROR: Failed to resolve dependencies from dev/requirements.txt"
+            rm -rf "$TEMP_DIR"
+            exit 1
+          }
+          rm -rf "$TEMP_DIR"
+          echo "✓ dev/requirements.txt can be resolved on this Python"
+
       - name: Download native library artifact
         uses: actions/download-artifact@v7
         with:
@@ -139,9 +128,15 @@ jobs:
         shell: bash
         run: |
           df -h
-          python -m pip install --upgrade pip
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
-          python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.48.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
+          if [[ "${{ matrix.python-version }}" == "3.6.15" ]]; then
+            python -m pip install --upgrade pip==21.3.1
+            python --version
+            python -m pip install --no-cache-dir pyroaring readerwriterlock==1.0.9 'fsspec==2021.10.1' 'cachetools==4.2.4' 'ossfs==2021.8.0' pyarrow==6.0.1 pandas==1.1.5 'polars==0.9.12' 'fastavro==1.4.7' zstandard==0.19.0 dataclasses==0.8.0 flake8 pytest py4j==0.10.9.9 requests parameterized==0.8.1 faiss-cpu==1.7.2 2>&1 >/dev/null
+          else
+            python -m pip install --upgrade pip
+            pip install torch --index-url https://download.pytorch.org/whl/cpu
+            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.48.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
+          fi
           df -h
       - name: Run lint-python.sh
         shell: bash
@@ -182,9 +177,14 @@ jobs:
           chmod +x paimon-python/dev/lint-python.sh
           ./paimon-python/dev/lint-python.sh -i pytest_torch
 
+  # Per-Python requirement check (all versions) + Ray version test (3.10 only).
   requirement_version_compatible_test:
     runs-on: ubuntu-latest
-    container: "python:3.10-slim"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.6.15', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
+    container: "python:${{ matrix.python-version }}-slim"
 
     steps:
       - name: Checkout code
@@ -193,16 +193,34 @@ jobs:
       - name: Install system dependencies
         shell: bash
         run: |
-          apt-get update && apt-get install -y \
-            build-essential \
-            git \
-            curl \
+          apt-get update && apt-get install -y --no-install-recommends \
+            build-essential git curl \
+            && rm -rf /var/lib/apt/lists/*
+      - name: Install build deps for source-built packages (e.g. PyArrow on 3.12/3.13)
+        if: matrix.python-version == '3.12' || matrix.python-version == '3.13'
+        run: |
+          apt-get update && apt-get install -y --no-install-recommends cmake \
             && rm -rf /var/lib/apt/lists/*
 
       - name: Verify Python version
         run: python --version
 
+      - name: Verify dev/requirements.txt can be resolved
+        shell: bash
+        run: |
+          cd paimon-python
+          python -m pip install --upgrade pip
+          TEMP_DIR=$(mktemp -d)
+          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || {
+            echo "ERROR: Failed to resolve dependencies from dev/requirements.txt"
+            rm -rf "$TEMP_DIR"
+            exit 1
+          }
+          rm -rf "$TEMP_DIR"
+          echo "✓ dev/requirements.txt can be resolved on Python ${{ matrix.python-version }}"
+
       - name: Install base Python dependencies
+        if: matrix.python-version == '3.10'
         shell: bash
         run: |
           python -m pip install --upgrade pip
@@ -226,9 +244,9 @@ jobs:
             requests \
             parameterized==0.9.0 \
             packaging
-            
 
       - name: Test requirement version compatibility
+        if: matrix.python-version == '3.10'
         shell: bash
         run: |
           cd paimon-python

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -93,18 +93,14 @@ jobs:
         run: |
           cd paimon-python
           python -m pip install --upgrade pip
-          # Use --target to install to a temporary directory to verify dependencies
-          # This works for both Python 3.6 (pip 21.3.1) and Python 3.10+ (pip 22.2+)
-          # since --target is supported in all pip versions
           TEMP_DIR=$(mktemp -d)
           python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || {
             echo "ERROR: Failed to resolve dependencies from dev/requirements.txt"
-            echo "This indicates a version conflict or unavailable package version"
             rm -rf "$TEMP_DIR"
             exit 1
           }
           rm -rf "$TEMP_DIR"
-          echo "✓ All dependencies in dev/requirements.txt can be resolved"
+          echo "✓ dev/requirements.txt can be resolved on this Python"
 
       - name: Download native library artifact
         uses: actions/download-artifact@v7
@@ -265,3 +261,38 @@ jobs:
           # done
         env:
           PYTHONPATH: ${{ github.workspace }}/paimon-python
+
+  # Verify dev/requirements.txt can be installed on multiple Python versions.
+  # Catches version constraints that have no wheel for a given Python (e.g. faiss-cpu 1.7.4 on 3.12).
+  # Runs without Java/native build so we can cheaply test many versions.
+  verify-requirements-txt:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Verify dev/requirements.txt on Python ${{ matrix.python-version }}
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          cd paimon-python
+          # Resolve and install to a temp dir; same logic as former lint-python step
+          TEMP_DIR=$(mktemp -d)
+          python -m pip install -r dev/requirements.txt --target "$TEMP_DIR" || {
+            echo "ERROR: dev/requirements.txt failed on Python ${{ matrix.python-version }}."
+            echo "Check that every dependency has a wheel or sdist for this Python version."
+            rm -rf "$TEMP_DIR"
+            exit 1
+          }
+          rm -rf "$TEMP_DIR"
+          echo "✓ dev/requirements.txt OK on Python ${{ matrix.python-version }}"

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -138,7 +138,9 @@ jobs:
           else
             python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu
-            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.48.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
+            # Ray 2.48+ has no wheel for Python 3.8; use 2.10.0 for 3.8 only
+            if [[ "${{ matrix.python-version }}" == "3.8" ]]; then RAY_VER=2.10.0; else RAY_VER=2.48.0; fi
+            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==$RAY_VER fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 faiss-cpu==1.7.4
           fi
           df -h
       - name: Run lint-python.sh

--- a/paimon-python/dev/requirements-dev.txt
+++ b/paimon-python/dev/requirements-dev.txt
@@ -21,6 +21,7 @@
 duckdb==1.3.2
 flake8==4.0.1
 pytest~=7.0
-ray==2.48.0
+# Ray: 2.48+ has no wheel for Python 3.8; use 2.10.0 on 3.8, 2.48.0 on 3.9+
+ray>=2.10.0
 requests
 parameterized

--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -38,5 +38,3 @@ pyroaring
 readerwriterlock>=1,<2
 zstandard>=0.19,<1
 cramjam>=1.3.0,<3; python_version>="3.7"
-faiss-cpu==1.7.2; python_version >= "3.6" and python_version < "3.7"
-faiss-cpu==1.7.4; python_version >= "3.7"

--- a/paimon-python/pypaimon/write/ray_datasink.py
+++ b/paimon-python/pypaimon/write/ray_datasink.py
@@ -40,9 +40,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Python 3.8 / Ray 2.10: Datasink is not subscriptable at runtime
+try:
+    _DatasinkBase = Datasink[List["CommitMessage"]]
+except TypeError:
+    _DatasinkBase = Datasink
+
 
 @DeveloperAPI
-class PaimonDatasink(Datasink[List["CommitMessage"]]):
+class PaimonDatasink(_DatasinkBase):
     def __init__(
         self,
         table: "Table",

--- a/paimon-python/setup.py
+++ b/paimon-python/setup.py
@@ -57,9 +57,18 @@ setup(
         'torch': [
             'torch',
         ],
+        # faiss-cpu: optional for vector ANN index. 1.7.x has no wheel for 3.12+; 3.12+ use 1.10+.
+        'faiss': [
+            'faiss-cpu==1.7.2; python_version >= "3.6" and python_version < "3.7"',
+            'faiss-cpu==1.7.4; python_version >= "3.7" and python_version < "3.12"',
+            'faiss-cpu>=1.10,<2; python_version >= "3.12"',
+        ],
         'all': [
             'ray>=2.10,<3; python_version>="3.7"',
             'torch',
+            'faiss-cpu==1.7.2; python_version >= "3.6" and python_version < "3.7"',
+            'faiss-cpu==1.7.4; python_version >= "3.7" and python_version < "3.12"',
+            'faiss-cpu>=1.10,<2; python_version >= "3.12"',
         ],
     },
     description="Apache Paimon Python API",


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Summary**
> 
> - Make `faiss-cpu` optional via `setup.py` extras (`faiss`, `all`) with version guards, including `>=1.10` for Python 3.12+; remove `faiss-cpu` pins from `dev/requirements.txt`.
> - Relax Ray test dependency to `ray>=2.10.0` and document Python 3.8 wheel constraint in `requirements-dev.txt`.
> - Update `PaimonDatasink` for Ray API compatibility: handle non-subscriptable `Datasink` on Python 3.8/Ray 2.10, accept `Any` for `on_write_complete`, and support both `WriteResult.write_returns` and list returns.
> - CI workflow: disable matrix fail-fast; add sequential `dev/requirements.txt` resolution on Python 3.8–3.13; run Ray compatibility tests on 3.10 for versions 2.44.0/2.48.0/2.53.0; minor install/logging tweaks (use sudo, add cmake).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b6001c6fde6c347aff49935319eeb32810227fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->