### PR TITLE
Import multi thread into pytorch

### DIFF
--- a/docs/content/pypaimon/pytorch.md
+++ b/docs/content/pypaimon/pytorch.md
@@ -37,7 +37,7 @@ You can read all the data into a `torch.utils.data.Dataset` or `torch.utils.data
 from torch.utils.data import DataLoader
 
 table_read = read_builder.new_read()
-dataset = table_read.to_torch(splits, streaming=True)
+dataset = table_read.to_torch(splits, streaming=True, prefetch_concurrency=2)
 dataloader = DataLoader(
     dataset,
     batch_size=2,
@@ -58,3 +58,5 @@ for batch_idx, batch_data in enumerate(dataloader):
 
 When the `streaming` parameter is true, it will iteratively read;
 when it is false, it will read the full amount of data into memory.
+
+**`prefetch_concurrency`** (default: 1): When streaming is true, number of threads used for parallel prefetch within each DataLoader worker. Set to a value greater than 1 to partition splits across threads and increase read throughput. Has no effect when streaming is false.

--- a/paimon-python/pypaimon/read/datasource/torch_dataset.py
+++ b/paimon-python/pypaimon/read/datasource/torch_dataset.py
@@ -117,7 +117,13 @@ class TorchIterDataset(IterableDataset):
 
     def __iter__(self):
         """
-        Iterate over the dataset, converting each row to a dict keyed by field names.
+        Iterate over the dataset, converting each OffsetRow to a dictionary.
+
+        Supports multi-worker data loading by partitioning splits across workers.
+        When num_workers > 0 in DataLoader, each worker will process a subset of splits.
+
+        Yields:
+            row data of dict type, where keys are column names.
         """
         worker_info = torch.utils.data.get_worker_info()
         if worker_info is not None:

--- a/paimon-python/pypaimon/read/datasource/torch_dataset.py
+++ b/paimon-python/pypaimon/read/datasource/torch_dataset.py
@@ -221,4 +221,3 @@ class TorchIterDataset(IterableDataset):
             stop.set()
             for t in threads:
                 t.join(timeout=self._PREFETCH_JOIN_TIMEOUT_SEC)
-

--- a/paimon-python/pypaimon/read/datasource/torch_dataset.py
+++ b/paimon-python/pypaimon/read/datasource/torch_dataset.py
@@ -18,6 +18,9 @@
 """
 Module to read a Paimon table into PyTorch Dataset.
 """
+import math
+import queue
+import threading
 from typing import List
 
 import torch
@@ -83,60 +86,101 @@ class TorchIterDataset(IterableDataset):
     rather than loading everything into memory upfront.
     """
 
-    def __init__(self, table_read: TableRead, splits: List[Split]):
+    _SENTINEL = 0
+    _ROW = 1
+    _ERR = 2
+    _PREFETCH_QUEUE_MAXSIZE = 512
+
+    def __init__(self, table_read: TableRead, splits: List[Split], prefetch_concurrency: int = 1):
         """
         Initialize TorchIterDataset.
 
         Args:
             table_read: TableRead instance for reading data
             splits: List of splits to read
+            prefetch_concurrency: Number of threads to use for parallel OSS reads within
+                this worker (default 1). When > 1, splits are partitioned across
+                threads to increase read throughput.
         """
         self.table_read = table_read
         self.splits = splits
+        self.prefetch_concurrency = max(1, int(prefetch_concurrency))
         # Get field names from read_type
         self.field_names = [field.name for field in table_read.read_type]
 
+    def _row_to_dict(self, offset_row) -> dict:
+        row_dict = {}
+        for i, field_name in enumerate(self.field_names):
+            value = offset_row.get_field(i)
+            row_dict[field_name] = value
+        return row_dict
+
     def __iter__(self):
         """
-        Iterate over the dataset, converting each OffsetRow to a dictionary.
-
-        Supports multi-worker data loading by partitioning splits across workers.
-        When num_workers > 0 in DataLoader, each worker will process a subset of splits.
-
-        Yields:
-            row data of dict type, where keys are column names
+        Iterate over the dataset, converting each row to a dict keyed by field names.
         """
         worker_info = torch.utils.data.get_worker_info()
-
-        if worker_info is None:
-            # Single-process data loading, iterate over all splits
-            splits_to_process = self.splits
+        if worker_info is not None:
+            per_worker = int(math.ceil(len(self.splits) / float(worker_info.num_workers)))
+            start = worker_info.id * per_worker
+            end = min(start + per_worker, len(self.splits))
+            splits_for_worker = self.splits[start:end]
         else:
-            # Multi-process data loading, partition splits across workers
-            worker_id = worker_info.id
-            num_workers = worker_info.num_workers
+            splits_for_worker = self.splits
 
-            # Calculate start and end indices for this worker
-            # Distribute splits evenly by slicing
-            total_splits = len(self.splits)
-            splits_per_worker = total_splits // num_workers
-            remainder = total_splits % num_workers
+        if self.prefetch_concurrency <= 1:
+            iterator = self.table_read.to_iterator(splits_for_worker)
+            for offset_row in iterator:
+                yield self._row_to_dict(offset_row)
+            return
 
-            # Workers with id < remainder get one extra split
-            if worker_id < remainder:
-                start_idx = worker_id * (splits_per_worker + 1)
-                end_idx = start_idx + splits_per_worker + 1
-            else:
-                start_idx = worker_id * splits_per_worker + remainder
-                end_idx = start_idx + splits_per_worker
+        n = min(self.prefetch_concurrency, len(splits_for_worker))
+        split_groups = [splits_for_worker[i::n] for i in range(n)]
+        if n == 0:
+            return
 
-            splits_to_process = self.splits[start_idx:end_idx]
+        q = queue.Queue(maxsize=self._PREFETCH_QUEUE_MAXSIZE)
+        stop_event = threading.Event()
 
-        worker_iterator = self.table_read.to_iterator(splits_to_process)
+        def producer(thread_id: int, split_group: List):
+            try:
+                for offset_row in self.table_read.to_iterator(split_group):
+                    if stop_event.is_set():
+                        break
+                    try:
+                        q.put((self._ROW, self._row_to_dict(offset_row)), timeout=30.0)
+                    except queue.Full:
+                        if stop_event.is_set():
+                            break
+                        q.put((self._ROW, self._row_to_dict(offset_row)))
+                q.put((self._SENTINEL, thread_id))
+            except Exception as e:
+                q.put((self._ERR, e))
 
-        for offset_row in worker_iterator:
-            row_dict = {}
-            for i, field_name in enumerate(self.field_names):
-                value = offset_row.get_field(i)
-                row_dict[field_name] = value
-            yield row_dict
+        threads = [
+            threading.Thread(target=producer, args=(i, split_groups[i]), daemon=True)
+            for i in range(n)
+        ]
+        for t in threads:
+            t.start()
+
+        try:
+            sentinel_count = 0
+            while sentinel_count < n:
+                try:
+                    tag, payload = q.get(timeout=300.0)
+                except queue.Empty:
+                    if stop_event.is_set():
+                        break
+                    continue
+                if tag == self._SENTINEL:
+                    sentinel_count += 1
+                elif tag == self._ERR:
+                    raise payload
+                elif tag == self._ROW:
+                    yield payload
+        finally:
+            stop_event.set()
+            for t in threads:
+                t.join(timeout=5.0)
+

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -204,7 +204,7 @@ class TableRead:
                 You needn't manually set this in most cases.
             **read_args: Additional kwargs passed to the datasource.
                 For example, ``per_task_row_limit`` (Ray 2.52.0+).
-
+        
         See `Ray Data API <https://docs.ray.io/en/latest/data/api/doc/ray.data.read_datasource.html>`_
         for details.
         """

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -204,7 +204,7 @@ class TableRead:
                 You needn't manually set this in most cases.
             **read_args: Additional kwargs passed to the datasource.
                 For example, ``per_task_row_limit`` (Ray 2.52.0+).
-        
+
         See `Ray Data API <https://docs.ray.io/en/latest/data/api/doc/ray.data.read_datasource.html>`_
         for details.
         """
