### PR TITLE
[python/hotfix] fix data evolution with_slice out-of-bounds: return e…

### DIFF
--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -32,13 +32,13 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
     """
 
     def __init__(
-            self,
-            table,
-            target_split_size: int,
-            open_file_cost: int,
-            deletion_files_map=None,
-            row_ranges: Optional[List] = None,
-            score_getter=None
+        self,
+        table,
+        target_split_size: int,
+        open_file_cost: int,
+        deletion_files_map=None,
+        row_ranges: Optional[List] = None,
+        score_getter=None
     ):
         super().__init__(table, target_split_size, open_file_cost, deletion_files_map)
         self.row_ranges = row_ranges
@@ -48,7 +48,6 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         """
         Create splits for data evolution tables.
         """
-
         def sort_key(manifest_entry: ManifestEntry) -> tuple:
             first_row_id = (
                 manifest_entry.file.first_row_id
@@ -121,10 +120,10 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         return splits
 
     def _build_split_from_pack_for_data_evolution(
-            self,
-            flatten_packed_files: List[List[DataFileMeta]],
-            packed_files: List[List[List[DataFileMeta]]],
-            file_entries: List[ManifestEntry]
+        self,
+        flatten_packed_files: List[List[DataFileMeta]],
+        packed_files: List[List[List[DataFileMeta]]],
+        file_entries: List[ManifestEntry]
     ) -> List[Split]:
         """
         Build splits from packed files for data evolution tables.
@@ -296,7 +295,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
     @staticmethod
     def _divide_ranges(
-            sorted_ranges: List[Range], sub_task_id: int, total_tasks: int
+        sorted_ranges: List[Range], sub_task_id: int, total_tasks: int
     ) -> Tuple[Optional[Range], Optional[Range]]:
         if not sorted_ranges:
             return None, None
@@ -318,8 +317,8 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         else:
             num_ranges_for_task = base_ranges_per_task
             start_idx = (
-                    remainder * (base_ranges_per_task + 1) +
-                    (sub_task_id - remainder) * base_ranges_per_task
+                remainder * (base_ranges_per_task + 1) +
+                (sub_task_id - remainder) * base_ranges_per_task
             )
         end_idx = start_idx + num_ranges_for_task - 1
         return sorted_ranges[start_idx], sorted_ranges[end_idx]
@@ -369,11 +368,11 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         return split_by_row_id
 
     def _compute_slice_split_file_idx_map(
-            self,
-            plan_start_pos: int,
-            plan_end_pos: int,
-            split: Split,
-            file_end_pos: int
+        self,
+        plan_start_pos: int,
+        plan_end_pos: int,
+        split: Split,
+        file_end_pos: int
     ) -> Dict[str, Tuple[int, int]]:
         """
         Compute file index map for a split, determining which rows to read from each file.

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -380,7 +380,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         For blob files (which may be rolled), the range is calculated based on each file's first_row_id.
         """
         shard_file_idx_map = {}
-
+        
         # First pass: data files only. Compute range and apply directly to avoid second-pass lookup.
         current_pos = file_end_pos
         data_file_infos = []

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -72,6 +72,9 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
             if slice_row_ranges:
                 # Filter files by Row ID range
                 partitioned_files = self._filter_files_by_row_ranges(partitioned_files, slice_row_ranges)
