### PR TITLE
[python] support format table for rest

### DIFF
--- a/paimon-python/pypaimon/catalog/rest/rest_catalog.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_catalog.py
@@ -45,7 +45,6 @@ from pypaimon.table.file_store_table import FileStoreTable
 from pypaimon.table.format.format_table import FormatTable, Format
 
 
-# Table type value from Java TableType.FORMAT_TABLE
 FORMAT_TABLE_TYPE = "format-table"
 
 

--- a/paimon-python/pypaimon/catalog/rest/rest_catalog.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_catalog.py
@@ -42,6 +42,11 @@ from pypaimon.schema.table_schema import TableSchema
 from pypaimon.snapshot.snapshot import Snapshot
 from pypaimon.snapshot.snapshot_commit import PartitionStatistics
 from pypaimon.table.file_store_table import FileStoreTable
+from pypaimon.table.format.format_table import FormatTable, Format
+
+
+# Table type value from Java TableType.FORMAT_TABLE
+FORMAT_TABLE_TYPE = "format-table"
 
 
 class RESTCatalog(Catalog):
@@ -180,7 +185,7 @@ class RESTCatalog(Catalog):
         except ForbiddenException as e:
             raise DatabaseNoPermissionException(database_name) from e
 
-    def get_table(self, identifier: Union[str, Identifier]) -> FileStoreTable:
+    def get_table(self, identifier: Union[str, Identifier]):
         if not isinstance(identifier, Identifier):
             identifier = Identifier.from_string(identifier)
         return self.load_table(
@@ -263,9 +268,12 @@ class RESTCatalog(Catalog):
                    internal_file_io: Callable[[str], Any],
                    external_file_io: Callable[[str], Any],
                    metadata_loader: Callable[[Identifier], TableMetadata],
-                   ) -> FileStoreTable:
+                   ):
         metadata = metadata_loader(identifier)
         schema = metadata.schema
+        table_type = schema.options.get(CoreOptions.TYPE.key(), "").strip().lower()
+        if table_type == FORMAT_TABLE_TYPE:
+            return self._create_format_table(identifier, metadata, internal_file_io, external_file_io)
         data_file_io = external_file_io if metadata.is_external else internal_file_io
         catalog_env = CatalogEnvironment(
             identifier=identifier,
@@ -280,6 +288,30 @@ class RESTCatalog(Catalog):
                             schema,
                             catalog_env)
         return table
