### PR TITLE
Bucket num fix

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -454,11 +454,12 @@ public class JavaPyE2ETest {
                         .as(
                                 "Python wrote row (pk_str_a=%s, pk_str_b=%s, pk_int=%s); "
                                         + "Java read with predicate should return it.",
-                                pkStrA,
-                                pkStrB,
-                                pkInt)
+                                pkStrA, pkStrB, pkInt)
                         .hasSize(1);
-                assertThat(res.get(0)).contains(pkStrA).contains(pkStrB).contains(String.valueOf(pkInt));
+                assertThat(res.get(0))
+                        .contains(pkStrA)
+                        .contains(pkStrB)
+                        .contains(String.valueOf(pkInt));
             }
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -412,31 +412,31 @@ public class JavaPyE2ETest {
                             "+I[4, Broccoli, Vegetable, 1.2, 1970-01-01T00:16:40.003, 1970-01-01T00:33:20.003, (store2, 1004, (Seoul, Korea))]",
                             "+I[5, Chicken, Meat, 5.0, 1970-01-01T00:16:40.004, 1970-01-01T00:33:20.004, (store3, 1005, (NewYork, USA))]",
                             "+I[6, Beef, Meat, 8.0, 1970-01-01T00:16:40.005, 1970-01-01T00:33:20.005, (store3, 1006, (London, UK))]");
-        }
 
-        PredicateBuilder predicateBuilder = new PredicateBuilder(table.rowType());
-        int[] ids = {1, 2, 3, 4, 5, 6};
-        String[] names = {"Apple", "Banana", "Carrot", "Broccoli", "Chicken", "Beef"};
-        for (int i = 0; i < ids.length; i++) {
-            int id = ids[i];
-            String expectedName = names[i];
-            Predicate predicate = predicateBuilder.equal(0, id);
-            ReadBuilder readBuilder = fileStoreTable.newReadBuilder().withFilter(predicate);
-            List<String> byKey =
-                    getResult(
-                            readBuilder.newRead(),
-                            readBuilder.newScan().plan().splits(),
-                            row -> rowToStringWithStruct(row, table.rowType()));
-            List<String> matching =
-                    byKey.stream()
-                            .filter(s -> s.trim().startsWith("+I[" + id + ", "))
-                            .collect(Collectors.toList());
-            assertThat(matching)
-                    .as(
-                            "Python wrote row id=%d; Java read with predicate id=%d should return it.",
-                            id, id)
-                    .hasSize(1);
-            assertThat(matching.get(0)).contains(String.valueOf(id)).contains(expectedName);
+            PredicateBuilder predicateBuilder = new PredicateBuilder(table.rowType());
+            int[] ids = {1, 2, 3, 4, 5, 6};
+            String[] names = {"Apple", "Banana", "Carrot", "Broccoli", "Chicken", "Beef"};
+            for (int i = 0; i < ids.length; i++) {
+                int id = ids[i];
+                String expectedName = names[i];
+                Predicate predicate = predicateBuilder.equal(0, id);
+                ReadBuilder readBuilder = fileStoreTable.newReadBuilder().withFilter(predicate);
+                List<String> byKey =
+                        getResult(
+                                readBuilder.newRead(),
+                                readBuilder.newScan().plan().splits(),
+                                row -> rowToStringWithStruct(row, table.rowType()));
+                List<String> matching =
+                        byKey.stream()
+                                .filter(s -> s.trim().startsWith("+I[" + id + ", "))
+                                .collect(Collectors.toList());
+                assertThat(matching)
+                        .as(
+                                "Python wrote row id=%d; Java read with predicate id=%d should return it.",
+                                id, id)
+                        .hasSize(1);
+                assertThat(matching.get(0)).contains(String.valueOf(id)).contains(expectedName);
+            }
         }
     }
 

