### PR TITLE
[python] support write tensorflow dataset into Paimon table

### DIFF
--- a/paimon-python/pypaimon/tests/tf_write_test.py
+++ b/paimon-python/pypaimon/tests/tf_write_test.py
@@ -1,0 +1,267 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.schema.data_types import PyarrowFieldParser
+
+_SUBPROCESS_ENV = {**os.environ, "CUDA_VISIBLE_DEVICES": "", "TF_WRITE_TEST_SUBPROCESS": "1"}
+
+
+def _tf_bootstrap_script(test_name):
+    """Run TF test in subprocess with TensorFlow imported FIRST (before pypaimon) to avoid mutex deadlock."""
+    return """
+import os
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+import sys
+sys.path.insert(0, ".")
+import tensorflow  # noqa: E402 - must be before pypaimon
+import unittest
+from pypaimon.tests.tf_write_test import TfWriteTest
+suite = unittest.defaultTestLoader.loadTestsFromName(%s, TfWriteTest)
+runner = unittest.TextTestRunner()
+result = runner.run(suite)
+sys.exit(0 if result.wasSuccessful() else 1)
+""" % repr(test_name)
+
+
+def _tf_diag(msg):
+    if os.environ.get("TF_WRITE_TEST_VERBOSE") == "1":
+        print("[tf_write_test] " + msg, flush=True)
+
+
+def _tf_subprocess_skip_on_mutex(result, err_msg):
+    if result.returncode == 0:
+        return
+    out = err_msg or (result.stdout or b"").decode() + (result.stderr or b"").decode()
+    out_lower = out.lower()
+    if (
+        "mutex" in out_lower
+        or "libc++abi" in out_lower
+        or "invalid argument" in out_lower
+        or result.returncode in (-6, -11)  # SIGABRT, SIGSEGV
+    ):
+        raise unittest.SkipTest("Skipped on local macOS: TF mutex/abort.")
+    raise AssertionError(err_msg or "subprocess exited with %s" % result.returncode)
+
+
+def _tf_test_cwd():
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+_tf_import_ok_cache = None
+
+
+def _tf_import_ok(timeout_sec=15):
+    global _tf_import_ok_cache
+    if _tf_import_ok_cache is not None:
+        return _tf_import_ok_cache
+    try:
+        subprocess.run(
+            [sys.executable, "-c", "import tensorflow"],
+            env={**os.environ, "CUDA_VISIBLE_DEVICES": ""},
+            timeout=timeout_sec,
+            capture_output=True,
+            cwd=_tf_test_cwd(),
+        )
+        _tf_import_ok_cache = True
+        return True
+    except subprocess.TimeoutExpired:
+        _tf_import_ok_cache = False
+        return False
+
+
+class TfWriteTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.warehouse = os.path.join(self.temp_dir, "warehouse")
+        os.makedirs(self.warehouse, exist_ok=True)
+        self.catalog = CatalogFactory.create({"warehouse": self.warehouse})
+        self.catalog.create_database("default", ignore_if_exists=True)
+        self.pa_schema = pa.schema([
+            ("id", pa.int64()),
+            ("name", pa.string()),
+            ("value", pa.float64()),
+        ])
+        self.schema = Schema.from_pyarrow_schema(
+            self.pa_schema,
+            partition_keys=None,
+            primary_keys=["id"],
+            options={"bucket": "2"},
+            comment="test table",
+        )
+        self.table_identifier = "default.tf_write_test_table"
+        self.catalog.create_table(self.table_identifier, self.schema, ignore_if_exists=False)
+        self.table = self.catalog.get_table(self.table_identifier)
+
+    def tearDown(self):
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def test_write_tf(self):
+        if os.environ.get("TF_WRITE_TEST_SUBPROCESS") != "1":
+            _tf_diag("main: probing TF import")
+            if not _tf_import_ok():
+                self.skipTest("Skipped on local macOS: TF import blocks.")
+            _tf_diag("main: spawning subprocess (TF-first bootstrap) for test_write_tf")
+            capture = os.environ.get("TF_WRITE_TEST_VERBOSE") != "1"
+            result = subprocess.run(
+                [sys.executable, "-c", _tf_bootstrap_script("test_write_tf")],
+                env=_SUBPROCESS_ENV,
+                timeout=120,
+                capture_output=capture,
+                cwd=_tf_test_cwd(),
+            )
+            _tf_diag("main: subprocess returned")
+            err_msg = (result.stdout or b"").decode() + (result.stderr or b"").decode() if capture else ""
+            if result.returncode != 0:
+                _tf_subprocess_skip_on_mutex(result, err_msg)
+            return
+        _tf_diag("subprocess: importing tensorflow")
+        import tensorflow as tf
+        _tf_diag("subprocess: creating dataset (unbatch)")
+        ds = tf.data.Dataset.from_tensor_slices({
+            "id": [1, 2, 3],
+            "name": ["a", "b", "c"],
+            "value": [1.0, 2.0, 3.0],
+        })
+        builder = self.table.new_batch_write_builder()
+        table_write = builder.new_write()
+        _tf_diag("subprocess: write_tf (first batch)")
+        table_write.write_tf(ds)
+        table_write.close()
+        _tf_diag("subprocess: reading back")
+        read_builder = self.table.new_read_builder()
+        table_read = read_builder.new_read()
+        splits = read_builder.new_scan().plan().splits()
+        actual = table_read.to_arrow(splits)
+        self.assertIsNotNone(actual)
+        self.assertEqual(actual.num_rows, 3)
+        actual_sorted = actual.sort_by("id")
+        self.assertEqual(actual_sorted.column("id").to_pylist(), [1, 2, 3])
+        self.assertEqual(actual_sorted.column("name").to_pylist(), ["a", "b", "c"])
+        self.assertEqual(actual_sorted.column("value").to_pylist(), [1.0, 2.0, 3.0])
+        _tf_diag("subprocess: creating batched dataset")
+        ds_batch = tf.data.Dataset.from_tensor_slices({
+            "id": [4, 5, 6, 7, 8],
+            "name": ["d", "e", "f", "g", "h"],
+            "value": [4.0, 5.0, 6.0, 7.0, 8.0],
+        }).batch(2)
+        builder2 = self.table.new_batch_write_builder()
+        table_write2 = builder2.new_write()
+        _tf_diag("subprocess: write_tf (batched)")
+        table_write2.write_tf(ds_batch)
+        table_write2.close()
+        actual2 = table_read.to_arrow(splits)
+        self.assertEqual(actual2.num_rows, 8)
+        actual2_sorted = actual2.sort_by("id")
+        self.assertEqual(actual2_sorted.column("id").to_pylist(), [1, 2, 3, 4, 5, 6, 7, 8])
+        _tf_diag("subprocess: test_write_tf done")
+
+    def test_write_tf_overwrite(self):
+        if os.environ.get("TF_WRITE_TEST_SUBPROCESS") != "1":
+            _tf_diag("main: probing TF import")
+            if not _tf_import_ok():
+                self.skipTest("Skipped on local macOS: TF import blocks.")
+            _tf_diag("main: spawning subprocess (TF-first bootstrap) for test_write_tf_overwrite")
+            capture = os.environ.get("TF_WRITE_TEST_VERBOSE") != "1"
+            result = subprocess.run(
+                [sys.executable, "-c", _tf_bootstrap_script("test_write_tf_overwrite")],
+                env=_SUBPROCESS_ENV,
+                timeout=120,
+                capture_output=capture,
+                cwd=_tf_test_cwd(),
+            )
+            _tf_diag("main: subprocess returned")
+            err_msg = (result.stdout or b"").decode() + (result.stderr or b"").decode() if capture else ""
+            if result.returncode != 0:
+                _tf_subprocess_skip_on_mutex(result, err_msg)
+            return
+        _tf_diag("subprocess: importing tensorflow")
+        import tensorflow as tf
+        _tf_diag("subprocess: creating ds1")
+        ds1 = tf.data.Dataset.from_tensor_slices({
+            "id": [1, 2],
+            "name": ["x", "y"],
+            "value": [10.0, 20.0],
+        })
+        builder1 = self.table.new_batch_write_builder()
+        table_write1 = builder1.new_write()
+        _tf_diag("subprocess: write_tf(ds1)")
+        table_write1.write_tf(ds1)
+        table_write1.close()
+
+        _tf_diag("subprocess: creating ds2")
+        ds2 = tf.data.Dataset.from_tensor_slices({
+            "id": [3, 4],
+            "name": ["p", "q"],
+            "value": [30.0, 40.0],
+        })
+        builder2 = self.table.new_batch_write_builder()
+        table_write2 = builder2.new_write()
+        _tf_diag("subprocess: write_tf(ds2, overwrite=True)")
+        table_write2.write_tf(ds2, overwrite=True)
+        table_write2.close()
+
+        _tf_diag("subprocess: reading back")
+        read_builder = self.table.new_read_builder()
+        table_read = read_builder.new_read()
+        splits = read_builder.new_scan().plan().splits()
+        actual = table_read.to_arrow(splits)
+        self.assertIsNotNone(actual)
+        self.assertEqual(actual.num_rows, 2)
+        actual_sorted = actual.sort_by("id")
+        self.assertEqual(actual_sorted.column("id").to_pylist(), [3, 4])
+        self.assertEqual(actual_sorted.column("name").to_pylist(), ["p", "q"])
+        self.assertEqual(actual_sorted.column("value").to_pylist(), [30.0, 40.0])
+        _tf_diag("subprocess: test_write_tf_overwrite done")
+
+    def test_tf_batch_to_arrow(self):
+        import numpy as np
+        from pypaimon.write.tf_write import _tf_batch_to_arrow
+
+        pa_schema = PyarrowFieldParser.from_paimon_schema(self.table.table_schema.fields)
+        batch = {
+            "id": np.array([1, 2, 3], dtype=np.int64),
+            "name": np.array(["a", "b", "c"]),
+            "value": np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        }
+        record_batch = _tf_batch_to_arrow(batch, pa_schema)
+        self.assertEqual(record_batch.num_rows, 3)
+        self.assertEqual(record_batch.schema.names, ["id", "name", "value"])
+        self.assertEqual(record_batch.column("id").to_pylist(), [1, 2, 3])
+        self.assertEqual(record_batch.column("name").to_pylist(), ["a", "b", "c"])
+        self.assertEqual(record_batch.column("value").to_pylist(), [1.0, 2.0, 3.0])
+        batch_missing = {"id": np.array([1, 2]), "value": np.array([1.0, 2.0], dtype=np.float64)}
+        with self.assertRaises(ValueError) as ctx:
+            _tf_batch_to_arrow(batch_missing, pa_schema)
+        self.assertIn("name", str(ctx.exception))
+        self.assertIn("missing column", str(ctx.exception).lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/write/table_write.py
+++ b/paimon-python/pypaimon/write/table_write.py
@@ -80,7 +80,7 @@ class TableWrite:
     ) -> None:
         """
         Write a Ray Dataset to Paimon table.
-        
+
         Args:
             dataset: Ray Dataset to write. This is a distributed data collection
                 from Ray Data (ray.data.Dataset).
@@ -101,17 +101,6 @@ class TableWrite:
     def write_tf(self, dataset, *, overwrite: bool = False) -> None:
         """
         Write a TensorFlow Dataset to this Paimon table.
