### PR TITLE
[python] support drop_partitions for rest catalog

### DIFF
--- a/paimon-python/pypaimon/catalog/catalog.py
+++ b/paimon-python/pypaimon/catalog/catalog.py
@@ -17,7 +17,7 @@
 #################################################################################
 
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from pypaimon.common.identifier import Identifier
 from pypaimon.schema.schema import Schema
@@ -94,3 +94,12 @@ class Catalog(ABC):
             True if commit was successful, False otherwise
 
         """
+
+    def drop_partitions(
+        self,
+        identifier: Union[str, Identifier],
+        partitions: List[Dict[str, str]],
+    ) -> None:
+        raise NotImplementedError(
+            "drop_partitions is not supported by this catalog. Use REST catalog for partition drop."
+        )

--- a/paimon-python/pypaimon/catalog/rest/rest_catalog.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_catalog.py
@@ -214,6 +214,22 @@ class RESTCatalog(Catalog):
         except ForbiddenException as e:
             raise TableNoPermissionException(identifier) from e
 
+    def drop_partitions(
+        self,
+        identifier: Union[str, Identifier],
+        partitions: List[Dict[str, str]],
+    ) -> None:
+        if not isinstance(identifier, Identifier):
+            identifier = Identifier.from_string(identifier)
+        if not partitions:
+            raise ValueError("Partitions list cannot be empty.")
+        table = self.get_table(identifier)
+        commit = table.new_batch_write_builder().new_commit()
+        try:
+            commit.truncate_partitions(partitions)
+        finally:
+            commit.close()
+
     def alter_table(
         self,
         identifier: Union[str, Identifier],

--- a/paimon-python/pypaimon/catalog/rest/rest_catalog.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_catalog.py
@@ -224,6 +224,11 @@ class RESTCatalog(Catalog):
         if not partitions:
             raise ValueError("Partitions list cannot be empty.")
         table = self.get_table(identifier)
+        if isinstance(table, FormatTable):
+            raise ValueError(
+                "drop_partitions is not supported for format tables. "
+                "Only Paimon (FileStore) tables support partition drop."
+            )
         commit = table.new_batch_write_builder().new_commit()
         try:
             commit.truncate_partitions(partitions)

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
 from pypaimon.write.commit_message import CommitMessage
@@ -79,6 +79,10 @@ class TableCommit:
 class BatchTableCommit(TableCommit):
     def commit(self, commit_messages: List[CommitMessage]):
         self._commit(commit_messages, BATCH_COMMIT_IDENTIFIER)
+
+    def truncate_partitions(self, partitions: List[Dict[str, str]]) -> None:
+        self._check_committed()
+        self.file_store_commit.drop_partitions(partitions, BATCH_COMMIT_IDENTIFIER)
 
 
 class StreamTableCommit(TableCommit):


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core commit/snapshot-writing logic (`FileStoreCommit._try_commit`) and introduces partition-deletion behavior, which could affect data retention and reader correctness if predicates or empty-commit handling are wrong.
> 
> **Overview**
> Adds `drop_partitions` support to the Python REST catalog API, implemented as a batch commit `OVERWRITE` that deletes data for the specified partition specs (with guards for empty input and non-FileStore/`FormatTable` tables).
> 
> Extends the write/commit pipeline with `BatchTableCommit.truncate_partitions()` and `FileStoreCommit.drop_partitions()` (including partition-key validation and skipping commits when no matching entries exist to avoid empty snapshot/manifest issues), and adds REST integration tests covering success, missing table, and empty partition list cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 740341d5dd49b4b3992880da6b761f270a1dbf43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->