### PR TITLE
Row id push pr

### DIFF
--- a/paimon-python/pypaimon/read/reader/row_range_filter_record_reader.py
+++ b/paimon-python/pypaimon/read/reader/row_range_filter_record_reader.py
@@ -1,0 +1,84 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+
+from typing import Optional, List
+
+from pypaimon.read.reader.iface.record_iterator import RecordIterator
+from pypaimon.read.reader.iface.record_reader import RecordReader
+from pypaimon.globalindex.range import Range
+
+
+class RowRangeFilterRecordReader(RecordReader):
+    """
+    A RecordReader that filters records based on row ID ranges.
+    """
+
+    def __init__(self, reader: RecordReader, first_row_id: int, row_id_ranges: List[Range]):
+        self.reader = reader
+        self.current_row_id = first_row_id
+        self.row_id_ranges = row_id_ranges
+
+    def read_batch(self) -> Optional[RecordIterator]:
+        iterator = self.reader.read_batch()
+        if iterator is None:
+            return None
+        return RowRangeFilterIterator(iterator, self.current_row_id, self.row_id_ranges, self)
+
+    def close(self) -> None:
+        self.reader.close()
+
+    def get_current_row_id(self) -> int:
+        return self.current_row_id
+
+    def update_row_id(self, row_id: int):
+        self.current_row_id = row_id
+
+
+class RowRangeFilterIterator(RecordIterator):
+    """
+    A RecordIterator that filters records based on row ID ranges.
+    """
+
+    def __init__(
+            self,
+            iterator: RecordIterator,
+            row_id_ranges: List[Range],
+            reader: RowRangeFilterRecordReader):
+        self.iterator = iterator
+        self.current_row_id = reader.get_current_row_id()
+        self.row_id_ranges = row_id_ranges
+        self.reader = reader
+
+    def next(self) -> Optional[object]:
+        while True:
+            record = self.iterator.next()
+            if record is None:
+                return None
+
+            self.current_row_id = self.current_row_id + 1
+            self.reader.update_row_id(self.current_row_id)
+
+            if self._is_row_in_range(self.current_row_id - 1):
+                return record
+
+    def _is_row_in_range(self, row_id: int) -> bool:
+        """Check if the given row ID is within any of the allowed ranges."""
+        for range_obj in self.row_id_ranges:
+            if range_obj.contains(row_id):
+                return True
+        return False

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -39,7 +39,7 @@ from pypaimon.read.reader.empty_record_reader import EmptyFileRecordReader
 from pypaimon.read.reader.field_bunch import BlobBunch, DataBunch, FieldBunch
 from pypaimon.read.reader.filter_record_reader import FilterRecordReader
 from pypaimon.read.reader.format_avro_reader import FormatAvroReader
-from pypaimon.read.reader.row_range_filter_record_reader import RowRangeFilterRecordReader
+from pypaimon.read.reader.row_range_filter_record_reader import RowIdFilterRecordBatchReader
 from pypaimon.read.reader.format_blob_reader import FormatBlobReader
 from pypaimon.read.reader.format_lance_reader import FormatLanceReader
 from pypaimon.read.reader.format_pyarrow_reader import FormatPyArrowReader
@@ -599,7 +599,7 @@ class DataEvolutionSplitRead(SplitRead):
                 read_fields=read_fields,
                 row_tracking_enabled=True)
             if self.row_ranges is not None:
-                record_reader = RowRangeFilterRecordReader(record_reader, file.first_row_id, self.row_ranges)
+                record_reader = RowIdFilterRecordBatchReader(record_reader, file.first_row_id, self.row_ranges)
             return record_reader
 
         shard_file_idx_map = (

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -21,7 +21,6 @@ import pandas
 import pyarrow
 
 from pypaimon.common.predicate import Predicate
-from pypaimon.globalindex.indexed_split import IndexedSplit
 from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
 from pypaimon.read.split import Split
 from pypaimon.read.split_read import (DataEvolutionSplitRead,
@@ -94,25 +93,10 @@ class TableRead:
         chunk_size = 65536
 
         for split in splits:
-            # Get row ranges if this is an IndexedSplit
-            row_ranges = None
-            actual_split = split
-            if isinstance(split, IndexedSplit):
-                row_ranges = split.row_ranges()
-                actual_split = split.data_split()
-
-            reader = self._create_split_read(actual_split).create_reader()
+            reader = self._create_split_read(split).create_reader()
             try:
                 if isinstance(reader, RecordBatchReader):
-                    # For IndexedSplit, filter batches by row ranges
-                    if row_ranges:
-                        yield from self._filter_batches_by_row_ranges(
-                            iter(reader.read_arrow_batch, None),
-                            actual_split,
-                            row_ranges
-                        )
-                    else:
-                        yield from iter(reader.read_arrow_batch, None)
+                    yield from iter(reader.read_arrow_batch, None)
                 else:
                     row_tuple_chunk = []
                     for row_iterator in iter(reader.read_batch, None):
@@ -131,46 +115,6 @@ class TableRead:
                         yield batch
             finally:
                 reader.close()
-
-    def _filter_batches_by_row_ranges(
-        self,
-        batch_iterator: Iterator[pyarrow.RecordBatch],
-        split: Split,
-        row_ranges: List
-    ) -> Iterator[pyarrow.RecordBatch]:
-        """Filter batches to only include rows within the given row ranges."""
-        import numpy as np
-
-        # Build a set of allowed row IDs for fast lookup
-        allowed_row_ids = set()
-        for r in row_ranges:
-            for row_id in range(r.from_, r.to + 1):
-                allowed_row_ids.add(row_id)
-
-        # Track current row ID based on file's first_row_id
-        current_row_id = 0
-        for file in split.files:
-            if file.first_row_id is not None:
-                current_row_id = file.first_row_id
-                break
-
-        for batch in batch_iterator:
-            if batch.num_rows == 0:
-                continue
-
-            # Build mask for rows that are in allowed_row_ids
-            mask = np.zeros(batch.num_rows, dtype=bool)
-            for i in range(batch.num_rows):
-                if current_row_id + i in allowed_row_ids:
-                    mask[i] = True
-
-            current_row_id += batch.num_rows
-
-            # Filter batch
-            if np.any(mask):
-                filtered_batch = batch.filter(pyarrow.array(mask))
-                if filtered_batch.num_rows > 0:
-                    yield filtered_batch
 
     def to_pandas(self, splits: List[Split]) -> pandas.DataFrame:
         arrow_table = self.to_arrow(splits)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the row-selection path for `IndexedSplit` reads and introduces per-batch masking, which could affect correctness/performance if row-id offsets or range semantics differ across files.
> 
> **Overview**
> Adds `RowIdFilterRecordBatchReader` to filter `pyarrow.RecordBatch` rows by `IndexedSplit` row-id ranges.
> 
> Moves `IndexedSplit` handling out of `TableRead` (removing the batch-level filtering helper) and into `DataEvolutionSplitRead`, which now unwraps `IndexedSplit` and wraps per-file readers with the new row-id filter (including when sharding via `ShardBatchReader`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afa6b37fc9dccac1e8204d6744a9b56cc1492607. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->