--- a/paimon-python/dev/run_mixed_tests.sh
+++ b/paimon-python/dev/run_mixed_tests.sh
@@ -117,12 +117,12 @@ run_python_read_test() {
 
 # Function to run Python Write test for Python-Write-Java-Read scenario
 run_python_write_test() {
-    echo -e "${YELLOW}=== Step 3: Running Python Write Test (test_py_write_read_pk_table, test_py_write_read_pk_table_bucket_num_calculate) ===${NC}"
+    echo -e "${YELLOW}=== Step 3: Running Python Write Test (test_py_write_read_pk_table) ===${NC}"
 
     cd "$PAIMON_PYTHON_DIR"
 
-    # Run the parameterized Python test method for writing data (pk table + bucket num calculate for Python/Java mismatch repro)
-    echo "Running Python test for JavaPyReadWriteTest (test_py_write_read_pk_table, test_py_write_read_pk_table_bucket_num_calculate)..."
+    # Run the parameterized Python test method for writing data (pk table, includes bucket num assertion)
+    echo "Running Python test for JavaPyReadWriteTest (test_py_write_read_pk_table)..."
     if python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest -k "test_py_write_read_pk_table" -v; then
         echo -e "${GREEN}✓ Python write test completed successfully${NC}"
         return 0
@@ -134,7 +134,7 @@ run_python_write_test() {
 
 # Function to run Java Read test for Python-Write-Java-Read scenario
 run_java_read_test() {
-    echo -e "${YELLOW}=== Step 4: Running Java Read Test (testReadPkTable, testReadPkTableBucketNumCalculate, testReadPkTableLance) ===${NC}"
+    echo -e "${YELLOW}=== Step 4: Running Java Read Test (testReadPkTable, testReadPkTableLance) ===${NC}"
 
     cd "$PROJECT_ROOT"
 
@@ -154,18 +154,6 @@ run_java_read_test() {
 
     echo ""
 
-    # Run Java test for bucket_num_calculate table (Python write, Java read with predicate; repro then fix in Python)
-    echo "Running Maven test for JavaPyE2ETest.testReadPkTableBucketNumCalculate (reads mixed_test_pk_table_bucket_num_calculate_*)..."
-    local bucket_num_calculate_result=0
-    if mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testReadPkTableBucketNumCalculate -pl paimon-core -Drun.e2e.tests=true -Dpython.version="$PYTHON_VERSION"; then
-        echo -e "${GREEN}✓ Java read bucket_num_calculate test completed successfully${NC}"
-    else
-        echo -e "${RED}✗ Java read bucket_num_calculate test failed (expected until Python bucket hash aligns with Java)${NC}"
-        bucket_num_calculate_result=1
-    fi
-
-    echo ""
-
     # Run Java test for lance format in paimon-lance
     echo "Running Maven test for JavaPyLanceE2ETest.testReadPkTableLance (Java Read Lance)..."
     echo "Note: Maven may download dependencies on first run, this may take a while..."
@@ -177,7 +165,7 @@ run_java_read_test() {
         lance_result=1
     fi
 
-    if [[ $parquet_result -eq 0 && $bucket_num_calculate_result -eq 0 && $lance_result -eq 0 ]]; then
+    if [[ $parquet_result -eq 0 && $lance_result -eq 0 ]]; then
         return 0
     else
         return 1
@@ -373,15 +361,15 @@ main() {
     fi
 
     if [[ $python_write_result -eq 0 ]]; then
-        echo -e "${GREEN}✓ Python Write Test (test_py_write_read_pk_table, test_py_write_read_pk_table_bucket_num_calculate): PASSED${NC}"
+        echo -e "${GREEN}✓ Python Write Test (test_py_write_read_pk_table): PASSED${NC}"
     else
-        echo -e "${RED}✗ Python Write Test (test_py_write_read_pk_table, test_py_write_read_pk_table_bucket_num_calculate): FAILED${NC}"
+        echo -e "${RED}✗ Python Write Test (test_py_write_read_pk_table): FAILED${NC}"
     fi
 
     if [[ $java_read_result -eq 0 ]]; then
-        echo -e "${GREEN}✓ Java Read Test (Parquet/Orc/Avro + bucket_num_calculate + Lance): PASSED${NC}"
+        echo -e "${GREEN}✓ Java Read Test (Parquet/Orc/Avro + Lance): PASSED${NC}"
     else
-        echo -e "${RED}✗ Java Read Test (Parquet/Orc/Avro + bucket_num_calculate + Lance): FAILED${NC}"
+        echo -e "${RED}✗ Java Read Test (Parquet/Orc/Avro + Lance): FAILED${NC}"
     fi
 
     if [[ $pk_dv_result -eq 0 ]]; then

--- a/paimon-python/dev/run_mixed_tests.sh
+++ b/paimon-python/dev/run_mixed_tests.sh
@@ -117,12 +117,12 @@ run_python_read_test() {
 
 # Function to run Python Write test for Python-Write-Java-Read scenario
 run_python_write_test() {
-    echo -e "${YELLOW}=== Step 3: Running Python Write Test (JavaPyReadWriteTest.test_py_write_read_pk_table) ===${NC}"
+    echo -e "${YELLOW}=== Step 3: Running Python Write Test (test_py_write_read_pk_table, test_py_write_read_pk_table_bucket_num_calculate) ===${NC}"
 
     cd "$PAIMON_PYTHON_DIR"
 
-    # Run the parameterized Python test method for writing data (runs for both Parquet/Orc/Avro and Lance)
-    echo "Running Python test for JavaPyReadWriteTest.test_py_write_read_pk_table (Python Write)..."
+    # Run the parameterized Python test method for writing data (pk table + bucket num calculate for Python/Java mismatch repro)
+    echo "Running Python test for JavaPyReadWriteTest (test_py_write_read_pk_table, test_py_write_read_pk_table_bucket_num_calculate)..."
     if python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest -k "test_py_write_read_pk_table" -v; then
         echo -e "${GREEN}✓ Python write test completed successfully${NC}"
         return 0
@@ -134,7 +134,7 @@ run_python_write_test() {
 
 # Function to run Java Read test for Python-Write-Java-Read scenario
 run_java_read_test() {
-    echo -e "${YELLOW}=== Step 4: Running Java Read Test (JavaPyE2ETest.testReadPkTable for Parquet/Orc/Avro, JavaPyLanceE2ETest.testReadPkTableLance for Lance) ===${NC}"
+    echo -e "${YELLOW}=== Step 4: Running Java Read Test (testReadPkTable, testReadPkTableBucketNumCalculate, testReadPkTableLance) ===${NC}"
 
     cd "$PROJECT_ROOT"
 
@@ -154,6 +154,18 @@ run_java_read_test() {
 
     echo ""
 
+    # Run Java test for bucket_num_calculate table (Python write, Java read with predicate; repro then fix in Python)
+    echo "Running Maven test for JavaPyE2ETest.testReadPkTableBucketNumCalculate (reads mixed_test_pk_table_bucket_num_calculate_*)..."
+    local bucket_num_calculate_result=0
+    if mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testReadPkTableBucketNumCalculate -pl paimon-core -Drun.e2e.tests=true -Dpython.version="$PYTHON_VERSION"; then
+        echo -e "${GREEN}✓ Java read bucket_num_calculate test completed successfully${NC}"
+    else
+        echo -e "${RED}✗ Java read bucket_num_calculate test failed (expected until Python bucket hash aligns with Java)${NC}"
+        bucket_num_calculate_result=1
+    fi
+
+    echo ""
+
     # Run Java test for lance format in paimon-lance
     echo "Running Maven test for JavaPyLanceE2ETest.testReadPkTableLance (Java Read Lance)..."
     echo "Note: Maven may download dependencies on first run, this may take a while..."
@@ -165,7 +177,7 @@ run_java_read_test() {
         lance_result=1
     fi
 
-    if [[ $parquet_result -eq 0 && $lance_result -eq 0 ]]; then
+    if [[ $parquet_result -eq 0 && $bucket_num_calculate_result -eq 0 && $lance_result -eq 0 ]]; then
         return 0
     else
         return 1
@@ -361,15 +373,15 @@ main() {
     fi
 
     if [[ $python_write_result -eq 0 ]]; then
-        echo -e "${GREEN}✓ Python Write Test (JavaPyReadWriteTest.test_py_write_read_pk_table): PASSED${NC}"
+        echo -e "${GREEN}✓ Python Write Test (test_py_write_read_pk_table, test_py_write_read_pk_table_bucket_num_calculate): PASSED${NC}"
     else
-        echo -e "${RED}✗ Python Write Test (JavaPyReadWriteTest.test_py_write_read_pk_table): FAILED${NC}"
+        echo -e "${RED}✗ Python Write Test (test_py_write_read_pk_table, test_py_write_read_pk_table_bucket_num_calculate): FAILED${NC}"
     fi
 
     if [[ $java_read_result -eq 0 ]]; then
-        echo -e "${GREEN}✓ Java Read Test (Parquet/Orc/Avro + Lance): PASSED${NC}"
+        echo -e "${GREEN}✓ Java Read Test (Parquet/Orc/Avro + bucket_num_calculate + Lance): PASSED${NC}"
     else
-        echo -e "${RED}✗ Java Read Test (Parquet/Orc/Avro + Lance): FAILED${NC}"
+        echo -e "${RED}✗ Java Read Test (Parquet/Orc/Avro + bucket_num_calculate + Lance): FAILED${NC}"
     fi
 
     if [[ $pk_dv_result -eq 0 ]]; then

--- a/paimon-python/pypaimon/tests/py36/ao_simple_test.py
+++ b/paimon-python/pypaimon/tests/py36/ao_simple_test.py
@@ -147,10 +147,10 @@ class AOSimpleTest(RESTBaseTest):
         splits = read_builder.new_scan().with_shard(0, 3).plan().splits()
         actual = table_sort_by(table_read.to_arrow(splits), 'user_id')
         expected = pa.Table.from_pydict({
-            'user_id': [1, 2, 3, 5, 8, 12],
-            'item_id': [1001, 1002, 1003, 1005, 1008, 1012],
-            'behavior': ['a', 'b', 'c', 'd', 'g', 'k'],
-            'dt': ['p1', 'p1', 'p2', 'p2', 'p1', 'p1'],
+            'user_id': [1, 2, 3, 4, 5, 13],
+            'item_id': [1001, 1002, 1003, 1004, 1005, 1013],
+            'behavior': ['a', 'b', 'c', None, 'd', 'l'],
+            'dt': ['p1', 'p1', 'p2', 'p1', 'p2', 'p2'],
         }, schema=self.pa_schema)
         self.assertEqual(actual, expected)
 

--- a/paimon-python/pypaimon/tests/rest/rest_simple_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_simple_test.py
@@ -205,10 +205,10 @@ class RESTSimpleTest(RESTBaseTest):
         splits = read_builder.new_scan().with_shard(0, 3).plan().splits()
         actual = table_sort_by(table_read.to_arrow(splits), 'user_id')
         expected = pa.Table.from_pydict({
-            'user_id': [1, 2, 3, 5, 8, 12],
-            'item_id': [1001, 1002, 1003, 1005, 1008, 1012],
-            'behavior': ['a', 'b', 'c', 'd', 'g', 'k'],
-            'dt': ['p1', 'p1', 'p2', 'p2', 'p1', 'p1'],
+            'user_id': [1, 2, 3, 4, 5, 13],
+            'item_id': [1001, 1002, 1003, 1004, 1005, 1013],
+            'behavior': ['a', 'b', 'c', None, 'd', 'l'],
+            'dt': ['p1', 'p1', 'p2', 'p1', 'p2', 'p2'],
         }, schema=self.pa_schema)
         self.assertEqual(actual, expected)
 
@@ -636,13 +636,13 @@ class RESTSimpleTest(RESTBaseTest):
         table_read = read_builder.new_read()
         actual = table_read.to_arrow(splits)
         data_expected = {
-            'user_id': [4, 6, 2, 10, 8],
-            'item_id': [1002, 1003, 1001, 1005, 1004],
-            'behavior': ['b', 'c', 'a', 'e', 'd'],
-            'dt': ['2025-08-10', '2025-08-11', '2000-10-10', '2025-08-13', '2025-08-12']
+            'user_id': [4, 6, 2, 8, 10],
+            'item_id': [1002, 1003, 1001, 1004, 1005],
+            'behavior': ['b', 'c', 'a', 'd', 'e'],
+            'dt': ['2025-08-10', '2025-08-11', '2000-10-10', '2025-08-12', '2025-08-13']
         }
         expected = pa.Table.from_pydict(data_expected, schema=self.pa_schema)
-        self.assertEqual(actual, expected)
+        self.assertEqual(actual.combine_chunks(), expected.combine_chunks())
 
     def test_with_shard_uniform_division(self):
         schema = Schema.from_pyarrow_schema(self.pa_schema, partition_keys=['dt'])

--- a/paimon-python/pypaimon/write/row_key_extractor.py
+++ b/paimon-python/pypaimon/write/row_key_extractor.py
@@ -15,17 +15,153 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
-import hashlib
-import json
+import struct
 from abc import ABC, abstractmethod
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import pyarrow as pa
 
 from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.schema.table_schema import TableSchema
 from pypaimon.table.bucket_mode import BucketMode
+
+_MURMUR_C1 = 0xCC9E2D51
+_MURMUR_C2 = 0x1B873593
+_DEFAULT_SEED = 42
+_HEADER_SIZE_IN_BITS = 8
+
+
+def _round_number_of_bytes_to_nearest_word(num_bytes: int) -> int:
+    remainder = num_bytes & 0x07
+    return num_bytes if remainder == 0 else num_bytes + (8 - remainder)
+
+
+def _calculate_bit_set_width_in_bytes(arity: int) -> int:
+    return ((arity + 63 + _HEADER_SIZE_IN_BITS) // 64) * 8
+
+
+def _get_fixed_length_part_size(arity: int) -> int:
+    return _calculate_bit_set_width_in_bytes(arity) + 8 * arity
+
+
+def _mix_k1(k1: int) -> int:
+    k1 = (k1 * _MURMUR_C1) & 0xFFFFFFFF
+    k1 = ((k1 << 15) | (k1 >> 17)) & 0xFFFFFFFF
+    k1 = (k1 * _MURMUR_C2) & 0xFFFFFFFF
+    return k1
+
+
+def _mix_h1(h1: int, k1: int) -> int:
+    h1 = (h1 ^ k1) & 0xFFFFFFFF
+    h1 = ((h1 << 13) | (h1 >> 19)) & 0xFFFFFFFF
+    h1 = (h1 * 5 + 0xE6546B64) & 0xFFFFFFFF
+    return h1
+
+
+def _fmix(h1: int, length: int) -> int:
+    # Finalization mix - force all bits of a hash block to avalanche
+    h1 = (h1 ^ length) & 0xFFFFFFFF
+    h1 ^= h1 >> 16
+    h1 = (h1 * 0x85EBCA6B) & 0xFFFFFFFF
+    h1 ^= h1 >> 13
+    h1 = (h1 * 0xC2B2AE35) & 0xFFFFFFFF
+    h1 ^= h1 >> 16
+    return h1
+
+
+def _hash_bytes_by_words(data: bytes, seed: int = _DEFAULT_SEED) -> int:
+    n = len(data)
+    length_aligned = n - (n % 4)
+    h1 = seed
+    for i in range(0, length_aligned, 4):
+        k1 = struct.unpack_from("<I", data, i)[0]
+        k1 = _mix_k1(k1)
+        h1 = _mix_h1(h1, k1)
+    return _fmix(h1, n)
+
+
+def _type_name_for_bucket(field_type: Any) -> str:
+    if hasattr(field_type, "type") and isinstance(getattr(field_type, "type"), str):
+        return getattr(field_type, "type").upper()
+    s = str(field_type).upper()
+    if "BIGINT" in s or "LONG" in s:
+        return "BIGINT"
+    if "TINYINT" in s:
+        return "TINYINT"
+    if "SMALLINT" in s:
+        return "SMALLINT"
+    if "INT" in s or "INTEGER" in s:
+        return "INT"
+    if "STRING" in s or "VARCHAR" in s or "CHAR" in s:
+        return "STRING"
+    if "FLOAT" in s:
+        return "FLOAT"
+    if "DOUBLE" in s:
+        return "DOUBLE"
+    if "BOOLEAN" in s or "BOOL" in s:
+        return "BOOLEAN"
+    return s
+
+
+def _to_binary_row_bytes(type_names: List[str], values: Tuple[Any, ...]) -> bytes:
+    arity = len(type_names)
+    assert arity == len(values)
+    null_size = _calculate_bit_set_width_in_bytes(arity)
+    fixed_size = _get_fixed_length_part_size(arity)
+    buf = bytearray(fixed_size)
+    buf[0] = 0
+    var_cursor = fixed_size
+    var_parts = []
+    for pos in range(arity):
+        type_name = type_names[pos]
+        value = values[pos]
+        field_offset = null_size + 8 * pos
+        if value is None:
+            byte_idx = (pos + _HEADER_SIZE_IN_BITS) // 8
+            bit_idx = (pos + _HEADER_SIZE_IN_BITS) % 8
+            buf[byte_idx] |= 1 << bit_idx
+            continue
+        if type_name in ("STRING", "VARCHAR", "CHAR"):
+            b = value.encode("utf-8") if isinstance(value, str) else value
+            length = len(b)
+            if length <= 7:
+                buf[field_offset:field_offset + length] = b
+                buf[field_offset + 7] = 0x80 | length
+            else:
+                rounded = _round_number_of_bytes_to_nearest_word(length)
+                var_parts.append((b, length, rounded))
+                struct.pack_into("<II", buf, field_offset, length, var_cursor)
+                var_cursor += rounded
+        elif type_name in ("INT", "INTEGER", "TINYINT", "SMALLINT"):
+            if type_name == "TINYINT":
+                struct.pack_into("<b", buf, field_offset, int(value))
+            elif type_name == "SMALLINT":
+                struct.pack_into("<h", buf, field_offset, int(value))
+            else:
+                struct.pack_into("<i", buf, field_offset, int(value))
+        elif type_name == "BIGINT":
+            struct.pack_into("<q", buf, field_offset, int(value))
+        elif type_name == "FLOAT":
+            struct.pack_into("<f", buf, field_offset, float(value))
+        elif type_name == "DOUBLE":
+            struct.pack_into("<d", buf, field_offset, float(value))
+        elif type_name == "BOOLEAN":
+            buf[field_offset] = 1 if value else 0
+        else:
+            b = str(value).encode("utf-8")
+            length = len(b)
+            if length <= 7:
+                buf[field_offset:field_offset + length] = b
+                buf[field_offset + 7] = 0x80 | length
+            else:
+                rounded = _round_number_of_bytes_to_nearest_word(length)
+                var_parts.append((b, length, rounded))
+                struct.pack_into("<II", buf, field_offset, length, var_cursor)
+                var_cursor += rounded
+    for b, length, rounded in var_parts:
+        buf.extend(b)
+        buf.extend(b"\x00" * (rounded - length))
+    return bytes(buf)
 
 
 class RowKeyExtractor(ABC):
@@ -82,19 +218,23 @@ class FixedBucketRowKeyExtractor(RowKeyExtractor):
                                 if pk not in table_schema.partition_keys]
 
         self.bucket_key_indices = self._get_field_indices(self.bucket_keys)
+        field_map = {f.name: f for f in table_schema.fields}
+        self._bucket_key_type_names = [
+            _type_name_for_bucket(field_map[name].type) for name in self.bucket_keys
+            if name in field_map
+        ]
 
     def _extract_buckets_batch(self, data: pa.RecordBatch) -> List[int]:
         columns = [data.column(i) for i in self.bucket_key_indices]
         hashes = []
         for row_idx in range(data.num_rows):
             row_values = tuple(col[row_idx].as_py() for col in columns)
-            hashes.append(self.hash(row_values))
-        return [abs(hash_val) % self.num_buckets for hash_val in hashes]
+            hashes.append(self._binary_row_hash_code(row_values))
+        return [abs(h) % self.num_buckets for h in hashes]
 
-    @staticmethod
-    def hash(data) -> int:
-        data_json = json.dumps(data)
-        return int(hashlib.md5(data_json.encode()).hexdigest(), 16)
+    def _binary_row_hash_code(self, row_values: Tuple[Any, ...]) -> int:
+        row_bytes = _to_binary_row_bytes(self._bucket_key_type_names, row_values)
+        return _hash_bytes_by_words(row_bytes)
 
 
 class UnawareBucketRowKeyExtractor(RowKeyExtractor):
@@ -126,7 +266,7 @@ class DynamicBucketRowKeyExtractor(RowKeyExtractor):
                 f"Only 'bucket' = '-1' is allowed for 'DynamicBucketRowKeyExtractor', but found: {num_buckets}"
             )
 
-    def _extract_buckets_batch(self, data: pa.RecordBatch) -> int:
+    def _extract_buckets_batch(self, data: pa.RecordBatch) -> List[int]:
         raise ValueError("Can't extract bucket from row in dynamic bucket mode")
 
 

--- a/paimon-python/pypaimon/write/row_key_extractor.py
+++ b/paimon-python/pypaimon/write/row_key_extractor.py
@@ -15,34 +15,23 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+
 import math
 import struct
 from abc import ABC, abstractmethod
-from typing import Any, List, Tuple
+from typing import List, Tuple
 
 import pyarrow as pa
 
 from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.schema.table_schema import TableSchema
 from pypaimon.table.bucket_mode import BucketMode
+from pypaimon.table.row.generic_row import GenericRow, GenericRowSerializer
+from pypaimon.table.row.internal_row import RowKind
 
 _MURMUR_C1 = 0xCC9E2D51
 _MURMUR_C2 = 0x1B873593
 _DEFAULT_SEED = 42
-_HEADER_SIZE_IN_BITS = 8
-
-
-def _round_number_of_bytes_to_nearest_word(num_bytes: int) -> int:
-    remainder = num_bytes & 0x07
-    return num_bytes if remainder == 0 else num_bytes + (8 - remainder)
-
-
-def _calculate_bit_set_width_in_bytes(arity: int) -> int:
-    return ((arity + 63 + _HEADER_SIZE_IN_BITS) // 64) * 8
-
-
-def _get_fixed_length_part_size(arity: int) -> int:
-    return _calculate_bit_set_width_in_bytes(arity) + 8 * arity
 
 
 def _mix_k1(k1: int) -> int:
@@ -60,7 +49,6 @@ def _mix_h1(h1: int, k1: int) -> int:
 
 
 def _fmix(h1: int, length: int) -> int:
-    # Finalization mix - force all bits of a hash block to avalanche
     h1 = (h1 ^ length) & 0xFFFFFFFF
     h1 ^= h1 >> 16
     h1 = (h1 * 0x85EBCA6B) & 0xFFFFFFFF
@@ -88,90 +76,6 @@ def _bucket_from_hash(hash_unsigned: int, num_buckets: int) -> int:
         hash_signed = hash_unsigned
     rem = hash_signed - math.trunc(hash_signed / num_buckets) * num_buckets
     return abs(rem)
-
-
-def _type_name_for_bucket(field_type: Any) -> str:
-    if hasattr(field_type, "type") and isinstance(getattr(field_type, "type"), str):
-        return getattr(field_type, "type").upper()
-    s = str(field_type).upper()
-    if "BIGINT" in s or "LONG" in s:
-        return "BIGINT"
-    if "TINYINT" in s:
-        return "TINYINT"
-    if "SMALLINT" in s:
-        return "SMALLINT"
-    if "INT" in s or "INTEGER" in s:
-        return "INT"
-    if "STRING" in s or "VARCHAR" in s or "CHAR" in s:
-        return "STRING"
-    if "FLOAT" in s:
-        return "FLOAT"
-    if "DOUBLE" in s:
-        return "DOUBLE"
-    if "BOOLEAN" in s or "BOOL" in s:
-        return "BOOLEAN"
-    return s
-
-
-def _to_binary_row_bytes(type_names: List[str], values: Tuple[Any, ...]) -> bytes:
-    arity = len(type_names)
-    assert arity == len(values)
-    null_size = _calculate_bit_set_width_in_bytes(arity)
-    fixed_size = _get_fixed_length_part_size(arity)
-    buf = bytearray(fixed_size)
-    buf[0] = 0
-    var_cursor = fixed_size
-    var_parts = []
-    for pos in range(arity):
-        type_name = type_names[pos]
-        value = values[pos]
-        field_offset = null_size + 8 * pos
-        if value is None:
-            byte_idx = (pos + _HEADER_SIZE_IN_BITS) // 8
-            bit_idx = (pos + _HEADER_SIZE_IN_BITS) % 8
-            buf[byte_idx] |= 1 << bit_idx
-            continue
-        if type_name in ("STRING", "VARCHAR", "CHAR"):
-            b = value.encode("utf-8") if isinstance(value, str) else value
-            length = len(b)
-            if length <= 7:
-                buf[field_offset:field_offset + length] = b
-                buf[field_offset + 7] = 0x80 | length
-            else:
-                rounded = _round_number_of_bytes_to_nearest_word(length)
-                var_parts.append((b, length, rounded))
-                struct.pack_into("<II", buf, field_offset, length, var_cursor)
-                var_cursor += rounded
-        elif type_name in ("INT", "INTEGER", "TINYINT", "SMALLINT"):
-            if type_name == "TINYINT":
-                struct.pack_into("<b", buf, field_offset, int(value))
-            elif type_name == "SMALLINT":
-                struct.pack_into("<h", buf, field_offset, int(value))
-            else:
-                struct.pack_into("<i", buf, field_offset, int(value))
-        elif type_name == "BIGINT":
-            struct.pack_into("<q", buf, field_offset, int(value))
-        elif type_name == "FLOAT":
-            struct.pack_into("<f", buf, field_offset, float(value))
-        elif type_name == "DOUBLE":
-            struct.pack_into("<d", buf, field_offset, float(value))
-        elif type_name == "BOOLEAN":
-            buf[field_offset] = 1 if value else 0
-        else:
-            b = str(value).encode("utf-8")
-            length = len(b)
-            if length <= 7:
-                buf[field_offset:field_offset + length] = b
-                buf[field_offset + 7] = 0x80 | length
-            else:
-                rounded = _round_number_of_bytes_to_nearest_word(length)
-                var_parts.append((b, length, rounded))
-                struct.pack_into("<II", buf, field_offset, length, var_cursor)
-                var_cursor += rounded
-    for b, length, rounded in var_parts:
-        buf.extend(b)
-        buf.extend(b"\x00" * (rounded - length))
-    return bytes(buf)
 
 
 class RowKeyExtractor(ABC):
@@ -229,22 +133,21 @@ class FixedBucketRowKeyExtractor(RowKeyExtractor):
 
         self.bucket_key_indices = self._get_field_indices(self.bucket_keys)
         field_map = {f.name: f for f in table_schema.fields}
-        self._bucket_key_type_names = [
-            _type_name_for_bucket(field_map[name].type) for name in self.bucket_keys
-            if name in field_map
+        self._bucket_key_fields = [
+            field_map[name] for name in self.bucket_keys if name in field_map
         ]
 
     def _extract_buckets_batch(self, data: pa.RecordBatch) -> List[int]:
         columns = [data.column(i) for i in self.bucket_key_indices]
-        hashes = []
-        for row_idx in range(data.num_rows):
-            row_values = tuple(col[row_idx].as_py() for col in columns)
-            hashes.append(self._binary_row_hash_code(row_values))
-        return [_bucket_from_hash(h, self.num_buckets) for h in hashes]
+        return [
+            _bucket_from_hash(self._binary_row_hash_code(tuple(col[row_idx].as_py() for col in columns)), self.num_buckets)
+            for row_idx in range(data.num_rows)
+        ]
 
-    def _binary_row_hash_code(self, row_values: Tuple[Any, ...]) -> int:
-        row_bytes = _to_binary_row_bytes(self._bucket_key_type_names, row_values)
-        return _hash_bytes_by_words(row_bytes)
+    def _binary_row_hash_code(self, row_values: Tuple) -> int:
+        row = GenericRow(list(row_values), self._bucket_key_fields, RowKind.INSERT)
+        serialized = GenericRowSerializer.to_bytes(row)
+        return _hash_bytes_by_words(serialized[4:])
 
 
 class UnawareBucketRowKeyExtractor(RowKeyExtractor):

--- a/paimon-python/pypaimon/write/row_key_extractor.py
+++ b/paimon-python/pypaimon/write/row_key_extractor.py
@@ -140,7 +140,10 @@ class FixedBucketRowKeyExtractor(RowKeyExtractor):
     def _extract_buckets_batch(self, data: pa.RecordBatch) -> List[int]:
         columns = [data.column(i) for i in self.bucket_key_indices]
         return [
-            _bucket_from_hash(self._binary_row_hash_code(tuple(col[row_idx].as_py() for col in columns)), self.num_buckets)
+            _bucket_from_hash(
+                self._binary_row_hash_code(tuple(col[row_idx].as_py() for col in columns)),
+                self.num_buckets,
+            )
             for row_idx in range(data.num_rows)
         ]
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the bucketing/hash algorithm used by Python writers, which can change file/bucket placement and could impact interoperability or data layout expectations; updates are backed by new cross-language assertions.
> 
> **Overview**
> Fixes **Python fixed-bucket assignment** by replacing the previous JSON+MD5-based hash in `FixedBucketRowKeyExtractor` with a Murmur3-style hash over Paimon `GenericRow` binary serialization, aligning bucket numbers with Java.
> 
> Updates mixed Java/Python E2E coverage: Python PK-table writer now uses `bucket=4` and asserts the expected bucket for a known row, while `JavaPyE2ETest.testReadPkTable` adds predicate-based reads (`withFilter(equal(id))`) to verify Java can correctly locate rows written by Python. Several Python REST/py36 sharding tests adjust expected results and comparisons (`combine_chunks`) to reflect the corrected bucketing behavior, and the mixed test runner output strings are cleaned up.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9a036b4c42c552eaa4b29eab5628ac23bf552bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->