### PR TITLE
[python/hotfix] fix nullable info for _ROW_ID and _SEQUENCE_NUMBER mi…

### DIFF
--- a/paimon-python/pypaimon/read/reader/concat_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/concat_batch_reader.py
@@ -184,8 +184,7 @@ class DataEvolutionMergeReader(RecordBatchReader):
                 names.append(batches[batch_index].schema.names[field_index])
         if columns:
             if self.schema is not None and len(columns) == len(self.schema):
-                schema_fields = [self.schema.field(i) for i in range(len(columns))]
-                return pa.RecordBatch.from_arrays(columns, schema=pa.schema(schema_fields))
+                return pa.RecordBatch.from_arrays(columns, schema=self.schema)
             return pa.RecordBatch.from_arrays(columns, names)
         return None
 

--- a/paimon-python/pypaimon/read/reader/data_file_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/data_file_batch_reader.py
@@ -135,18 +135,7 @@ class DataFileBatchReader(RecordBatchReader):
             # Create a new array that fills with max_sequence_number
             arrays[idx] = pa.repeat(self.max_sequence_number, record_batch.num_rows)
 
-        names = record_batch.schema.names
-        table = None
-        for i, name in enumerate(names):
-            field = pa.field(
-                name, arrays[i].type,
-                nullable=record_batch.schema.field(name).nullable
-            )
-            if table is None:
-                table = pa.table({name: arrays[i]}, schema=pa.schema([field]))
-            else:
-                table = table.append_column(field, arrays[i])
-        return table.to_batches()[0]
+        return pa.RecordBatch.from_arrays(arrays, schema=record_batch.schema)
 
     def close(self) -> None:
         self.format_reader.close()

--- a/paimon-python/pypaimon/read/reader/data_file_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/data_file_batch_reader.py
@@ -135,7 +135,18 @@ class DataFileBatchReader(RecordBatchReader):
             # Create a new array that fills with max_sequence_number
             arrays[idx] = pa.repeat(self.max_sequence_number, record_batch.num_rows)
 
-        return pa.RecordBatch.from_arrays(arrays, schema=record_batch.schema)
+        names = record_batch.schema.names
+        table = None
+        for i, name in enumerate(names):
+            field = pa.field(
+                name, arrays[i].type,
+                nullable=record_batch.schema.field(name).nullable
+            )
+            if table is None:
+                table = pa.table({name: arrays[i]}, schema=pa.schema([field]))
+            else:
+                table = table.append_column(field, arrays[i])
+        return table.to_batches()[0]
 
     def close(self) -> None:
         self.format_reader.close()

--- a/paimon-python/pypaimon/read/reader/data_file_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/data_file_batch_reader.py
@@ -135,7 +135,9 @@ class DataFileBatchReader(RecordBatchReader):
             # Create a new array that fills with max_sequence_number
             arrays[idx] = pa.repeat(self.max_sequence_number, record_batch.num_rows)
 
-        return pa.RecordBatch.from_arrays(arrays, names=record_batch.schema.names)
+        names = record_batch.schema.names
+        fields = [pa.field(name, arrays[i].type, nullable=record_batch.schema.field(name).nullable) for i, name in enumerate(names)]
+        return pa.RecordBatch.from_arrays(arrays, schema=pa.schema(fields))
 
     def close(self) -> None:
         self.format_reader.close()

--- a/paimon-python/pypaimon/read/reader/data_file_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/data_file_batch_reader.py
@@ -136,7 +136,10 @@ class DataFileBatchReader(RecordBatchReader):
             arrays[idx] = pa.repeat(self.max_sequence_number, record_batch.num_rows)
 
         names = record_batch.schema.names
-        fields = [pa.field(name, arrays[i].type, nullable=record_batch.schema.field(name).nullable) for i, name in enumerate(names)]
+        fields = [
+            pa.field(name, arrays[i].type, nullable=record_batch.schema.field(name).nullable)
+            for i, name in enumerate(names)
+        ]
         return pa.RecordBatch.from_arrays(arrays, schema=pa.schema(fields))
 
     def close(self) -> None:

--- a/paimon-python/pypaimon/read/reader/format_pyarrow_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_pyarrow_reader.py
@@ -62,18 +62,20 @@ class FormatPyArrowReader(RecordBatchReader):
 
             # Reconstruct the batch with all fields in the correct order
             all_columns = []
