### PR TITLE
[python/hotfix] fix data evolution merge batch size mismatch issue

### DIFF
--- a/paimon-python/pypaimon/read/reader/concat_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/concat_batch_reader.py
@@ -186,8 +186,9 @@ class DataEvolutionMergeReader(RecordBatchReader):
                 else:
                     batch = reader.read_arrow_batch()
                     if batch is None:
-                        return None
-                    batches[i] = batch
+                        batches[i] = None
+                    else:
+                        batches[i] = batch
             else:
                 batches[i] = None
 

--- a/paimon-python/pypaimon/read/reader/concat_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/concat_batch_reader.py
@@ -182,8 +182,7 @@ class MergeAllBatchReader(RecordBatchReader):
 class DataEvolutionMergeReader(RecordBatchReader):
     """
     Union reader with multiple inner readers (each wrapped with ForceSingleBatchReader).
-    Merges one batch per reader row-by-row, aligned with Java DataEvolutionFileReader +
-    ForceSingleBatchReader + DataEvolutionIterator.
+    Merges one batch per reader row-by-row.
 
     For example, if rowOffsets is {0, 2, 0, 1, 2, 1} and fieldOffsets is {0, 0, 1, 1, 1, 0}, it means:
      - The first field comes from batch0, and it is at offset 0 in batch0.

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -31,9 +31,7 @@ from pypaimon.read.interval_partition import IntervalPartition, SortedRun
 from pypaimon.read.partition_info import PartitionInfo
 from pypaimon.read.push_down_utils import trim_predicate_by_fields
 from pypaimon.read.reader.concat_batch_reader import (ConcatBatchReader,
-                                                      DataEvolutionMergeReader,
-                                                      ForceSingleBatchReader,
-                                                      MergeAllBatchReader)
+                                                      MergeAllBatchReader, DataEvolutionMergeReader)
 from pypaimon.read.reader.concat_record_reader import ConcatRecordReader
 
 from pypaimon.read.reader.data_file_batch_reader import DataFileBatchReader
@@ -574,15 +572,14 @@ class DataEvolutionSplitRead(SplitRead):
                     suppliers = [lambda r=self._create_file_reader(
                         bunch.files()[0], read_field_names
                     ): r]
-                    inner = MergeAllBatchReader(suppliers, batch_size=batch_size)
+                    file_record_readers[i] = MergeAllBatchReader(suppliers, batch_size=batch_size)
                 else:
                     # Create concatenated reader for multiple files
                     suppliers = [
                         partial(self._create_file_reader, file=file,
                                 read_fields=read_field_names) for file in bunch.files()
                     ]
-                    inner = MergeAllBatchReader(suppliers, batch_size=batch_size)
-                file_record_readers[i] = ForceSingleBatchReader(inner)
+                    file_record_readers[i] = MergeAllBatchReader(suppliers, batch_size=batch_size)
                 self.read_fields = table_fields
 
         # Validate that all required fields are found

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -582,9 +582,6 @@ class DataEvolutionSplitRead(SplitRead):
                                 read_fields=read_field_names) for file in bunch.files()
                     ]
                     inner = MergeAllBatchReader(suppliers, batch_size=batch_size)
-                # Align with Java: wrap with ForceSingleBatchReader so each inner
-                # reader exposes one batch (all rows); DataEvolutionMergeReader
-                # then merges row-by-row without buffer/min_rows logic.
                 file_record_readers[i] = ForceSingleBatchReader(inner)
                 self.read_fields = table_fields
 

--- a/paimon-python/pypaimon/tests/data_evolution_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_test.py
@@ -94,6 +94,76 @@ class DataEvolutionTest(unittest.TestCase):
         self.assertEqual(0, manifest.min_row_id)
         self.assertEqual(1, manifest.max_row_id)
 
+    def test_merge_reader(self):
+        from pypaimon.read.reader.concat_batch_reader import MergeAllBatchReader
+
+        simple_pa_schema = pa.schema([
+            ('f0', pa.int32()),
+            ('f1', pa.string()),
+            ('f2', pa.string()),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            simple_pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'read.batch-size': '4096',
+            },
+        )
+        self.catalog.create_table('default.test_merge_reader_batch_sizes', schema, False)
+        table = self.catalog.get_table('default.test_merge_reader_batch_sizes')
+
+        write_builder = table.new_batch_write_builder()
+        size = 5000
+        w0 = write_builder.new_write().with_write_type(['f0', 'f1'])
+        w1 = write_builder.new_write().with_write_type(['f2'])
+        c = write_builder.new_commit()
+        d0 = pa.Table.from_pydict(
+            {'f0': list(range(size)), 'f1': [f'a{i}' for i in range(size)]},
+            schema=pa.schema([('f0', pa.int32()), ('f1', pa.string())]),
+        )
+        d1 = pa.Table.from_pydict(
+            {'f2': [f'b{i}' for i in range(size)]},
+            schema=pa.schema([('f2', pa.string())]),
+        )
+        w0.write_arrow(d0)
+        w1.write_arrow(d1)
+        cmts = w0.prepare_commit() + w1.prepare_commit()
+        for msg in cmts:
+            for nf in msg.new_files:
+                nf.first_row_id = 0
+        c.commit(cmts)
+        w0.close()
+        w1.close()
+        c.close()
+
+        original_merge_all = MergeAllBatchReader
+        call_count = [0]
+
+        def patched_merge_all(reader_suppliers, batch_size=1024):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                batch_size = 999
+            return original_merge_all(reader_suppliers, batch_size=batch_size)
+
+        import pypaimon.read.split_read as split_read_module
+        split_read_module.MergeAllBatchReader = patched_merge_all
+        try:
+            read_builder = table.new_read_builder()
+            table_scan = read_builder.new_scan()
+            table_read = read_builder.new_read()
+            splits = table_scan.plan().splits()
+            actual_data = table_read.to_arrow(splits)
+            expect_data = pa.Table.from_pydict({
+                'f0': list(range(size)),
+                'f1': [f'a{i}' for i in range(size)],
+                'f2': [f'b{i}' for i in range(size)],
+            }, schema=simple_pa_schema)
+            self.assertEqual(actual_data.num_rows, size)
+            self.assertEqual(actual_data, expect_data)
+        finally:
+            split_read_module.MergeAllBatchReader = original_merge_all
+
     def test_with_slice(self):
         pa_schema = pa.schema([
             ("id", pa.int64()),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core batch-merging logic in the data-evolution read path; mistakes could cause subtle row/column misalignment or dropped/duplicated rows despite added regression coverage.
> 
> **Overview**
> Fixes a data-evolution read bug where merged field readers could return different batch sizes, causing misaligned columns or premature end-of-data.
> 
> `DataEvolutionMergeReader` now *aligns batches by the minimum available row count*, slices columns to that size, fills missing columns with typed nulls, and buffers per-reader remainders (with a small-batch refill threshold) to carry over extra rows to the next call. Adds a regression test that forces `MergeAllBatchReader` to emit mismatched batch sizes and verifies the merged result is complete and correct.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 789d27ad098831c62b96a02753c9e26fc1c7041c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->