### PR TITLE
[python/hotfix] correct with_slice row count for split with multi files

### DIFF
--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -344,21 +344,20 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                 blob_first_row_id = file.first_row_id if file.first_row_id is not None else 0
                 data_file = None
                 data_file_range = None
+                data_file_first_row_id = None
                 for df, fr in data_file_infos:
                     df_first = df.first_row_id if df.first_row_id is not None else 0
                     if df_first <= blob_first_row_id < df_first + df.row_count:
                         data_file = df
                         data_file_range = fr
+                        data_file_first_row_id = df_first
                         break
-                if data_file is None or data_file_range is None:
+                if data_file is None or data_file_range is None or data_file_first_row_id is None:
                     continue
                 if data_file_range == (-1, -1):
                     # Data file is completely outside shard, blob files should be skipped
                     shard_file_idx_map[file.file_name] = (-1, -1)
                     continue
-                data_file_first_row_id = (
-                    data_file.first_row_id if data_file.first_row_id is not None else 0
-                )
                 # Blob's position relative to data file start
                 blob_rel_start = blob_first_row_id - data_file_first_row_id
                 blob_rel_end = blob_rel_start + file.row_count

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -329,7 +329,8 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                 plan_start_pos, plan_end_pos, file_begin_pos, file.row_count
             )
             data_file_infos.append((file, data_file_range))
-            shard_file_idx_map[file.file_name] = data_file_range
+            if data_file_range is not None:
+                shard_file_idx_map[file.file_name] = data_file_range
 
         if not data_file_infos:
             # No data file, skip this split
@@ -343,17 +344,15 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
             if not self._is_blob_file(file.file_name):
                 continue
             blob_first_row_id = file.first_row_id if file.first_row_id is not None else 0
-            data_file = None
             data_file_range = None
             data_file_first_row_id = None
             for df, fr in data_file_infos:
                 df_first = df.first_row_id if df.first_row_id is not None else 0
                 if df_first <= blob_first_row_id < df_first + df.row_count:
-                    data_file = df
                     data_file_range = fr
                     data_file_first_row_id = df_first
                     break
-            if data_file is None or data_file_range is None or data_file_first_row_id is None:
+            if data_file_range is None or data_file_first_row_id is None:
                 continue
             if data_file_range == (-1, -1):
                 shard_file_idx_map[file.file_name] = (-1, -1)

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -316,7 +316,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         For blob files (which may be rolled), the range is calculated based on each file's first_row_id.
         """
         shard_file_idx_map = {}
-
+        
         # Find the first non-blob file to determine the row range for this split
         current_pos = file_end_pos
         data_file_infos = []

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -352,7 +352,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                     data_file_range = fr
                     data_file_first_row_id = df_first
                     break
-            if data_file_range is None or data_file_first_row_id is None:
+            if data_file_range is None:
                 continue
             if data_file_range == (-1, -1):
                 shard_file_idx_map[file.file_name] = (-1, -1)


### PR DESCRIPTION
… 

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes row-range slicing/index mapping during scans for data-evolution tables; incorrect calculations could cause missing/extra rows in sliced reads, but impact is limited to read planning (no auth/security).
> 
> **Overview**
> Fixes `DataEvolutionSplitGenerator._compute_split_file_idx_map` so `with_slice`/shard range slicing works when a split contains *multiple* data files. The generator now computes per-data-file ranges across the split (tracking cumulative positions) and maps blob files to the correct owning data file range, instead of assuming a single data file drives the whole split.
> 
> Adds a regression test `test_with_slice` that writes multiple batches, applies `with_slice(1, 4)`, and asserts the sliced scan returns the expected 3 rows/IDs (previously returned 2 for multi-data-file splits).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d31860673691290ced636532452681c6dae0c112. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->