### PR TITLE
[python/doc] add alterTable in pypaimon doc

### DIFF
--- a/docs/content/pypaimon/python-api.md
+++ b/docs/content/pypaimon/python-api.md
@@ -153,6 +153,34 @@ catalog.create_table(
 table = catalog.get_table('database_name.table_name')
 ```
 
+## Alter Table
+
+Alter a table with a list of schema changes. Use `SchemaChange` from `pypaimon.schema.schema_change` and types from `pypaimon.schema.data_types` (e.g. `AtomicType`).
+
+```python
+from pypaimon.schema.schema_change import SchemaChange
+from pypaimon.schema.data_types import AtomicType
+
+# Add column(s)
+catalog.alter_table(
+    'database_name.table_name',
+    [
+        SchemaChange.add_column('new_col', AtomicType('STRING')),
+        SchemaChange.add_column('score', AtomicType('DOUBLE'), comment='optional'),
+    ],
+    ignore_if_not_exists=False
+)
+
+# Drop column
+catalog.alter_table(
+    'database_name.table_name',
+    [SchemaChange.drop_column('col_name')],
+    ignore_if_not_exists=False
+)
+```
+
+Other supported changes: `SchemaChange.rename_column`, `update_column_type`, `update_column_comment`, `set_option`, `remove_option`, `update_comment`.
+
 ## Batch Write
 
 Paimon table write is Two-Phase Commit, you can write many times, but once committed, no more data can be written.


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces documentation for altering tables in the Python API.
> 
> - Adds an **Alter Table** section to `docs/content/pypaimon/python-api.md` with examples using `catalog.alter_table` and `SchemaChange` (e.g., `add_column`, `drop_column`) and `AtomicType` types
> - Notes other supported changes: `rename_column`, `update_column_type`, `update_column_comment`, `set_option`, `remove_option`, `update_comment`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40f80d2357a54ecc6879debeee958b10f1d6c8d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->