+            out_fields = []
             for field_name in self.read_fields:
                 if field_name in self.existing_fields:
                     # Get the column from the existing batch
                     column_idx = self.existing_fields.index(field_name)
                     all_columns.append(batch.column(column_idx))
+                    out_fields.append(batch.schema.field(column_idx))
                 else:
                     # Get the column from missing fields
                     column_idx = self.missing_fields.index(field_name)
                     all_columns.append(missing_columns[column_idx])
-
+                    out_fields.append(pa.field(field_name, pa.null(), nullable=True))
             # Create a new RecordBatch with all columns
-            return pa.RecordBatch.from_arrays(all_columns, names=self.read_fields)
+            return pa.RecordBatch.from_arrays(all_columns, schema=pa.schema(out_fields))
 
         except StopIteration:
             return None

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -52,7 +52,7 @@ from pypaimon.read.reader.shard_batch_reader import ShardBatchReader
 from pypaimon.read.reader.sort_merge_reader import SortMergeReaderWithMinHeap
 from pypaimon.read.split import Split
 from pypaimon.read.sliced_split import SlicedSplit
-from pypaimon.schema.data_types import DataField
+from pypaimon.schema.data_types import DataField, PyarrowFieldParser
 from pypaimon.table.special_fields import SpecialFields
 
 KEY_PREFIX = "_KEY_"
@@ -571,7 +571,8 @@ class DataEvolutionSplitRead(SplitRead):
                 if not field.type.nullable:
                     raise ValueError(f"Field {field} is not null but can't find any file contains it.")
 
-        return DataEvolutionMergeReader(row_offsets, field_offsets, file_record_readers)
+        output_schema = PyarrowFieldParser.from_paimon_schema(all_read_fields)
+        return DataEvolutionMergeReader(row_offsets, field_offsets, file_record_readers, schema=output_schema)
 
     def _create_file_reader(self, file: DataFileMeta, read_fields: [str]) -> Optional[RecordReader]:
         """Create a file reader for a single file."""

--- a/paimon-python/pypaimon/tests/data_evolution_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_test.py
@@ -634,3 +634,21 @@ class DataEvolutionTest(unittest.TestCase):
             pa.field('_SEQUENCE_NUMBER', pa.int64(), nullable=False),
         ]))
         self.assertEqual(actual_data, expect_data)
+
+    def test_from_arrays_without_schema(self):
+        schema = pa.schema([
+            ('f0', pa.int8()),
+            pa.field('_ROW_ID', pa.int64(), nullable=False),
+            pa.field('_SEQUENCE_NUMBER', pa.int64(), nullable=False),
+        ])
+        batch = pa.RecordBatch.from_pydict(
+            {'f0': [1], '_ROW_ID': [0], '_SEQUENCE_NUMBER': [1]},
+            schema=schema
+        )
+        self.assertFalse(batch.schema.field('_ROW_ID').nullable)
+        self.assertFalse(batch.schema.field('_SEQUENCE_NUMBER').nullable)
+
+        arrays = list(batch.columns)
+        rebuilt = pa.RecordBatch.from_arrays(arrays, names=batch.schema.names)
+        self.assertTrue(rebuilt.schema.field('_ROW_ID').nullable)
+        self.assertTrue(rebuilt.schema.field('_SEQUENCE_NUMBER').nullable)


### PR DESCRIPTION
…ssing issue

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Arrow batch/schema construction across read/write paths; mistakes could subtly change schema/nullability or column ordering and impact downstream consumers, though scope is limited and covered by updated tests.
> 
> **Overview**
> Ensures `RecordBatch` reconstruction preserves full PyArrow `schema` metadata (not just column names), fixing loss of *non-nullable* info for row-tracking fields like `_ROW_ID` and `_SEQUENCE_NUMBER`.
> 
> This updates multiple readers/writers to build batches/tables with explicit `pa.Schema`/`pa.Field` objects (including nullability) during data evolution merges, missing-field backfills, row-tracking assignment, and primary-key system-field injection, and extends `data_evolution_test` to assert the corrected nullability and demonstrate the regression when using `from_arrays(..., names=...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02a889ce064441612599ba172342aba838155eab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->