### PR TITLE
Pr 7185

### DIFF
--- a/paimon-python/pypaimon/deletionvectors/apply_deletion_vector_reader.py
+++ b/paimon-python/pypaimon/deletionvectors/apply_deletion_vector_reader.py
@@ -23,9 +23,7 @@ from pyarrow import RecordBatch
 from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
 from pypaimon.read.reader.iface.record_iterator import RecordIterator
 from pypaimon.deletionvectors.deletion_vector import DeletionVector
-
-from pyroaring import BitMap
-
+from pypaimon.utils.roaring_bitmap import RoaringBitmap
 from pypaimon.read.reader.iface.record_reader import RecordReader
 
 
@@ -57,10 +55,11 @@ class ApplyDeletionVectorReader(RecordBatchReader):
         if arrow_batch is None:
             return None
         # Remove the deleted rows from the batch
-        range_bitmap = BitMap(
-            range(self._reader.return_batch_pos() - arrow_batch.num_rows, self._reader.return_batch_pos()))
-        intersection_bitmap = range_bitmap - self._deletion_vector.bit_map()
-        added_row_list = [x - (self._reader.return_batch_pos() - arrow_batch.num_rows) for x in
+        range_bitmap = RoaringBitmap()
+        return_batch_pos = self._reader.return_batch_pos()
+        range_bitmap.add_range(return_batch_pos - arrow_batch.num_rows, return_batch_pos - 1)
+        intersection_bitmap = RoaringBitmap.and_(range_bitmap, self._deletion_vector.bit_map())
+        added_row_list = [x - (return_batch_pos - arrow_batch.num_rows) for x in
                           list(intersection_bitmap)]
         return arrow_batch.take(pyarrow.array(added_row_list, type=pyarrow.int32()))
 

--- a/paimon-python/pypaimon/deletionvectors/apply_deletion_vector_reader.py
+++ b/paimon-python/pypaimon/deletionvectors/apply_deletion_vector_reader.py
@@ -58,7 +58,7 @@ class ApplyDeletionVectorReader(RecordBatchReader):
         range_bitmap = RoaringBitmap()
         return_batch_pos = self._reader.return_batch_pos()
         range_bitmap.add_range(return_batch_pos - arrow_batch.num_rows, return_batch_pos - 1)
-        intersection_bitmap = RoaringBitmap.and_(range_bitmap, self._deletion_vector.bit_map())
+        intersection_bitmap = RoaringBitmap.remove_all(range_bitmap, self._deletion_vector.bit_map())
         added_row_list = [x - (return_batch_pos - arrow_batch.num_rows) for x in
                           list(intersection_bitmap)]
         return arrow_batch.take(pyarrow.array(added_row_list, type=pyarrow.int32()))

--- a/paimon-python/pypaimon/deletionvectors/bitmap_deletion_vector.py
+++ b/paimon-python/pypaimon/deletionvectors/bitmap_deletion_vector.py
@@ -18,7 +18,7 @@
 from pypaimon.deletionvectors.deletion_vector import DeletionVector
 import struct
 import zlib
-from pyroaring import BitMap
+from pypaimon.utils.roaring_bitmap import RoaringBitmap
 
 
 class BitmapDeletionVector(DeletionVector):
@@ -31,14 +31,14 @@ class BitmapDeletionVector(DeletionVector):
     MAGIC_NUMBER_SIZE_BYTES = 4
     MAX_VALUE = 2147483647
 
-    def __init__(self, bitmap: BitMap = None):
+    def __init__(self, bitmap: RoaringBitmap = None):
         """
         Initialize a BitmapDeletionVector.
 
         Args:
             bitmap: Optional RoaringBitmap instance. If None, creates an empty bitmap.
         """
-        self._bitmap = bitmap if bitmap is not None else BitMap()
+        self._bitmap = bitmap if bitmap is not None else RoaringBitmap()
 
     def delete(self, position: int) -> None:
         """
@@ -121,7 +121,7 @@ class BitmapDeletionVector(DeletionVector):
         Returns:
             A BitmapDeletionVector instance.
         """
-        bitmap = BitMap.deserialize(data)
+        bitmap = RoaringBitmap.deserialize(data)
         return BitmapDeletionVector(bitmap)
 
     def bit_map(self):

--- a/paimon-python/pypaimon/deletionvectors/deletion_vector.py
+++ b/paimon-python/pypaimon/deletionvectors/deletion_vector.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 
 from pypaimon.common.file_io import FileIO
 from pypaimon.table.source.deletion_file import DeletionFile
+from pypaimon.utils.roaring_bitmap import RoaringBitmap
 
 
 class DeletionVector(ABC):
@@ -28,7 +29,7 @@ class DeletionVector(ABC):
     """
 
     @abstractmethod
-    def bit_map(self):
+    def bit_map(self) -> RoaringBitmap:
         """
         Returns the bitmap of the DeletionVector.
         """

--- a/paimon-python/pypaimon/globalindex/__init__.py
+++ b/paimon-python/pypaimon/globalindex/__init__.py
@@ -30,7 +30,6 @@ from pypaimon.globalindex.global_index_scan_builder import (
     GlobalIndexScanBuilder,
     RowRangeGlobalIndexScanner,
 )
-from pypaimon.globalindex.roaring_bitmap import RoaringBitmap64
 from pypaimon.globalindex.range import Range
 
 __all__ = [
@@ -46,6 +45,5 @@ __all__ = [
     'GlobalIndexEvaluator',
     'GlobalIndexScanBuilder',
     'RowRangeGlobalIndexScanner',
-    'RoaringBitmap64',
     'Range',
 ]

--- a/paimon-python/pypaimon/globalindex/btree/btree_index_reader.py
+++ b/paimon-python/pypaimon/globalindex/btree/btree_index_reader.py
@@ -33,7 +33,7 @@ from pypaimon.globalindex.btree.key_serializer import KeySerializer
 from pypaimon.globalindex.global_index_meta import GlobalIndexIOMeta
 from pypaimon.globalindex.global_index_reader import FieldRef, GlobalIndexReader
 from pypaimon.globalindex.global_index_result import GlobalIndexResult
-from pypaimon.globalindex.roaring_bitmap import RoaringBitmap64
+from pypaimon.utils.roaring_bitmap import RoaringBitmap64
 from pypaimon.globalindex.btree.btree_file_footer import BTreeFileFooter
 from pypaimon.globalindex.btree.sst_file_reader import SstFileReader
 from pypaimon.globalindex.btree.memory_slice_input import MemorySliceInput

--- a/paimon-python/pypaimon/globalindex/faiss/faiss_vector_reader.py
+++ b/paimon-python/pypaimon/globalindex/faiss/faiss_vector_reader.py
@@ -31,7 +31,7 @@ from pypaimon.globalindex.global_index_reader import GlobalIndexReader
 from pypaimon.globalindex.global_index_result import GlobalIndexResult
 from pypaimon.globalindex.global_index_meta import GlobalIndexIOMeta
 from pypaimon.globalindex.vector_search_result import DictBasedScoredIndexResult
-from pypaimon.globalindex.roaring_bitmap import RoaringBitmap64
+from pypaimon.utils.roaring_bitmap import RoaringBitmap64
 from pypaimon.globalindex.faiss.faiss_options import (
     FaissVectorIndexOptions,
     FaissVectorMetric,

--- a/paimon-python/pypaimon/globalindex/global_index_result.py
+++ b/paimon-python/pypaimon/globalindex/global_index_result.py
@@ -19,7 +19,7 @@
 from abc import ABC, abstractmethod
 from typing import Callable, List, Optional
 
-from pypaimon.globalindex.roaring_bitmap import RoaringBitmap64
+from pypaimon.utils.roaring_bitmap import RoaringBitmap64
 from pypaimon.globalindex.range import Range
 
 

--- a/paimon-python/pypaimon/globalindex/vector_search.py
+++ b/paimon-python/pypaimon/globalindex/vector_search.py
@@ -65,7 +65,7 @@ class VectorSearch:
         """
         Create a new VectorSearch with include_row_ids offset to the given range.
         """
-        from pypaimon.globalindex.roaring_bitmap import RoaringBitmap64
+        from pypaimon.utils.roaring_bitmap import RoaringBitmap64
 
         if self.include_row_ids is not None:
             range_bitmap = RoaringBitmap64()

--- a/paimon-python/pypaimon/globalindex/vector_search_result.py
+++ b/paimon-python/pypaimon/globalindex/vector_search_result.py
@@ -22,7 +22,7 @@ from abc import abstractmethod
 from typing import Callable, Dict, Optional
 
 from pypaimon.globalindex.global_index_result import GlobalIndexResult
-from pypaimon.globalindex.roaring_bitmap import RoaringBitmap64
+from pypaimon.utils.roaring_bitmap import RoaringBitmap64
 
 
 # Type alias for score getter function

--- a/paimon-python/pypaimon/utils/roaring_bitmap.py
+++ b/paimon-python/pypaimon/utils/roaring_bitmap.py
@@ -21,7 +21,6 @@ Roaring Bitmap.
 """
 
 from typing import Iterator
-from pyroaring import BitMap64
 
 
 class RoaringBitmap64:
@@ -33,6 +32,7 @@ class RoaringBitmap64:
     """
 
     def __init__(self):
+        from pyroaring import BitMap64
         self._data = BitMap64()
 
     def add(self, value: int) -> None:
@@ -133,6 +133,7 @@ class RoaringBitmap64:
     def deserialize(data: bytes) -> 'RoaringBitmap64':
         """Deserialize a bitmap from bytes."""
         result = RoaringBitmap64()
+        from pyroaring import BitMap64
         result._data = BitMap64.deserialize(data)
         return result
 
@@ -149,3 +150,102 @@ class RoaringBitmap64:
         if len(values) <= 10:
             return f"RoaringBitmap64({values})"
         return f"RoaringBitmap64({len(values)} elements)"
+
+
+class RoaringBitmap:
+    """
+    A 32-bit roaring bitmap implementation.
+
+    This class provides efficient storage and operations for sets of 32-bit integers.
+    It uses pyroaring.BitMap for better performance and memory efficiency.
+    """
+
+    def __init__(self):
+        from pyroaring import BitMap
+        self._data = BitMap()
+
+    def add(self, value: int) -> None:
+        """Add a single value to the bitmap."""
+        self._data.add(value)
+
+    def add_range(self, from_: int, to: int) -> None:
+        """Add a range of values [from_, to] to the bitmap."""
+        self._data.add_range(from_, to + 1)
+
+    def contains(self, value: int) -> bool:
+        """Check if the bitmap contains the given value."""
+        return value in self._data
+
+    def is_empty(self) -> bool:
+        """Check if the bitmap is empty."""
+        return len(self._data) == 0
+
+    def cardinality(self) -> int:
+        """Return the number of elements in the bitmap."""
+        return len(self._data)
+
+    def __iter__(self) -> Iterator[int]:
+        """Iterate over all values in the bitmap in sorted order."""
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        """Return the number of elements in the bitmap."""
+        return len(self._data)
+
+    def __contains__(self, value: int) -> bool:
+        """Check if the bitmap contains the given value."""
+        return self.contains(value)
+
+    def clear(self) -> None:
+        """Clear all values from the bitmap."""
+        self._data.clear()
+
+    def to_list(self) -> list:
+        """Return a sorted list of all values in the bitmap."""
+        return list(self._data)
+
+    @staticmethod
+    def and_(a: 'RoaringBitmap', b: 'RoaringBitmap') -> 'RoaringBitmap':
+        """Return the intersection of two bitmaps."""
+        result = RoaringBitmap()
+        result._data = a._data & b._data
+        return result
+
+    @staticmethod
+    def or_(a: 'RoaringBitmap', b: 'RoaringBitmap') -> 'RoaringBitmap':
+        """Return the union of two bitmaps."""
+        result = RoaringBitmap()
+        result._data = a._data | b._data
+        return result
+
+    @staticmethod
+    def remove_all(a: 'RoaringBitmap', b: 'RoaringBitmap') -> 'RoaringBitmap':
+        result = RoaringBitmap()
+        result._data = a._data - b._data
+        return result
+
+    def serialize(self) -> bytes:
+        """Serialize the bitmap to bytes."""
+        return self._data.serialize()
+
+    @staticmethod
+    def deserialize(data: bytes) -> 'RoaringBitmap':
+        """Deserialize a bitmap from bytes."""
+        result = RoaringBitmap()
+        from pyroaring import BitMap
+        result._data = BitMap.deserialize(data)
+        return result
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, RoaringBitmap):
+            return False
+        return self._data == other._data
+
+    def __hash__(self) -> int:
+        return hash(tuple(sorted(self._data)))
+
+    def __repr__(self) -> str:
+        values = list(self._data)
+        if len(values) <= 10:
+            return f"RoaringBitmap({values})"
+        return f"RoaringBitmap({len(values)} elements)"


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compaction/commit-message rewriting paths (Spark/Flink) and significantly refactors Python scan and bitmap/storage IO behavior, which could affect correctness/performance across multiple runtimes despite being mostly additive and covered by tests.
> 
> **Overview**
> Adds **Spark support for postpone-bucket table compaction** via new `SparkPostponeCompactProcedure` and wires it into `CompactProcedure` when `BucketMode.POSTPONE_MODE` is used; includes new UT coverage that writes to bucket `-2` and verifies compaction results (including partitioned tables, changelog files, and snapshot expiration behavior).
> 
> Moves postpone-bucket configuration into core by adding `CoreOptions.POSTPONE_DEFAULT_BUCKET_NUM` (and generated docs updates), refactors Flink postpone compaction to read this core option, and extracts shared postpone-bucket commit-message rewriting logic into a new core utility `BucketFiles` (used by both Flink and Spark).
> 
> Python changes refactor the read path by replacing `StartingScanner` variants with a single `FileScanner` driven by a manifest supplier (supports incremental-between-timestamp via delta manifests), adds optional manifest `min_row_id/max_row_id` metadata and uses it to prune manifests for data-evolution/vector-search scans, switches bitmap implementations to `pyroaring`-backed wrappers (32/64-bit) and renames vector-search result types, and improves `PyArrowFileIO` handling for OSS + older PyArrow versions with added tests and updated CI lint script to run the new test on Python 3.6.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d44041dccd176c4f392b88976e43163fa591a2c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->