### PR TITLE
[python] Python BTree index reader supports INT and BIGINT

### DIFF
--- a/paimon-python/pypaimon/globalindex/btree/block_reader.py
+++ b/paimon-python/pypaimon/globalindex/btree/block_reader.py
@@ -223,7 +223,7 @@ class BlockIterator:
             
             self.input.set_position(self.reader.seek_to(mid))
             mid_entry = self.read_entry()
-            compare = self.reader.comparator(mid_entry.key, target_key) if self.reader.comparator else -1
+            compare = self.reader.comparator(mid_entry.key, target_key)
             
             if compare == 0:
                 self.polled = mid_entry

--- a/paimon-python/pypaimon/globalindex/global_index_evaluator.py
+++ b/paimon-python/pypaimon/globalindex/global_index_evaluator.py
@@ -18,15 +18,13 @@
 
 """Global index evaluator for filtering data using global indexes."""
 
-from typing import Callable, Collection, Dict, List, Optional, TYPE_CHECKING
+from typing import Callable, Collection, Dict, List, Optional
 
 from pypaimon.globalindex.global_index_reader import GlobalIndexReader, FieldRef
 from pypaimon.globalindex.global_index_result import GlobalIndexResult
-
-if TYPE_CHECKING:
-    from pypaimon.common.predicate import Predicate
-    from pypaimon.globalindex.vector_search import VectorSearch
-    from pypaimon.schema.data_types import DataField
+from pypaimon.common.predicate import Predicate
+from pypaimon.globalindex.vector_search import VectorSearch
+from pypaimon.schema.data_types import DataField
 
 
 class GlobalIndexEvaluator:
@@ -36,8 +34,8 @@ class GlobalIndexEvaluator:
 
     def __init__(
         self,
-        fields: List['DataField'],
-        readers_function: Callable[[int], Collection[GlobalIndexReader]]
+        fields: List[DataField],
+        readers_function: Callable[[DataField], Collection[GlobalIndexReader]]
     ):
         self._fields = fields
         self._field_by_name = {f.name: f for f in fields}
@@ -46,8 +44,8 @@ class GlobalIndexEvaluator:
 
     def evaluate(
         self,
-        predicate: Optional['Predicate'],
-        vector_search: Optional['VectorSearch']
+        predicate: Optional[Predicate],
+        vector_search: Optional[VectorSearch]
     ) -> Optional[GlobalIndexResult]:
         compound_result: Optional[GlobalIndexResult] = None
         
@@ -64,7 +62,7 @@ class GlobalIndexEvaluator:
             field_id = field.id
             readers = self._index_readers_cache.get(field_id)
             if readers is None:
-                readers = self._readers_function(field_id)
+                readers = self._readers_function(field)
                 self._index_readers_cache[field_id] = readers
             
             # If we have a compound result from predicates, use it to filter vector search
@@ -87,7 +85,7 @@ class GlobalIndexEvaluator:
         
         return compound_result
 
-    def _visit_predicate(self, predicate: 'Predicate') -> Optional[GlobalIndexResult]:
+    def _visit_predicate(self, predicate: Predicate) -> Optional[GlobalIndexResult]:
         """Visit a predicate and return the index result."""
         if predicate.method == 'and':
             compound_result: Optional[GlobalIndexResult] = None
@@ -121,7 +119,7 @@ class GlobalIndexEvaluator:
             # Leaf predicate
             return self._visit_leaf_predicate(predicate)
 
-    def _visit_leaf_predicate(self, predicate: 'Predicate') -> Optional[GlobalIndexResult]:
+    def _visit_leaf_predicate(self, predicate: Predicate) -> Optional[GlobalIndexResult]:
         """Visit a leaf predicate and return the index result."""
         field = self._field_by_name.get(predicate.field)
         if field is None:
@@ -130,7 +128,7 @@ class GlobalIndexEvaluator:
         field_id = field.id
         readers = self._index_readers_cache.get(field_id)
         if readers is None:
-            readers = self._readers_function(field_id)
+            readers = self._readers_function(field)
             self._index_readers_cache[field_id] = readers
         
         field_ref = FieldRef(predicate.index, predicate.field, str(field.type))
@@ -155,7 +153,7 @@ class GlobalIndexEvaluator:
     def _visit_function(
         self,
         reader: GlobalIndexReader,
-        predicate: 'Predicate',
+        predicate: Predicate,
         field_ref: FieldRef
     ) -> Optional[GlobalIndexResult]:
         """Visit a predicate function with the given reader."""


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core B-tree index lookup/range logic and changes numeric key encoding, which could break index compatibility or query correctness if the on-disk format/comparator expectations are wrong.
> 
> **Overview**
> Extends Python B-tree global index reading to support non-string keys by introducing type-driven key serialization (`create_serializer`) for `INT`/`BIGINT` and wiring it through `GlobalIndexScanBuilder`/`GlobalIndexEvaluator`.
> 
> Updates the B-tree reader internals to rely on the provided comparator for seeks and range scans (dropping raw byte-range comparisons), and aligns integer/long serialization endianness with the on-disk format.
> 
> Expands Java↔Python E2E tests to create/read B-tree indexed tables for `STRING`, `INT`, and `BIGINT` keys and asserts index-based reads for each type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aefae9c687c84321bc596f4cc08cb91b6e95fb82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->