-
-        Use this API instead of manual multi-process write to avoid Paimon commit
-        conflicts: each replica writes its shard; the chief collects commit messages
-        from all replicas and runs a single commit (no concurrent commits).
-
-        Uses the current TF distribution strategy (e.g. get_strategy(), MirroredStrategy).
-        The first batch may be slow (several seconds) due to TensorFlow initialization;
-        if you do not need GPU for this write, set env CUDA_VISIBLE_DEVICES="" to avoid
-        GPU init and potential stalls. For better performance: keep the dataset on CPU
-        (GPU .numpy() triggers device-to-host copy); use larger batch_size (e.g. 4096).
-
         Args:
             dataset: tf.data.Dataset (dict of column name -> Tensor per batch).
             overwrite: Whether to overwrite existing data. Defaults to False.

--- a/paimon-python/pypaimon/write/tf_write.py
+++ b/paimon-python/pypaimon/write/tf_write.py
@@ -81,12 +81,7 @@ def write_tf_dataset(
     Write a TensorFlow Dataset to a Paimon table.
 
     Each replica writes its shard via write_arrow_batch. The chief collects
-    commit messages from all replicas and runs a single commit. Works with
-    single process (1 replica) or multi-replica (e.g. MirroredStrategy).
-
-    On commit failure, TableCommit aborts the commit messages (same as write_ray);
-    table_commit is always closed in finally.
-
+    commit messages from all replicas and runs a single commit.
     Args:
         table: Paimon table (from catalog.get_table(...)).
         dataset: tf.data.Dataset whose elements are dicts of column name -> Tensor,

--- a/paimon-python/pypaimon/write/tf_write.py
+++ b/paimon-python/pypaimon/write/tf_write.py
@@ -1,0 +1,146 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from typing import TYPE_CHECKING, Any, Dict, List
+
+import pyarrow as pa
+
+from pypaimon.schema.data_types import PyarrowFieldParser
+
+if TYPE_CHECKING:
+    from pypaimon.table.table import Table
+from pypaimon.write.commit_message import CommitMessage
+
+
+def _tf_batch_to_arrow(batch: Any, pa_schema: pa.Schema) -> pa.RecordBatch:
+    """
+    Convert one batch from tf.data.Dataset (dict of tensors) to pyarrow.RecordBatch.
+    Uses zero-copy from numpy to Arrow when types match (1D primitive columns).
+    """
+    import numpy as np
+
+    names = pa_schema.names
+    arrays = []
+    for name in names:
+        if name not in batch:
+            raise ValueError(f"Batch missing column '{name}'; got keys: {list(batch.keys())}")
+        t = batch[name]
+        if hasattr(t, "numpy"):
+            arr = t.numpy()
+        else:
+            arr = np.asarray(t)
+        if arr.ndim == 0:
+            arr = np.expand_dims(arr, 0)
+        elif arr.ndim > 1:
+            # Nested/high-dim: Arrow needs list-of-rows; tolist() is slow for large arrays
+            pa_type = pa_schema.field(name).type
+            try:
+                pa_arr = pa.array(arr.tolist(), type=pa_type)
+            except (pa.ArrowInvalid, pa.ArrowTypeError):
+                pa_arr = pa.array(np.asarray(arr.tolist()), type=pa_type)
+            arrays.append(pa_arr)
+            continue
+
+        pa_type = pa_schema.field(name).type
+        # Zero-copy path: pa.array(arr) without type= lets PyArrow reuse numpy buffer when possible
+        try:
+            pa_arr = pa.array(arr)
+            if pa_arr.type != pa_type:
+                pa_arr = pa_arr.cast(pa_type)
+        except (pa.ArrowInvalid, pa.ArrowTypeError):
+            try:
+                pa_arr = pa.array(arr, type=pa_type)
+            except (pa.ArrowInvalid, pa.ArrowTypeError):
+                pa_arr = pa.array(arr.tolist(), type=pa_type)
+        arrays.append(pa_arr)
+    return pa.RecordBatch.from_arrays(arrays, schema=pa_schema)
+
+
+def write_tf_dataset(
+    table: "Table",
+    dataset: Any,  # tf.data.Dataset
+    strategy: Any,  # tf.distribute.Strategy
+    *,
+    overwrite: bool = False,
+) -> None:
+    """
+    Write a TensorFlow Dataset to a Paimon table.
+
+    Each replica writes its shard via write_arrow_batch. The chief collects
+    commit messages from all replicas and runs a single commit. Works with
+    single process (1 replica) or multi-replica (e.g. MirroredStrategy).
+
+    On commit failure, TableCommit aborts the commit messages (same as write_ray);
+    table_commit is always closed in finally.
+
+    Args:
+        table: Paimon table (from catalog.get_table(...)).
+        dataset: tf.data.Dataset whose elements are dicts of column name -> Tensor,
+                 matching the table schema.
+        strategy: tf.distribute.Strategy (e.g. from get_strategy(), MirroredStrategy()).
+        overwrite: If True, overwrite existing data.
+    """
+    import tensorflow as tf
+
+    pa_schema = PyarrowFieldParser.from_paimon_schema(table.table_schema.fields)
+
+    def _replica_id(ctx) -> int:
+        x = ctx.replica_id_in_sync_group
+        return int(x.numpy()) if hasattr(x, "numpy") else int(x)
+
+    replica_writes: Dict[int, Any] = {}
+
+    def write_batch_fn(batch: Any) -> None:
+        ctx = tf.distribute.get_replica_context()
+        rid = _replica_id(ctx)
+        if rid not in replica_writes:
+            builder = table.new_batch_write_builder()
+            if overwrite:
+                builder = builder.overwrite()
+            replica_writes[rid] = builder.new_write()
+        pa_batch = _tf_batch_to_arrow(batch, pa_schema)
+        replica_writes[rid].write_arrow_batch(pa_batch)
+
+    def prepare_commit_per_replica() -> List[CommitMessage]:
+        """Each replica returns its own commit messages (prepare_commit); chief will merge and commit once."""
+        ctx = tf.distribute.get_replica_context()
+        rid = _replica_id(ctx)
+        tw = replica_writes[rid]
+        msgs = tw.prepare_commit()
+        tw.close()
+        return msgs
+
+    dist_dataset = strategy.experimental_distribute_dataset(dataset)
+
+    for batch in dist_dataset:
+        strategy.run(write_batch_fn, args=(batch,))
+
+    per_replica_messages = strategy.run(prepare_commit_per_replica)
+    local_results = strategy.experimental_local_results(per_replica_messages)
+    merged: List[CommitMessage] = []
+    for lst in local_results:
+        merged.extend(lst)
+
+    builder = table.new_batch_write_builder()
+    if overwrite:
+        builder = builder.overwrite()
+    table_commit = builder.new_commit()
+    try:
+        table_commit.commit(merged)
+    finally:
+        # On commit failure, TableCommit._commit already calls file_store_commit.abort(merged)
+        table_commit.close()

--- a/paimon-python/pypaimon/write/tf_write.py
+++ b/paimon-python/pypaimon/write/tf_write.py
@@ -104,8 +104,6 @@ def write_tf_dataset(
         rid = _replica_id(ctx)
         if rid not in replica_writes:
             builder = table.new_batch_write_builder()
-            if overwrite:
-                builder = builder.overwrite()
             replica_writes[rid] = builder.new_write()
         pa_batch = _tf_batch_to_arrow(batch, pa_schema)
         replica_writes[rid].write_arrow_batch(pa_batch)

--- a/paimon-python/setup.py
+++ b/paimon-python/setup.py
@@ -57,6 +57,9 @@ setup(
         'torch': [
             'torch',
         ],
+        'tensorflow': [
+            'tensorflow>=2.0',
+        ],
         # faiss-cpu: optional for vector ANN index. 1.7.x has no wheel for 3.12+; 3.12+ use 1.10+.
         'faiss': [
             'faiss-cpu==1.7.2; python_version >= "3.6" and python_version < "3.7"',
@@ -66,6 +69,7 @@ setup(
         'all': [
             'ray>=2.10,<3; python_version>="3.7"',
             'torch',
+            'tensorflow>=2.0',
             'faiss-cpu==1.7.2; python_version >= "3.6" and python_version < "3.7"',
             'faiss-cpu==1.7.4; python_version >= "3.7" and python_version < "3.12"',
             'faiss-cpu>=1.10,<2; python_version >= "3.12"',


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new TensorFlow write/commit path that touches batching, distributed execution, and overwrite behavior; correctness depends on schema/type conversions and commit-message aggregation across replicas.
> 
> **Overview**
> Adds TensorFlow ingestion support by introducing `TableWrite.write_tf()` and new `write_tf_dataset()` logic that converts `tf.data.Dataset` batches into Arrow (`_tf_batch_to_arrow`) and commits once after collecting per-replica `CommitMessage`s from distributed strategies, with optional overwrite.
> 
> Extends packaging with a `tensorflow` extra (and includes it in `all`) and adds `tf_write_test.py` coverage for unbatched/batched writes, overwrite semantics, and batch-to-Arrow conversion, running TF-first in a subprocess to avoid macOS TF mutex/import issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e12075ec7774c6a835a3fe122da97016ce03337. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->