+            else:
+                # Slice is out of bounds: return no splits
+                partitioned_files = defaultdict(list)
         elif self.idx_of_this_subtask is not None:
             partitioned_files = self._filter_by_shard(
                 partitioned_files, self.idx_of_this_subtask, self.number_of_para_subtasks

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -69,11 +69,8 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         if self.start_pos_of_this_subtask is not None:
             # Calculate Row ID range for slice-based filtering
             slice_row_ranges = self._calculate_slice_row_ranges(partitioned_files)
-            if slice_row_ranges:
-                # Filter files by Row ID range
-                partitioned_files = self._filter_files_by_row_ranges(partitioned_files, slice_row_ranges)
-            else:
-                partitioned_files = defaultdict(list)
+            # Filter files by Row ID range
+            partitioned_files = self._filter_files_by_row_ranges(partitioned_files, slice_row_ranges)
         elif self.idx_of_this_subtask is not None:
             partitioned_files = self._filter_by_shard(
                 partitioned_files, self.idx_of_this_subtask, self.number_of_para_subtasks

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -32,13 +32,13 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
     """
 
     def __init__(
-        self,
-        table,
-        target_split_size: int,
-        open_file_cost: int,
-        deletion_files_map=None,
-        row_ranges: Optional[List] = None,
-        score_getter=None
+            self,
+            table,
+            target_split_size: int,
+            open_file_cost: int,
+            deletion_files_map=None,
+            row_ranges: Optional[List] = None,
+            score_getter=None
     ):
         super().__init__(table, target_split_size, open_file_cost, deletion_files_map)
         self.row_ranges = row_ranges
@@ -48,6 +48,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         """
         Create splits for data evolution tables.
         """
+
         def sort_key(manifest_entry: ManifestEntry) -> tuple:
             first_row_id = (
                 manifest_entry.file.first_row_id
@@ -73,7 +74,6 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                 # Filter files by Row ID range
                 partitioned_files = self._filter_files_by_row_ranges(partitioned_files, slice_row_ranges)
             else:
-                # Slice is out of bounds: return no splits
                 partitioned_files = defaultdict(list)
         elif self.idx_of_this_subtask is not None:
             partitioned_files = self._filter_by_shard(
@@ -121,10 +121,10 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         return splits
 
     def _build_split_from_pack_for_data_evolution(
-        self,
-        flatten_packed_files: List[List[DataFileMeta]],
-        packed_files: List[List[List[DataFileMeta]]],
-        file_entries: List[ManifestEntry]
+            self,
+            flatten_packed_files: List[List[DataFileMeta]],
+            packed_files: List[List[List[DataFileMeta]]],
+            file_entries: List[ManifestEntry]
     ) -> List[Split]:
         """
         Build splits from packed files for data evolution tables.
@@ -296,7 +296,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
     @staticmethod
     def _divide_ranges(
-        sorted_ranges: List[Range], sub_task_id: int, total_tasks: int
+            sorted_ranges: List[Range], sub_task_id: int, total_tasks: int
     ) -> Tuple[Optional[Range], Optional[Range]]:
         if not sorted_ranges:
             return None, None
@@ -318,8 +318,8 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         else:
             num_ranges_for_task = base_ranges_per_task
             start_idx = (
-                remainder * (base_ranges_per_task + 1) +
-                (sub_task_id - remainder) * base_ranges_per_task
+                    remainder * (base_ranges_per_task + 1) +
+                    (sub_task_id - remainder) * base_ranges_per_task
             )
         end_idx = start_idx + num_ranges_for_task - 1
         return sorted_ranges[start_idx], sorted_ranges[end_idx]
@@ -369,11 +369,11 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         return split_by_row_id
 
     def _compute_slice_split_file_idx_map(
-        self,
-        plan_start_pos: int,
-        plan_end_pos: int,
-        split: Split,
-        file_end_pos: int
+            self,
+            plan_start_pos: int,
+            plan_end_pos: int,
+            split: Split,
+            file_end_pos: int
     ) -> Dict[str, Tuple[int, int]]:
         """
         Compute file index map for a split, determining which rows to read from each file.
@@ -381,7 +381,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         For blob files (which may be rolled), the range is calculated based on each file's first_row_id.
         """
         shard_file_idx_map = {}
-        
+
         # First pass: data files only. Compute range and apply directly to avoid second-pass lookup.
         current_pos = file_end_pos
         data_file_infos = []

--- a/paimon-python/pypaimon/tests/data_evolution_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_test.py
@@ -156,6 +156,17 @@ class DataEvolutionTest(unittest.TestCase):
             "with_slice(1, 4) should return id in (2, 1001, 2001). Got ids=%s" % ids,
         )
 
+        # Out-of-bounds slice: 6 rows total, slice(10, 12) should return 0 rows
+        scan_oob = rb.new_scan().with_slice(10, 12)
+        splits_oob = scan_oob.plan().splits()
+        result_oob = rb.new_read().to_pandas(splits_oob)
+        self.assertEqual(
+            len(result_oob),
+            0,
+            "with_slice(10, 12) on 6 rows should return 0 rows (out of bounds), got %d"
+            % len(result_oob),
+        )
+
     def test_multiple_appends(self):
         simple_pa_schema = pa.schema([
             ('f0', pa.int32()),


### PR DESCRIPTION
…mpty rows instead of all data

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to slice-based split filtering plus a unit test; main risk is unintended split omission if empty-range handling is wrong.
> 
> **Overview**
> Fixes `DataEvolutionSplitGenerator` slice planning so `with_slice` always applies Row ID range filtering (even when the computed range is empty), preventing out-of-bounds slices from returning all data.
> 
> Extends `DataEvolutionTest.test_with_slice` with a new assertion that `with_slice(10, 12)` on a 6-row table yields zero rows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bef2ac13ced8ee6b72bc18e698c95a77904959a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->