@@ -231,11 +231,11 @@ class TableRead:
             **read_args
         )
 
-    def to_torch(self, splits: List[Split], streaming: bool = False) -> "torch.utils.data.Dataset":
+    def to_torch(self, splits: List[Split], streaming: bool = False, prefetch_concurrency: int = 1) -> "torch.utils.data.Dataset":
         """Wrap Paimon table data to PyTorch Dataset."""
         if streaming:
             from pypaimon.read.datasource.torch_dataset import TorchIterDataset
-            dataset = TorchIterDataset(self, splits)
+            dataset = TorchIterDataset(self, splits, prefetch_concurrency)
             return dataset
         else:
             from pypaimon.read.datasource.torch_dataset import TorchDataset

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -231,7 +231,12 @@ class TableRead:
             **read_args
         )
 
-    def to_torch(self, splits: List[Split], streaming: bool = False, prefetch_concurrency: int = 1) -> "torch.utils.data.Dataset":
+    def to_torch(
+        self,
+        splits: List[Split],
+        streaming: bool = False,
+        prefetch_concurrency: int = 1,
+    ) -> "torch.utils.data.Dataset":
         """Wrap Paimon table data to PyTorch Dataset."""
         if streaming:
             from pypaimon.read.datasource.torch_dataset import TorchIterDataset


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new concurrency/queueing behavior in the streaming iterator path, which can impact ordering, performance, and failure/timeout handling under load; non-streaming reads are unchanged.
> 
> **Overview**
> Adds a new `prefetch_concurrency` option to `TableRead.to_torch(..., streaming=True)` / `TorchIterDataset` to enable **multi-threaded prefetch** within each PyTorch `DataLoader` worker by partitioning splits across threads and merging rows via a bounded queue.
> 
> Updates the PyTorch docs to describe and demonstrate the new parameter, and adds a unit test covering streaming reads with `prefetch_concurrency > 1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f7b3180e945b36cdb0ad77217c44606a4b8adad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->