+
+    def _create_format_table(self,
+                             identifier: Identifier,
+                             metadata: TableMetadata,
+                             internal_file_io: Callable[[str], Any],
+                             external_file_io: Callable[[str], Any],
+                             ) -> FormatTable:
+        schema = metadata.schema
+        location = schema.options.get(CoreOptions.PATH.key())
+        if not location:
+            raise ValueError("Format table schema must have path option")
+        data_file_io = external_file_io if metadata.is_external else internal_file_io
+        file_io = data_file_io(location)
+        file_format = schema.options.get(CoreOptions.FILE_FORMAT.key(), "parquet")
+        fmt = Format.parse(file_format)
+        return FormatTable(
+            file_io=file_io,
+            identifier=identifier,
+            table_schema=schema,
+            location=location,
+            format=fmt,
+            options=dict(schema.options),
+            comment=schema.comment,
+        )
 
     @staticmethod
     def create(file_io: FileIO,

--- a/paimon-python/pypaimon/table/format/__init__.py
+++ b/paimon-python/pypaimon/table/format/__init__.py
@@ -22,7 +22,6 @@ from pypaimon.table.format.format_table_read import FormatTableRead
 from pypaimon.table.format.format_batch_write_builder import FormatBatchWriteBuilder
 from pypaimon.table.format.format_table_write import FormatTableWrite
 from pypaimon.table.format.format_table_commit import FormatTableCommit
-from pypaimon.table.format.format_commit_message import FormatTableCommitMessage
 
 __all__ = [
     "FormatDataSplit",

--- a/paimon-python/pypaimon/table/format/__init__.py
+++ b/paimon-python/pypaimon/table/format/__init__.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pypaimon.table.format.format_data_split import FormatDataSplit
+from pypaimon.table.format.format_table import FormatTable, Format
+from pypaimon.table.format.format_read_builder import FormatReadBuilder
+from pypaimon.table.format.format_table_scan import FormatTableScan
+from pypaimon.table.format.format_table_read import FormatTableRead
+from pypaimon.table.format.format_batch_write_builder import FormatBatchWriteBuilder
+from pypaimon.table.format.format_table_write import FormatTableWrite
+from pypaimon.table.format.format_table_commit import FormatTableCommit
+from pypaimon.table.format.format_commit_message import FormatTableCommitMessage
+
+__all__ = [
+    "FormatDataSplit",
+    "FormatTable",
+    "Format",
+    "FormatReadBuilder",
+    "FormatTableScan",
+    "FormatTableRead",
+    "FormatBatchWriteBuilder",
+    "FormatTableWrite",
+    "FormatTableCommit",
+]

--- a/paimon-python/pypaimon/table/format/format_batch_write_builder.py
+++ b/paimon-python/pypaimon/table/format/format_batch_write_builder.py
@@ -48,8 +48,4 @@ class FormatBatchWriteBuilder:
         return FormatTableWrite(self.table, overwrite=self._overwrite)
 
     def new_commit(self) -> FormatTableCommit:
-        return FormatTableCommit(
-            table=self.table,
-            overwrite=self._overwrite,
-            static_partitions=self._static_partition,
-        )
+        return FormatTableCommit(table=self.table)

--- a/paimon-python/pypaimon/table/format/format_batch_write_builder.py
+++ b/paimon-python/pypaimon/table/format/format_batch_write_builder.py
@@ -45,7 +45,11 @@ class FormatBatchWriteBuilder:
                 raise ValueError(f"Unknown static partition column: {key}")
 
     def new_write(self) -> FormatTableWrite:
-        return FormatTableWrite(self.table, overwrite=self._overwrite)
+        return FormatTableWrite(
+            self.table,
+            overwrite=self._overwrite,
+            static_partitions=self._static_partition,
+        )
 
     def new_commit(self) -> FormatTableCommit:
         return FormatTableCommit(table=self.table)

--- a/paimon-python/pypaimon/table/format/format_batch_write_builder.py
+++ b/paimon-python/pypaimon/table/format/format_batch_write_builder.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from pypaimon.table.format.format_table import FormatTable
+from pypaimon.table.format.format_table_commit import FormatTableCommit
+from pypaimon.table.format.format_table_write import FormatTableWrite
+
+
+class FormatBatchWriteBuilder:
+    def __init__(self, table: FormatTable):
+        self.table = table
+        self._overwrite = False
+        self._static_partition: Optional[dict] = None
+
+    def overwrite(self, static_partition: Optional[dict] = None) -> "FormatBatchWriteBuilder":
+        self._overwrite = True
+        self._validate_static_partition(static_partition)
+        self._static_partition = static_partition if static_partition is not None else {}
+        return self
+
+    def _validate_static_partition(self, static_partition: Optional[dict]) -> None:
+        if not static_partition:
+            return
+        if not self.table.partition_keys:
+            raise ValueError(
+                "Format table is not partitioned, static partition values are not allowed."
+            )
+        for key in static_partition:
+            if key not in self.table.partition_keys:
+                raise ValueError(f"Unknown static partition column: {key}")
+
+    def new_write(self) -> FormatTableWrite:
+        return FormatTableWrite(self.table, overwrite=self._overwrite)
+
+    def new_commit(self) -> FormatTableCommit:
+        return FormatTableCommit(
+            table=self.table,
+            overwrite=self._overwrite,
+            static_partitions=self._static_partition,
+        )

--- a/paimon-python/pypaimon/table/format/format_commit_message.py
+++ b/paimon-python/pypaimon/table/format/format_commit_message.py
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class FormatTableCommitMessage:
+    written_paths: List[str]
+
+    def is_empty(self) -> bool:
+        return not self.written_paths

--- a/paimon-python/pypaimon/table/format/format_data_split.py
+++ b/paimon-python/pypaimon/table/format/format_data_split.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Any
 
 
-@dataclass(frozen=True)xi
+@dataclass(frozen=True)
 class FormatDataSplit:
     file_path: str
     file_size: int

--- a/paimon-python/pypaimon/table/format/format_data_split.py
+++ b/paimon-python/pypaimon/table/format/format_data_split.py
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Any
+
+
+@dataclass(frozen=True)xi
+class FormatDataSplit:
+    file_path: str
+    file_size: int
+    offset: int = 0
+    length: Optional[int] = None  # None means read whole file
+    partition: Optional[Dict[str, Any]] = None  # partition column name -> value
+
+    def data_path(self) -> str:
+        return self.file_path

--- a/paimon-python/pypaimon/table/format/format_data_split.py
+++ b/paimon-python/pypaimon/table/format/format_data_split.py
@@ -20,10 +20,10 @@ from typing import Dict, Optional, Any
 
 @dataclass(frozen=True)
 class FormatDataSplit:
+    """Split for format table: one file (or future: byte range) per split."""
+
     file_path: str
     file_size: int
-    offset: int = 0
-    length: Optional[int] = None  # None means read whole file
     partition: Optional[Dict[str, Any]] = None  # partition column name -> value
 
     def data_path(self) -> str:

--- a/paimon-python/pypaimon/table/format/format_read_builder.py
+++ b/paimon-python/pypaimon/table/format/format_read_builder.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Optional
+
+from pypaimon.common.predicate import Predicate
+from pypaimon.common.predicate_builder import PredicateBuilder
+from pypaimon.schema.data_types import DataField
+from pypaimon.table.format.format_table import FormatTable
+from pypaimon.table.format.format_table_scan import FormatTableScan
+from pypaimon.table.format.format_table_read import FormatTableRead
+
+
+class FormatReadBuilder:
+    def __init__(self, table: FormatTable):
+        self.table = table
+        self._projection: Optional[List[str]] = None
+        self._limit: Optional[int] = None
+        self._partition_filter: Optional[dict] = None
+
+    def with_filter(self, predicate: Predicate) -> "FormatReadBuilder":
+        # Format table supports partition filter only; data predicate applied in read
+        self._partition_filter = None  # could extract partition from predicate
+        return self
+
+    def with_projection(self, projection: List[str]) -> "FormatReadBuilder":
+        self._projection = projection
+        return self
+
+    def with_limit(self, limit: int) -> "FormatReadBuilder":
+        self._limit = limit
+        return self
+
+    def with_partition_filter(self, partition_spec: Optional[dict]) -> "FormatReadBuilder":
+        self._partition_filter = partition_spec
+        return self
+
+    def new_scan(self) -> FormatTableScan:
+        return FormatTableScan(
+            self.table,
+            partition_filter=self._partition_filter,
+            limit=self._limit,
+        )
+
+    def new_read(self) -> FormatTableRead:
+        return FormatTableRead(
+            table=self.table,
+            projection=self._projection,
+            limit=self._limit,
+        )
+
+    def new_predicate_builder(self) -> PredicateBuilder:
+        return PredicateBuilder(self.read_type())
+
+    def read_type(self) -> List[DataField]:
+        if self._projection:
+            return [f for f in self.table.fields if f.name in self._projection]
+        return list(self.table.fields)

--- a/paimon-python/pypaimon/table/format/format_read_builder.py
+++ b/paimon-python/pypaimon/table/format/format_read_builder.py
@@ -33,8 +33,15 @@ class FormatReadBuilder:
         self._partition_filter: Optional[dict] = None
 
     def with_filter(self, predicate: Predicate) -> "FormatReadBuilder":
-        if self._partition_filter is None and self.table.partition_keys and predicate:
-            spec = extract_partition_spec_from_predicate(predicate, self.table.partition_keys)
+        ok = (
+            self._partition_filter is None
+            and self.table.partition_keys
+            and predicate
+        )
+        if ok:
+            spec = extract_partition_spec_from_predicate(
+                predicate, self.table.partition_keys
+            )
             if spec is not None:
                 self._partition_filter = spec
         return self
@@ -47,7 +54,9 @@ class FormatReadBuilder:
         self._limit = limit
         return self
 
-    def with_partition_filter(self, partition_spec: Optional[dict]) -> "FormatReadBuilder":
+    def with_partition_filter(
+        self, partition_spec: Optional[dict]
+    ) -> "FormatReadBuilder":
         self._partition_filter = partition_spec
         return self
 
@@ -55,7 +64,6 @@ class FormatReadBuilder:
         return FormatTableScan(
             self.table,
             partition_filter=self._partition_filter,
-            limit=self._limit,
         )
 
     def new_read(self) -> FormatTableRead:

--- a/paimon-python/pypaimon/table/format/format_read_builder.py
+++ b/paimon-python/pypaimon/table/format/format_read_builder.py
@@ -33,12 +33,6 @@ class FormatReadBuilder:
         self._partition_filter: Optional[dict] = None
 
     def with_filter(self, predicate: Predicate) -> "FormatReadBuilder":
-        """
-        Store predicate and, when table has partition keys and no partition filter is set,
-        try to extract partition spec from predicate (AND of equality on partition columns)
-        and set partition filter for scan, aligned with Java FormatReadBuilder.withFilter.
-        Data predicate is not yet applied in read (FormatTableRead does not support filter).
-        """
         if self._partition_filter is None and self.table.partition_keys and predicate:
             spec = extract_partition_spec_from_predicate(predicate, self.table.partition_keys)
             if spec is not None:

--- a/paimon-python/pypaimon/table/format/format_table.py
+++ b/paimon-python/pypaimon/table/format/format_table.py
@@ -1,0 +1,109 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+from typing import Dict, List, Optional
+
+from pypaimon.common.file_io import FileIO
+from pypaimon.common.identifier import Identifier
+from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.common.options.options import Options
+
+PARTITION_DEFAULT_NAME_KEY = "partition.default-name"
+PARTITION_DEFAULT_NAME_DEFAULT = "__DEFAULT_PARTITION__"
+from pypaimon.schema.table_schema import TableSchema
+from pypaimon.table.table import Table
+from pypaimon.table.format.format_read_builder import FormatReadBuilder
+from pypaimon.table.format.format_batch_write_builder import FormatBatchWriteBuilder
+
+
+class Format(str, Enum):
+    ORC = "orc"
+    PARQUET = "parquet"
+    CSV = "csv"
+    TEXT = "text"
+    JSON = "json"
+
+    @classmethod
+    def parse(cls, file_format: str) -> "Format":
+        s = (file_format or "parquet").strip().upper()
+        try:
+            return cls[s]
+        except KeyError:
+            raise ValueError(
+                f"Format table unsupported file format: {file_format}. "
+                f"Supported: {[f.name for f in cls]}"
+            )
+
+
+class FormatTable(Table):
+    def __init__(
+        self,
+        file_io: FileIO,
+        identifier: Identifier,
+        table_schema: TableSchema,
+        location: str,
+        format: Format,
+        options: Optional[Dict[str, str]] = None,
+        comment: Optional[str] = None,
+    ):
+        self.file_io = file_io
+        self.identifier = identifier
+        self._table_schema = table_schema
+        self._location = location.rstrip("/")
+        self._format = format
+        self.options = options or dict(table_schema.options)
+        self.comment = comment
+        self.fields = table_schema.fields
+        self.field_names = [f.name for f in self.fields]
+        self.partition_keys = table_schema.partition_keys or []
+        self.primary_keys: List[str] = []  # format table has no primary key
+        self._core_options = CoreOptions(Options(self.options))
+
+    def name(self) -> str:
+        return self.identifier.get_table_name()
+
+    def full_name(self) -> str:
+        return self.identifier.get_full_name()
+
+    @property
+    def table_schema(self) -> TableSchema:
+        return self._table_schema
+
+    @table_schema.setter
+    def table_schema(self, value: TableSchema):
+        self._table_schema = value
+
+    def location(self) -> str:
+        return self._location
+
+    def format(self) -> Format:
+        return self._format
+
+    def options(self) -> Dict[str, str]:
+        return self.options
+
+    def default_part_name(self) -> str:
+        return self.options.get(PARTITION_DEFAULT_NAME_KEY, PARTITION_DEFAULT_NAME_DEFAULT)
+
+    def new_read_builder(self) -> FormatReadBuilder:
+        return FormatReadBuilder(self)
+
+    def new_batch_write_builder(self) -> FormatBatchWriteBuilder:
+        return FormatBatchWriteBuilder(self)
+
+    def new_stream_write_builder(self):
+        raise NotImplementedError("Format table does not support stream write.")

--- a/paimon-python/pypaimon/table/format/format_table.py
+++ b/paimon-python/pypaimon/table/format/format_table.py
@@ -19,11 +19,6 @@ from typing import Dict, List, Optional
 
 from pypaimon.common.file_io import FileIO
 from pypaimon.common.identifier import Identifier
-from pypaimon.common.options.core_options import CoreOptions
-from pypaimon.common.options.options import Options
-
-PARTITION_DEFAULT_NAME_KEY = "partition.default-name"
-PARTITION_DEFAULT_NAME_DEFAULT = "__DEFAULT_PARTITION__"
 from pypaimon.schema.table_schema import TableSchema
 from pypaimon.table.table import Table
 
@@ -63,13 +58,12 @@ class FormatTable(Table):
         self._table_schema = table_schema
         self._location = location.rstrip("/")
         self._format = format
-        self.options = options or dict(table_schema.options)
+        self._options = options or dict(table_schema.options)
         self.comment = comment
         self.fields = table_schema.fields
         self.field_names = [f.name for f in self.fields]
         self.partition_keys = table_schema.partition_keys or []
         self.primary_keys: List[str] = []  # format table has no primary key
-        self._core_options = CoreOptions(Options(self.options))
 
     def name(self) -> str:
         return self.identifier.get_table_name()
@@ -92,10 +86,7 @@ class FormatTable(Table):
         return self._format
 
     def options(self) -> Dict[str, str]:
-        return self.options
-
-    def default_part_name(self) -> str:
-        return self.options.get(PARTITION_DEFAULT_NAME_KEY, PARTITION_DEFAULT_NAME_DEFAULT)
+        return self._options
 
     def new_read_builder(self):
         from pypaimon.table.format.format_read_builder import FormatReadBuilder

--- a/paimon-python/pypaimon/table/format/format_table.py
+++ b/paimon-python/pypaimon/table/format/format_table.py
@@ -26,8 +26,6 @@ PARTITION_DEFAULT_NAME_KEY = "partition.default-name"
 PARTITION_DEFAULT_NAME_DEFAULT = "__DEFAULT_PARTITION__"
 from pypaimon.schema.table_schema import TableSchema
 from pypaimon.table.table import Table
-from pypaimon.table.format.format_read_builder import FormatReadBuilder
-from pypaimon.table.format.format_batch_write_builder import FormatBatchWriteBuilder
 
 
 class Format(str, Enum):
@@ -99,10 +97,12 @@ class FormatTable(Table):
     def default_part_name(self) -> str:
         return self.options.get(PARTITION_DEFAULT_NAME_KEY, PARTITION_DEFAULT_NAME_DEFAULT)
 
-    def new_read_builder(self) -> FormatReadBuilder:
+    def new_read_builder(self):
+        from pypaimon.table.format.format_read_builder import FormatReadBuilder
         return FormatReadBuilder(self)
 
-    def new_batch_write_builder(self) -> FormatBatchWriteBuilder:
+    def new_batch_write_builder(self):
+        from pypaimon.table.format.format_batch_write_builder import FormatBatchWriteBuilder
         return FormatBatchWriteBuilder(self)
 
     def new_stream_write_builder(self):

--- a/paimon-python/pypaimon/table/format/format_table_commit.py
+++ b/paimon-python/pypaimon/table/format/format_table_commit.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import List
 
 import pyarrow.fs as pafs
 
@@ -41,16 +41,10 @@ def _delete_data_files_in_path(file_io, path: str) -> None:
 
 
 class FormatTableCommit:
+    """Commit for format table. Overwrite is applied in FormatTableWrite at write time."""
 
-    def __init__(
-        self,
-        table: FormatTable,
-        overwrite: bool = False,
-        static_partitions: Optional[dict] = None,
-    ):
+    def __init__(self, table: FormatTable):
         self.table = table
-        self.overwrite = overwrite
-        self.static_partitions = static_partitions or {}
         self._committed = False
 
     def commit(self, commit_messages: List[FormatTableCommitMessage]) -> None:

--- a/paimon-python/pypaimon/table/format/format_table_commit.py
+++ b/paimon-python/pypaimon/table/format/format_table_commit.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Optional
+
+import pyarrow.fs as pafs
+
+from pypaimon.table.format.format_table import FormatTable
+from pypaimon.table.format.format_table_scan import _is_data_file_name
+from pypaimon.table.format.format_commit_message import FormatTableCommitMessage
+
+
+def _delete_data_files_in_path(file_io, path: str) -> None:
+    try:
+        infos = file_io.list_status(path)
+    except Exception:
+        return
+    for info in infos:
+        if info.type == pafs.FileType.Directory:
+            _delete_data_files_in_path(file_io, info.path)
+        elif info.type == pafs.FileType.File:
+            name = info.path.split("/")[-1] if "/" in info.path else info.path
+            if _is_data_file_name(name):
+                try:
+                    file_io.delete(info.path, False)
+                except Exception:
+                    pass
+
+
+class FormatTableCommit:
+
+    def __init__(
+        self,
+        table: FormatTable,
+        overwrite: bool = False,
+        static_partitions: Optional[dict] = None,
+    ):
+        self.table = table
+        self.overwrite = overwrite
+        self.static_partitions = static_partitions or {}
+        self._committed = False
+
+    def commit(self, commit_messages: List[FormatTableCommitMessage]) -> None:
+        if self._committed:
+            raise RuntimeError("FormatTableCommit supports only one commit.")
+        self._committed = True
+        return
+
+    def abort(self, commit_messages: List[FormatTableCommitMessage]) -> None:
+        for msg in commit_messages:
+            for path in msg.written_paths:
+                try:
+                    if self.table.file_io.exists(path):
+                        self.table.file_io.delete(path, False)
+                except Exception:
+                    pass
+
+    def close(self) -> None:
+        pass

--- a/paimon-python/pypaimon/table/format/format_table_read.py
+++ b/paimon-python/pypaimon/table/format/format_table_read.py
@@ -1,0 +1,149 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, Iterator, List, Optional
+
+import pandas
+import pyarrow
+
+from pypaimon.schema.data_types import PyarrowFieldParser
+from pypaimon.table.format.format_data_split import FormatDataSplit
+from pypaimon.table.format.format_table import FormatTable, Format
+
+
+def _read_file_to_arrow(
+    file_io: Any,
+    split: FormatDataSplit,
+    fmt: Format,
+    partition_spec: Optional[Dict[str, str]],
+    read_fields: Optional[List[str]],
+) -> pyarrow.Table:
+    path = split.data_path()
+    opts = {}
+    if fmt == Format.CSV:
+        opts = {"max_read_options": {"block_size": 1 << 20}}
+    try:
+        with file_io.new_input_stream(path) as stream:
+            data = stream.read()
+    except Exception as e:
+        raise RuntimeError(f"Failed to read {path}") from e
+
+    if fmt == Format.PARQUET:
+        import io
+        tbl = pyarrow.parquet.read_table(io.BytesIO(data))
+    elif fmt == Format.CSV:
+        tbl = pyarrow.csv.read_csv(pyarrow.BufferReader(data), **opts)
+    elif fmt == Format.JSON:
+        import json
+        text = data.decode("utf-8") if isinstance(data, bytes) else data
+        records = []
+        for line in text.strip().split("\n"):
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+        if not records:
+            return pyarrow.table({})
+        tbl = pyarrow.Table.from_pylist(records)
+    else:
+        raise ValueError(f"Format {fmt} read not implemented in Python")
+
+    if partition_spec:
+        for k, v in partition_spec.items():
+            tbl = tbl.append_column(
+                k,
+                pyarrow.array([v] * tbl.num_rows, type=pyarrow.string()),
+            )
+        if read_fields:
+            col_order = [c for c in read_fields if c in tbl.column_names]
+            if col_order:
+                tbl = tbl.select(col_order)
+
+    if read_fields and tbl.num_columns > 0:
+        existing = [c for c in read_fields if c in tbl.column_names]
+        if existing:
+            tbl = tbl.select(existing)
+    return tbl
+
+
+class FormatTableRead:
+
+    def __init__(
+        self,
+        table: FormatTable,
+        projection: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+    ):
+        self.table = table
+        self.projection = projection
+        self.limit = limit
+
+    def to_arrow(
+        self,
+        splits: List[FormatDataSplit],
+    ) -> pyarrow.Table:
+        read_fields = self.projection
+        fmt = self.table.format()
+        tables = []
+        nrows = 0
+        for split in splits:
+            t = _read_file_to_arrow(
+                self.table.file_io,
+                split,
+                fmt,
+                split.partition,
+                read_fields,
+            )
+            if t.num_rows > 0:
+                tables.append(t)
+                nrows += t.num_rows
+                if self.limit is not None and nrows >= self.limit:
+                    if nrows > self.limit:
+                        excess = nrows - self.limit
+                        last = tables[-1]
+                        tables[-1] = last.slice(0, last.num_rows - excess)
+                    break
+        if not tables:
+            fields = self.table.fields
+            if read_fields:
+                fields = [f for f in self.table.fields if f.name in read_fields]
+            schema = PyarrowFieldParser.from_paimon_schema(fields)
+            return pyarrow.Table.from_pydict(
+                {n: [] for n in schema.names},
+                schema=schema,
+            )
+        out = pyarrow.concat_tables(tables)
+        if self.limit is not None and out.num_rows > self.limit:
+            out = out.slice(0, self.limit)
+        return out
+
+    def to_pandas(self, splits: List[FormatDataSplit]) -> pandas.DataFrame:
+        return self.to_arrow(splits).to_pandas()
+
+    def to_iterator(
+        self,
+        splits: List[FormatDataSplit],
+    ) -> Iterator[Any]:
+        for split in splits:
+            t = _read_file_to_arrow(
+                self.table.file_io,
+                split,
+                self.table.format(),
+                split.partition,
+                self.projection,
+            )
+            for batch in t.to_batches():
+                for i in range(batch.num_rows):
+                    yield batch.slice(i, 1)

--- a/paimon-python/pypaimon/table/format/format_table_scan.py
+++ b/paimon-python/pypaimon/table/format/format_table_scan.py
@@ -103,11 +103,9 @@ class FormatTableScan:
         self,
         table: FormatTable,
         partition_filter: Optional[Dict[str, str]] = None,
-        limit: Optional[int] = None,
     ):
         self.table = table
         self.partition_filter = partition_filter  # optional equality filter
-        self.limit = limit
 
     def plan(self) -> Plan:
         partition_only_value = self.table.options().get(
@@ -129,8 +127,4 @@ class FormatTableScan:
                 if match:
                     filtered.append(s)
             splits = filtered
-        if self.limit is not None and self.limit <= 0:
-            splits = []
-        elif self.limit is not None and len(splits) > self.limit:
-            splits = splits[: self.limit]
         return Plan(_splits=splits)

--- a/paimon-python/pypaimon/table/format/format_table_scan.py
+++ b/paimon-python/pypaimon/table/format/format_table_scan.py
@@ -25,14 +25,12 @@ from pypaimon.table.format.format_table import FormatTable
 
 
 def _is_data_file_name(name: str) -> bool:
-    """Match Java FormatTableScan.isDataFileName: exclude hidden/metadata."""
     if name is None:
         return False
     return not name.startswith(".") and not name.startswith("_")
 
 
 def _is_reserved_dir_name(name: str) -> bool:
-    """Skip metadata/reserved dirs (not treated as partition levels)."""
     if not name:
         return True
     if name.startswith(".") or name.startswith("_"):
@@ -49,7 +47,6 @@ def _list_data_files_recursive(
     partition_only_value: bool,
     rel_path_parts: Optional[List[str]] = None,
 ) -> List[FormatDataSplit]:
-    """List data files under path, building partition spec from dir names."""
     splits: List[FormatDataSplit] = []
     rel_path_parts = rel_path_parts or []
     try:

--- a/paimon-python/pypaimon/table/format/format_table_scan.py
+++ b/paimon-python/pypaimon/table/format/format_table_scan.py
@@ -32,7 +32,6 @@ def _is_data_file_name(name: str) -> bool:
 def _list_data_files_recursive(
     file_io: FileIO,
     path: str,
-    base_path: str,
     partition_keys: List[str],
     partition_only_value: bool,
     rel_path_parts: Optional[List[str]] = None,
@@ -60,7 +59,6 @@ def _list_data_files_recursive(
                 sub_splits = _list_data_files_recursive(
                     file_io,
                     full_path,
-                    base_path,
                     partition_keys,
                     partition_only_value,
                     child_parts,
@@ -99,7 +97,6 @@ class FormatTableScan:
         ).lower() == "true"
         splits = _list_data_files_recursive(
             self.table.file_io,
-            self.table.location(),
             self.table.location(),
             self.table.partition_keys,
             partition_only_value,

--- a/paimon-python/pypaimon/table/format/format_table_scan.py
+++ b/paimon-python/pypaimon/table/format/format_table_scan.py
@@ -45,8 +45,12 @@ def _list_data_files_recursive(
         return splits
     if not infos:
         return splits
+    path_rstrip = path.rstrip("/")
     for info in infos:
         name = info.path.split("/")[-1] if "/" in info.path else info.path
+        full_path = f"{path_rstrip}/{name}" if path_rstrip else name
+        if info.path.startswith("/") or info.path.startswith("file:"):
+            full_path = info.path
         if info.type == pafs.FileType.Directory:
             part_value = name
             if not partition_only_value and "=" in name:
@@ -55,7 +59,7 @@ def _list_data_files_recursive(
             if len(child_parts) <= len(partition_keys):
                 sub_splits = _list_data_files_recursive(
                     file_io,
-                    info.path,
+                    full_path,
                     base_path,
                     partition_keys,
                     partition_only_value,
@@ -69,7 +73,7 @@ def _list_data_files_recursive(
                 part_spec = dict(zip(partition_keys, rel_path_parts[: len(partition_keys)]))
             splits.append(
                 FormatDataSplit(
-                    file_path=info.path,
+                    file_path=full_path,
                     file_size=size if size is not None else 0,
                     partition=part_spec,
                 )

--- a/paimon-python/pypaimon/table/format/format_table_scan.py
+++ b/paimon-python/pypaimon/table/format/format_table_scan.py
@@ -1,0 +1,115 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, Optional
+
+import pyarrow.fs as pafs
+
+from pypaimon.common.file_io import FileIO
+from pypaimon.read.plan import Plan
+from pypaimon.table.format.format_data_split import FormatDataSplit
+from pypaimon.table.format.format_table import FormatTable
+
+
+def _is_data_file_name(name: str) -> bool:
+    """Match Java FormatTableScan.isDataFileName: exclude hidden and metadata."""
+    return name is not None and not name.startswith(".") and not name.startswith("_")
+
+
+def _list_data_files_recursive(
+    file_io: FileIO,
+    path: str,
+    base_path: str,
+    partition_keys: List[str],
+    partition_only_value: bool,
+    rel_path_parts: Optional[List[str]] = None,
+) -> List[FormatDataSplit]:
+    splits: List[FormatDataSplit] = []
+    rel_path_parts = rel_path_parts or []
+    try:
+        infos = file_io.list_status(path)
+    except Exception:
+        return splits
+    if not infos:
+        return splits
+    for info in infos:
+        name = info.path.split("/")[-1] if "/" in info.path else info.path
+        if info.type == pafs.FileType.Directory:
+            part_value = name
+            if not partition_only_value and "=" in name:
+                part_value = name.split("=", 1)[1]
+            child_parts = rel_path_parts + [part_value]
+            if len(child_parts) <= len(partition_keys):
+                sub_splits = _list_data_files_recursive(
+                    file_io,
+                    info.path,
+                    base_path,
+                    partition_keys,
+                    partition_only_value,
+                    child_parts,
+                )
+                splits.extend(sub_splits)
+        elif info.type == pafs.FileType.File and _is_data_file_name(name):
+            size = getattr(info, "size", None) or 0
+            part_spec: Optional[Dict[str, str]] = None
+            if partition_keys and len(rel_path_parts) >= len(partition_keys):
+                part_spec = dict(zip(partition_keys, rel_path_parts[: len(partition_keys)]))
+            splits.append(
+                FormatDataSplit(
+                    file_path=info.path,
+                    file_size=size if size is not None else 0,
+                    partition=part_spec,
+                )
+            )
+    return splits
+
+
+class FormatTableScan:
+
+    def __init__(
+        self,
+        table: FormatTable,
+        partition_filter: Optional[Dict[str, str]] = None,
+        limit: Optional[int] = None,
+    ):
+        self.table = table
+        self.partition_filter = partition_filter  # optional equality filter
+        self.limit = limit
+
+    def plan(self) -> Plan:
+        partition_only_value = self.table.options.get(
+            "format-table.partition-path-only-value", "false"
+        ).lower() == "true"
+        splits = _list_data_files_recursive(
+            self.table.file_io,
+            self.table.location(),
+            self.table.location(),
+            self.table.partition_keys,
+            partition_only_value,
+        )
+        if self.partition_filter:
+            filtered = []
+            for s in splits:
+                if s.partition and all(
+                    s.partition.get(k) == v for k, v in self.partition_filter.items()
+                ):
+                    filtered.append(s)
+            splits = filtered
+        if self.limit is not None and self.limit <= 0:
+            splits = []
+        elif self.limit is not None and len(splits) > self.limit:
+            splits = splits[: self.limit]
+        return Plan(_splits=splits)

--- a/paimon-python/pypaimon/table/format/format_table_scan.py
+++ b/paimon-python/pypaimon/table/format/format_table_scan.py
@@ -94,7 +94,7 @@ class FormatTableScan:
         self.limit = limit
 
     def plan(self) -> Plan:
-        partition_only_value = self.table.options.get(
+        partition_only_value = self.table.options().get(
             "format-table.partition-path-only-value", "false"
         ).lower() == "true"
         splits = _list_data_files_recursive(

--- a/paimon-python/pypaimon/table/format/format_table_scan.py
+++ b/paimon-python/pypaimon/table/format/format_table_scan.py
@@ -90,7 +90,7 @@ def _list_data_files_recursive(
             splits.append(
                 FormatDataSplit(
                     file_path=full_path,
-                    file_size=size if size is not None else 0,
+                    file_size=size,
                     partition=part_spec,
                 )
             )
@@ -123,7 +123,7 @@ class FormatTableScan:
             filtered = []
             for s in splits:
                 match = s.partition and all(
-                    s.partition.get(k) == v
+                    str(s.partition.get(k)) == str(v)
                     for k, v in self.partition_filter.items()
                 )
                 if match:

--- a/paimon-python/pypaimon/table/format/format_table_write.py
+++ b/paimon-python/pypaimon/table/format/format_table_write.py
@@ -1,0 +1,157 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import uuid
+from collections import defaultdict
+from typing import List
+
+import pyarrow
+
+from pypaimon.schema.data_types import PyarrowFieldParser
+from pypaimon.table.format.format_commit_message import FormatTableCommitMessage
+from pypaimon.table.format.format_table import FormatTable, Format
+
+
+def _partition_path(partition_spec: dict, partition_keys: List[str], only_value: bool) -> str:
+    parts = []
+    for k in partition_keys:
+        v = partition_spec.get(k)
+        if v is None:
+            break
+        parts.append(str(v) if only_value else f"{k}={v}")
+    return "/".join(parts)
+
+
+def _partition_from_row(
+    row: pyarrow.RecordBatch,
+    partition_keys: List[str],
+    row_index: int,
+) -> tuple:
+    out = []
+    for k in partition_keys:
+        col = row.column(row.schema.get_field_index(k))
+        val = col[row_index]
+        if val is None or (hasattr(val, "as_py") and val.as_py() is None):
+            out.append(None)
+        else:
+            out.append(val.as_py() if hasattr(val, "as_py") else val)
+    return tuple(out)
+
+
+class FormatTableWrite:
+    """Batch write for format table: writes Arrow/Pandas to partition dirs as files."""
+
+    def __init__(self, table: FormatTable, overwrite: bool = False):
+        self.table = table
+        self._overwrite = overwrite
+        self._written_paths: List[str] = []
+        self._partition_only_value = (
+            table.options.get("format-table.partition-path-only-value", "false").lower() == "true"
+        )
+        self._file_format = table.format()
+        self._data_file_prefix = "data-"
+        self._suffix = {"parquet": ".parquet", "csv": ".csv", "json": ".json"}.get(
+            self._file_format.value, ".parquet"
+        )
+
+    def write_arrow(self, data: pyarrow.Table) -> None:
+        for batch in data.to_batches():
+            self.write_arrow_batch(batch)
+
+    def write_arrow_batch(self, data: pyarrow.RecordBatch) -> None:
+        partition_keys = self.table.partition_keys
+        if not partition_keys:
+            part_spec = {}
+            self._write_single_batch(data, part_spec)
+            return
+        # Group rows by partition
+        parts_to_indices = defaultdict(list)
+        for i in range(data.num_rows):
+            part = _partition_from_row(data, partition_keys, i)
+            parts_to_indices[part].append(i)
+        for part_tuple, indices in parts_to_indices.items():
+            part_spec = dict(zip(partition_keys, part_tuple))
+            sub = data.take(pyarrow.array(indices))
+            self._write_single_batch(sub, part_spec)
+
+    def write_pandas(self, df) -> None:
+        pa_schema = PyarrowFieldParser.from_paimon_schema(self.table.fields)
+        batch = pyarrow.RecordBatch.from_pandas(df, schema=pa_schema)
+        self.write_arrow_batch(batch)
+
+    def _write_single_batch(
+        self,
+        data: pyarrow.RecordBatch,
+        partition_spec: dict,
+    ) -> None:
+        if data.num_rows == 0:
+            return
+        location = self.table.location()
+        partition_only_value = self._partition_only_value
+        part_path = _partition_path(
+            partition_spec,
+            self.table.partition_keys,
+            partition_only_value,
+        )
+        if part_path:
+            dir_path = f"{location}/{part_path}"
+        else:
+            dir_path = location
+        if self._overwrite and self.table.file_io.exists(dir_path):
+            from pypaimon.table.format.format_table_commit import _delete_data_files_in_path
+            _delete_data_files_in_path(self.table.file_io, dir_path)
+        self.table.file_io.check_or_mkdirs(dir_path)
+        file_name = f"{self._data_file_prefix}{uuid.uuid4().hex}{self._suffix}"
+        path = f"{dir_path}/{file_name}"
+
+        fmt = self._file_format
+        if fmt == Format.PARQUET:
+            buf = io.BytesIO()
+            pyarrow.parquet.write_table(
+                pyarrow.Table.from_batches([data]),
+                buf,
+                compression="zstd",
+            )
+            raw = buf.getvalue()
+        elif fmt == Format.CSV:
+            buf = io.BytesIO()
+            pyarrow.csv.write_csv(
+                pyarrow.Table.from_batches([data]),
+                buf,
+            )
+            raw = buf.getvalue()
+        elif fmt == Format.JSON:
+            tbl = pyarrow.Table.from_batches([data])
+            import json
+            lines = []
+            for i in range(tbl.num_rows):
+                row = {tbl.column_names[j]: tbl.column(j)[i].as_py() for j in range(tbl.num_columns)}
+                lines.append(json.dumps(row) + "\n")
+            raw = "".join(lines).encode("utf-8")
+        else:
+            raise ValueError(f"Format table write not implemented for {fmt}")
+
+        with self.table.file_io.new_output_stream(path) as out:
+            out.write(raw)
+
+        self._written_paths.append(path)
+
+    def prepare_commit(self) -> List[FormatTableCommitMessage]:
+        return [FormatTableCommitMessage(written_paths=list(self._written_paths))]
+
+    def close(self) -> None:
+        pass

--- a/paimon-python/pypaimon/table/format/format_table_write.py
+++ b/paimon-python/pypaimon/table/format/format_table_write.py
@@ -176,16 +176,12 @@ class FormatTableWrite:
         path = f"{dir_path}/{file_name}"
 
         fmt = self._file_format
+        tbl = pyarrow.Table.from_batches([data])
         if fmt == Format.PARQUET:
             buf = io.BytesIO()
-            pyarrow.parquet.write_table(
-                pyarrow.Table.from_batches([data]),
-                buf,
-                compression="zstd",
-            )
+            pyarrow.parquet.write_table(tbl, buf, compression="zstd")
             raw = buf.getvalue()
         elif fmt == Format.CSV:
-            tbl = pyarrow.Table.from_batches([data])
             if hasattr(pyarrow, "csv"):
                 buf = io.BytesIO()
                 pyarrow.csv.write_csv(tbl, buf)
@@ -195,7 +191,6 @@ class FormatTableWrite:
                 tbl.to_pandas().to_csv(buf, index=False)
                 raw = buf.getvalue().encode("utf-8")
         elif fmt == Format.JSON:
-            tbl = pyarrow.Table.from_batches([data])
             import json
             lines = []
             for i in range(tbl.num_rows):
@@ -206,7 +201,6 @@ class FormatTableWrite:
                 lines.append(json.dumps(row) + "\n")
             raw = "".join(lines).encode("utf-8")
         elif fmt == Format.ORC:
-            tbl = pyarrow.Table.from_batches([data])
             if hasattr(pyarrow, "orc"):
                 buf = io.BytesIO()
                 pyarrow.orc.write_table(tbl, buf)
@@ -217,7 +211,6 @@ class FormatTableWrite:
                     "support (pyarrow.orc)"
                 )
         elif fmt == Format.TEXT:
-            tbl = pyarrow.Table.from_batches([data])
             partition_keys = self.table.partition_keys
             if partition_keys:
                 data_cols = [

--- a/paimon-python/pypaimon/table/format/format_table_write.py
+++ b/paimon-python/pypaimon/table/format/format_table_write.py
@@ -60,7 +60,7 @@ class FormatTableWrite:
         self._overwrite = overwrite
         self._written_paths: List[str] = []
         self._partition_only_value = (
-            table.options.get("format-table.partition-path-only-value", "false").lower() == "true"
+            table.options().get("format-table.partition-path-only-value", "false").lower() == "true"
         )
         self._file_format = table.format()
         self._data_file_prefix = "data-"
@@ -166,12 +166,13 @@ class FormatTableWrite:
                     "TEXT format only supports a single string column, "
                     f"got {tbl.num_columns} columns"
                 )
-            line_delimiter = self.table.options.get("text.line-delimiter", "\n")
+            line_delimiter = self.table.options().get("text.line-delimiter", "\n")
             lines = []
             col = tbl.column(0)
             for i in range(tbl.num_rows):
                 val = col[i]
-                lines.append((val.as_py() if val is not None else "") + line_delimiter)
+                py_val = val.as_py() if hasattr(val, "as_py") else val
+                lines.append(("" if py_val is None else str(py_val)) + line_delimiter)
             raw = "".join(lines).encode("utf-8")
         else:
             raise ValueError(f"Format table write not implemented for {fmt}")

--- a/paimon-python/pypaimon/tests/rest/rest_format_table_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_format_table_test.py
@@ -122,7 +122,6 @@ class RESTFormatTableTest(RESTBaseTest):
         pd.testing.assert_frame_equal(actual, expected)
 
     def test_format_table_text_read_write_with_nulls(self):
-        """TEXT format: null string values are written as empty string and read back as empty."""
         pa_schema = pa.schema([("value", pa.string())])
         schema = Schema.from_pyarrow_schema(
             pa_schema,
@@ -154,7 +153,6 @@ class RESTFormatTableTest(RESTBaseTest):
         self.assertIn("", actual["value"].values)
 
     def test_format_table_text_partitioned_read_write(self):
-        """Partitioned TEXT table: partition columns are stripped before write; read back with partition."""
         pa_schema = pa.schema([
             ("value", pa.string()),
             ("dt", pa.int32()),
@@ -191,7 +189,6 @@ class RESTFormatTableTest(RESTBaseTest):
         self.assertEqual(actual["dt"].tolist(), [1, 1, 2])
 
     def test_format_table_read_with_limit_to_iterator(self):
-        """with_limit(N) must be respected by to_iterator (same as to_arrow/to_pandas)."""
         pa_schema = pa.schema([
             ("a", pa.int32()),
             ("b", pa.int32()),
@@ -265,7 +262,6 @@ class RESTFormatTableTest(RESTBaseTest):
         self.assertEqual(actual["b"].tolist(), [100, 200])
 
     def test_format_table_overwrite_only_specified_partition(self):
-        """overwrite(static_partition) must only clear that partition; other partitions unchanged."""
         pa_schema = pa.schema([
             ("a", pa.int32()),
             ("b", pa.int32()),
@@ -312,7 +308,6 @@ class RESTFormatTableTest(RESTBaseTest):
         self.assertEqual(c2, [30, 40], "partition c=2 must be unchanged")
 
     def test_format_table_overwrite_multiple_batches_same_partition(self):
-        """Overwrite mode must clear partition dir only once; multiple batches same partition keep all data."""
         pa_schema = pa.schema([
             ("a", pa.int32()),
             ("b", pa.int32()),
@@ -440,7 +435,6 @@ class RESTFormatTableTest(RESTBaseTest):
         )
 
     def test_format_table_with_filter_extracts_partition_like_java(self):
-        """with_filter(partition equality) extracts partition like Java; does not overwrite partition filter."""
         pa_schema = pa.schema([
             ("a", pa.int32()),
             ("b", pa.int32()),

--- a/paimon-python/pypaimon/tests/rest/rest_format_table_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_format_table_test.py
@@ -1,0 +1,301 @@
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+
+import pandas as pd
+import pyarrow as pa
+from parameterized import parameterized
+
+from pypaimon import Schema
+from pypaimon.catalog.catalog_exception import TableNotExistException
+from pypaimon.table.format import FormatTable
+from pypaimon.tests.rest.rest_base_test import RESTBaseTest
+
+
+def _format_table_read_write_formats():
+    formats = [("parquet",), ("csv",), ("json",)]
+    if hasattr(pa, "orc"):
+        formats.append(("orc",))
+    return formats
+
+
+class RESTFormatTableTest(RESTBaseTest):
+
+    @parameterized.expand(_format_table_read_write_formats())
+    def test_format_table_read_write(self, file_format):
+        pa_schema = pa.schema([
+            ("a", pa.int32()),
+            ("b", pa.int32()),
+            ("c", pa.int32()),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={"type": "format-table", "file.format": file_format},
+        )
+        table_name = f"default.format_table_rw_{file_format}"
+        try:
+            self.rest_catalog.drop_table(table_name, True)
+        except Exception:
+            pass
+        self.rest_catalog.create_table(table_name, schema, False)
+        table = self.rest_catalog.get_table(table_name)
+        self.assertIsInstance(table, FormatTable)
+        self.assertEqual(table.format().value, file_format)
+
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        df = pd.DataFrame({
+            "a": [10, 10],
+            "b": [1, 2],
+            "c": [1, 2],
+        })
+        table_write.write_pandas(df)
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+
+        read_builder = table.new_read_builder()
+        splits = read_builder.new_scan().plan().splits()
+        table_read = read_builder.new_read()
+        actual = table_read.to_pandas(splits).sort_values(by="b").reset_index(drop=True)
+        expected = pa.Table.from_pydict(
+            {"a": [10, 10], "b": [1, 2], "c": [1, 2]},
+            schema=pa_schema,
+        ).to_pandas()
+        for col in expected.columns:
+            if col in actual.columns and actual[col].dtype != expected[col].dtype:
+                actual[col] = actual[col].astype(expected[col].dtype)
+        pd.testing.assert_frame_equal(actual, expected)
+
+    def test_format_table_text_read_write(self):
+        pa_schema = pa.schema([("value", pa.string())])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={"type": "format-table", "file.format": "text"},
+        )
+        table_name = "default.format_table_rw_text"
+        try:
+            self.rest_catalog.drop_table(table_name, True)
+        except Exception:
+            pass
+        self.rest_catalog.create_table(table_name, schema, False)
+        table = self.rest_catalog.get_table(table_name)
+        self.assertIsInstance(table, FormatTable)
+        self.assertEqual(table.format().value, "text")
+
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        df = pd.DataFrame({"value": ["hello", "world"]})
+        table_write.write_pandas(df)
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+
+        read_builder = table.new_read_builder()
+        splits = read_builder.new_scan().plan().splits()
+        table_read = read_builder.new_read()
+        actual = table_read.to_pandas(splits).sort_values(by="value").reset_index(drop=True)
+        expected = pd.DataFrame({"value": ["hello", "world"]})
+        pd.testing.assert_frame_equal(actual, expected)
+
+    @parameterized.expand(_format_table_read_write_formats())
+    def test_format_table_partitioned_overwrite(self, file_format):
+        pa_schema = pa.schema([
+            ("a", pa.int32()),
+            ("b", pa.int32()),
+            ("c", pa.int32()),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            partition_keys=["c"],
+            options={"type": "format-table", "file.format": file_format},
+        )
+        table_name = f"default.format_table_partitioned_overwrite_{file_format}"
+        self.rest_catalog.drop_table(table_name, True)
+        self.rest_catalog.create_table(table_name, schema, False)
+        table = self.rest_catalog.get_table(table_name)
+
+        write_builder = table.new_batch_write_builder()
+        tw = write_builder.new_write()
+        tc = write_builder.new_commit()
+        tw.write_pandas(pd.DataFrame({"a": [10, 10], "b": [10, 20], "c": [1, 1]}))
+        tc.commit(tw.prepare_commit())
+        tw.close()
+        tc.close()
+
+        tw = table.new_batch_write_builder().overwrite({"c": 1}).new_write()
+        tc = table.new_batch_write_builder().overwrite({"c": 1}).new_commit()
+        tw.write_pandas(pd.DataFrame({"a": [12, 12], "b": [100, 200], "c": [1, 1]}))
+        tc.commit(tw.prepare_commit())
+        tw.close()
+        tc.close()
+
+        read_builder = table.new_read_builder()
+        splits = read_builder.new_scan().plan().splits()
+        actual = read_builder.new_read().to_pandas(splits).sort_values(by="b")
+        self.assertEqual(len(actual), 2)
+        self.assertEqual(actual["b"].tolist(), [100, 200])
+
+    @parameterized.expand(_format_table_read_write_formats())
+    def test_format_table_partitioned_read_write(self, file_format):
+        pa_schema = pa.schema([
+            ("a", pa.int32()),
+            ("b", pa.int32()),
+            ("dt", pa.int32()),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            partition_keys=["dt"],
+            options={"type": "format-table", "file.format": file_format},
+        )
+        table_name = f"default.format_table_partitioned_rw_{file_format}"
+        self.rest_catalog.drop_table(table_name, True)
+        self.rest_catalog.create_table(table_name, schema, False)
+        table = self.rest_catalog.get_table(table_name)
+        self.assertIsInstance(table, FormatTable)
+
+        wb = table.new_batch_write_builder()
+        tw = wb.new_write()
+        tc = wb.new_commit()
+        tw.write_pandas(pd.DataFrame({"a": [1, 2], "b": [10, 20], "dt": [10, 10]}))
+        tc.commit(tw.prepare_commit())
+        tw.close()
+        tc.close()
+
+        tw = wb.new_write()
+        tc = wb.new_commit()
+        tw.write_pandas(pd.DataFrame({"a": [3, 4], "b": [30, 40], "dt": [11, 11]}))
+        tc.commit(tw.prepare_commit())
+        tw.close()
+        tc.close()
+
+        rb = table.new_read_builder()
+        splits_all = rb.new_scan().plan().splits()
+        actual_all = rb.new_read().to_pandas(splits_all).sort_values(by="b")
+        self.assertEqual(len(actual_all), 4)
+        self.assertEqual(sorted(actual_all["b"].tolist()), [10, 20, 30, 40])
+
+        rb_dt10 = table.new_read_builder().with_partition_filter({"dt": "10"})
+        splits_dt10 = rb_dt10.new_scan().plan().splits()
+        actual_dt10 = rb_dt10.new_read().to_pandas(splits_dt10).sort_values(by="b")
+        self.assertEqual(len(actual_dt10), 2)
+        self.assertEqual(actual_dt10["b"].tolist(), [10, 20])
+
+    @parameterized.expand(_format_table_read_write_formats())
+    def test_format_table_full_overwrite(self, file_format):
+        pa_schema = pa.schema([
+            ("a", pa.int32()),
+            ("b", pa.int32()),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={"type": "format-table", "file.format": file_format},
+        )
+        table_name = f"default.format_table_full_overwrite_{file_format}"
+        self.rest_catalog.drop_table(table_name, True)
+        self.rest_catalog.create_table(table_name, schema, False)
+        table = self.rest_catalog.get_table(table_name)
+
+        wb = table.new_batch_write_builder()
+        tw = wb.new_write()
+        tc = wb.new_commit()
+        tw.write_pandas(pd.DataFrame({"a": [1, 2], "b": [10, 20]}))
+        tc.commit(tw.prepare_commit())
+        tw.close()
+        tc.close()
+
+        tw = wb.overwrite().new_write()
+        tc = wb.overwrite().new_commit()
+        tw.write_pandas(pd.DataFrame({"a": [3], "b": [30]}))
+        tc.commit(tw.prepare_commit())
+        tw.close()
+        tc.close()
+
+        rb = table.new_read_builder()
+        splits = rb.new_scan().plan().splits()
+        actual = rb.new_read().to_pandas(splits)
+        self.assertEqual(len(actual), 1)
+        self.assertEqual(actual["b"].tolist(), [30])
+
+    @parameterized.expand(_format_table_read_write_formats())
+    def test_format_table_split_read(self, file_format):
+        pa_schema = pa.schema([
+            ("id", pa.int32()),
+            ("name", pa.string()),
+            ("score", pa.float64()),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                "type": "format-table",
+                "file.format": file_format,
+                "source.split.target-size": "54",
+            },
+        )
+        table_name = f"default.format_table_split_read_{file_format}"
+        self.rest_catalog.drop_table(table_name, True)
+        self.rest_catalog.create_table(table_name, schema, False)
+        table = self.rest_catalog.get_table(table_name)
+
+        size = 50
+        for i in range(0, size, 10):
+            batch = pd.DataFrame({
+                "id": list(range(i, min(i + 10, size))),
+                "name": [f"User{j}" for j in range(i, min(i + 10, size))],
+                "score": [85.5 + (j % 15) for j in range(i, min(i + 10, size))],
+            })
+            wb = table.new_batch_write_builder()
+            tw = wb.new_write()
+            tc = wb.new_commit()
+            tw.write_pandas(batch)
+            tc.commit(tw.prepare_commit())
+            tw.close()
+            tc.close()
+
+        rb = table.new_read_builder()
+        splits = rb.new_scan().plan().splits()
+        actual = rb.new_read().to_pandas(splits).sort_values(by="id")
+        self.assertEqual(len(actual), size)
+        self.assertEqual(actual["id"].tolist(), list(range(size)))
+
+    @parameterized.expand(_format_table_read_write_formats())
+    def test_format_table_catalog(self, file_format):
+        pa_schema = pa.schema([
+            ("str", pa.string()),
+            ("int", pa.int32()),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={"type": "format-table", "file.format": file_format},
+        )
+        table_name = f"default.format_table_catalog_{file_format}"
+        self.rest_catalog.drop_table(table_name, True)
+        self.rest_catalog.create_table(table_name, schema, False)
+        self.assertIn(f"format_table_catalog_{file_format}", self.rest_catalog.list_tables("default"))
+        table = self.rest_catalog.get_table(table_name)
+        self.assertIsInstance(table, FormatTable)
+
+        self.rest_catalog.drop_table(table_name, False)
+        with self.assertRaises(TableNotExistException):
+            self.rest_catalog.get_table(table_name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a sizable new table type with filesystem I/O and data format handling (PyArrow/Pandas), which could impact correctness and performance of reads/writes and partition overwrite behavior despite good test coverage.
> 
> **Overview**
> Adds **REST support for `format-table`** by teaching `RESTCatalog.load_table()` to detect `CoreOptions.TYPE == "format-table"` and instantiate a new `FormatTable` instead of a `FileStoreTable`.
> 
> Introduces a new `pypaimon.table.format` module implementing format-table scanning/reading/writing: recursive file-based splits, Arrow/Pandas reads for Parquet/CSV/JSON/ORC/TEXT (with projection/limit and schema-typed partition columns), and batch writes with optional full/partition overwrite.
> 
> Extends predicate utilities with `extract_partition_spec_from_predicate()` to turn equality predicates into partition specs (used by `FormatReadBuilder.with_filter()`), and adds comprehensive REST tests covering read/write across formats, partition filtering, overwrite semantics, and limits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 540f303b244ba5021bc7cd96c4408f298e2b8010. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->