### PR TITLE
[python] fix filter on data evolution table not working issue

### DIFF
--- a/paimon-python/pypaimon/common/predicate.py
+++ b/paimon-python/pypaimon/common/predicate.py
@@ -66,15 +66,6 @@ class Predicate:
             return tester.test_by_value(field_value, self.literals)
         raise ValueError(f"Unsupported predicate method: {self.method}")
 
-    def has_null_check(self) -> bool:
-        if self.method in ('isNull', 'isNotNull'):
-            return False
-        if self.method not in ('and', 'or') and self.literals and any(lit is None for lit in self.literals):
-            return True
-        if self.method in ('and', 'or') and self.literals:
-            return any(p.has_null_check() for p in self.literals)
-        return False
-
     def test_by_simple_stats(self, stat: SimpleStats, row_count: int) -> bool:
         """Test predicate against BinaryRow stats with denseIndexMapping like Java implementation."""
         if self.method == 'and':

--- a/paimon-python/pypaimon/common/predicate.py
+++ b/paimon-python/pypaimon/common/predicate.py
@@ -66,6 +66,15 @@ class Predicate:
             return tester.test_by_value(field_value, self.literals)
         raise ValueError(f"Unsupported predicate method: {self.method}")
 
+    def has_null_check(self) -> bool:
+        if self.method in ('isNull', 'isNotNull'):
+            return False
+        if self.method not in ('and', 'or') and self.literals and any(lit is None for lit in self.literals):
+            return True
+        if self.method in ('and', 'or') and self.literals:
+            return any(p.has_null_check() for p in self.literals)
+        return False
+
     def test_by_simple_stats(self, stat: SimpleStats, row_count: int) -> bool:
         """Test predicate against BinaryRow stats with denseIndexMapping like Java implementation."""
         if self.method == 'and':

--- a/paimon-python/pypaimon/read/reader/filter_record_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/filter_record_batch_reader.py
@@ -17,16 +17,14 @@
 ###############################################################################
 
 import logging
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import pyarrow as pa
-import pyarrow.compute as pc
 import pyarrow.dataset as ds
 
 from pypaimon.common.predicate import Predicate
 from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
 from pypaimon.schema.data_types import DataField
-from pypaimon.table.row.offset_row import OffsetRow
 
 logger = logging.getLogger(__name__)
 
@@ -62,39 +60,7 @@ class FilterRecordBatchReader(RecordBatchReader):
                 return filtered
             continue
 
-    def _build_col_indices(self, batch: pa.RecordBatch) -> Tuple[List[Optional[int]], int]:
-        names = set(batch.schema.names)
-        if self.schema_fields is not None:
-            fields = self.schema_fields
-        elif self.field_names is not None:
-            fields = self.field_names
-        else:
-            return list(range(batch.num_columns)), batch.num_columns
-        indices = []
-        for f in fields:
-            name = f.name if hasattr(f, 'name') else f
-            indices.append(batch.schema.get_field_index(name) if name in names else None)
-        return indices, len(indices)
-
-    def _filter_batch_simple_null(
-        self, batch: pa.RecordBatch
-    ) -> Optional[pa.RecordBatch]:
-        if self.predicate.method not in ('isNull', 'isNotNull') or not self.predicate.field:
-            return None
-        if self.predicate.field not in batch.schema.names:
-            return None
-        col = batch.column(self.predicate.field)
-        mask = pc.is_null(col) if self.predicate.method == 'isNull' else pc.is_valid(col)
-        return batch.filter(mask)
-
     def _filter_batch(self, batch: pa.RecordBatch) -> Optional[pa.RecordBatch]:
-        simple_null = self._filter_batch_simple_null(batch)
-        if simple_null is not None:
-            return simple_null
-        # When predicate has NULL literal (e.g. equal(col, None)), use row-by-row to avoid
-        # InMemoryDataset/scanner; reduces PyArrow object churn and py36 exit segfault in CI.
-        if self.predicate.has_null_check():
-            return self._filter_batch_row_by_row(batch)
         expr = self.predicate.to_arrow()
         result = ds.InMemoryDataset(pa.Table.from_batches([batch])).scanner(
             filter=expr
@@ -111,7 +77,7 @@ class FilterRecordBatchReader(RecordBatchReader):
             return concat_batches(batches)
         return pa.RecordBatch.from_arrays(
             [result.column(i) for i in range(result.num_columns)],
-            schema=batch.schema,
+            schema=result.schema,
         )
 
     def return_batch_pos(self) -> int:

--- a/paimon-python/pypaimon/read/reader/filter_record_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/filter_record_batch_reader.py
@@ -1,0 +1,143 @@
+###############################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import logging
+from typing import List, Optional, Tuple
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.dataset as ds
+
+from pypaimon.common.predicate import Predicate
+from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
+from pypaimon.schema.data_types import DataField
+from pypaimon.table.row.offset_row import OffsetRow
+
+logger = logging.getLogger(__name__)
+
+
+class FilterRecordBatchReader(RecordBatchReader):
+    """
+    Wraps a RecordBatchReader and filters each batch by predicate.
+    Used for data evolution read where predicate cannot be pushed down to
+    individual file readers. Only used when predicate columns are in read schema.
+    """
+
+    def __init__(
+        self,
+        reader: RecordBatchReader,
+        predicate: Predicate,
+        field_names: Optional[List[str]] = None,
+        schema_fields: Optional[List[DataField]] = None,
+    ):
+        self.reader = reader
+        self.predicate = predicate
+        self.field_names = field_names
+        self.schema_fields = schema_fields
+
+    def read_arrow_batch(self) -> Optional[pa.RecordBatch]:
+        while True:
+            batch = self.reader.read_arrow_batch()
+            if batch is None:
+                return None
+            if batch.num_rows == 0:
+                return batch
+            filtered = self._filter_batch(batch)
+            if filtered is not None and filtered.num_rows > 0:
+                return filtered
+            continue
+
+    def _build_col_indices(self, batch: pa.RecordBatch) -> Tuple[List[Optional[int]], int]:
+        names = set(batch.schema.names)
+        if self.schema_fields is not None:
+            fields = self.schema_fields
+        elif self.field_names is not None:
+            fields = self.field_names
+        else:
+            return list(range(batch.num_columns)), batch.num_columns
+        indices = []
+        for f in fields:
+            name = f.name if hasattr(f, 'name') else f
+            indices.append(batch.schema.get_field_index(name) if name in names else None)
+        return indices, len(indices)
+
+    def _filter_batch_simple_null(
+        self, batch: pa.RecordBatch
+    ) -> Optional[pa.RecordBatch]:
+        if self.predicate.method not in ('isNull', 'isNotNull') or not self.predicate.field:
+            return None
+        if self.predicate.field not in batch.schema.names:
+            return None
+        col = batch.column(self.predicate.field)
+        mask = pc.is_null(col) if self.predicate.method == 'isNull' else pc.is_valid(col)
+        return batch.filter(mask)
+
+    def _filter_batch(self, batch: pa.RecordBatch) -> Optional[pa.RecordBatch]:
+        simple_null = self._filter_batch_simple_null(batch)
+        if simple_null is not None:
+            return simple_null
+        if not self.predicate.has_null_check():
+            try:
+                expr = self.predicate.to_arrow()
+                result = ds.InMemoryDataset(pa.Table.from_batches([batch])).scanner(
+                    filter=expr
+                ).to_table()
+                if result.num_rows == 0:
+                    return None
+                batches = result.to_batches()
+                if not batches:
+                    return None
+                if len(batches) == 1:
+                    return batches[0]
+                concat_batches = getattr(pa, "concat_batches", None)
+                if concat_batches is not None:
+                    return concat_batches(batches)
+                return pa.RecordBatch.from_arrays(
+                    [result.column(i) for i in range(result.num_columns)],
+                    schema=result.schema,
+                )
+            except (TypeError, ValueError, pa.ArrowInvalid) as e:
+                logger.debug(
+                    "PyArrow vectorized filtering failed, fallback to row-by-row: %s", e
+                )
+        nrows = batch.num_rows
+        col_indices, ncols = self._build_col_indices(batch)
+        mask = []
+        row_tuple = [None] * ncols
+        offset_row = OffsetRow(row_tuple, 0, ncols)
+        for i in range(nrows):
+            for j in range(ncols):
+                if col_indices[j] is not None:
+                    row_tuple[j] = batch.column(col_indices[j])[i].as_py()
+                else:
+                    row_tuple[j] = None
+            offset_row.replace(tuple(row_tuple))
+            try:
+                mask.append(self.predicate.test(offset_row))
+            except (TypeError, ValueError):
+                mask.append(False)
+        if not any(mask):
+            return None
+        return batch.filter(pa.array(mask))
+
+    def return_batch_pos(self) -> int:
+        pos = getattr(self.reader, 'return_batch_pos', lambda: 0)()
+        return pos if pos is not None else 0
+
+    def close(self) -> None:
+        self.reader.close()

--- a/paimon-python/pypaimon/read/scanner/file_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/file_scanner.py
@@ -434,11 +434,7 @@ class FileScanner:
         else:
             if not self.predicate:
                 return True
-<<<<<<< HEAD
-            if self.predicate_for_stats is None:
-=======
-            if self.data_evolution:
->>>>>>> 867ca010a ([python] fix data evolution predicate filtering)
+            if self.predicate_for_stats is None or self.data_evolution:
                 return True
             if entry.file.value_stats_cols is None and entry.file.write_cols is not None:
                 stats_fields = entry.file.write_cols

--- a/paimon-python/pypaimon/read/scanner/file_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/file_scanner.py
@@ -434,7 +434,11 @@ class FileScanner:
         else:
             if not self.predicate:
                 return True
+<<<<<<< HEAD
             if self.predicate_for_stats is None:
+=======
+            if self.data_evolution:
+>>>>>>> 867ca010a ([python] fix data evolution predicate filtering)
                 return True
             if entry.file.value_stats_cols is None and entry.file.write_cols is not None:
                 stats_fields = entry.file.write_cols

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -66,7 +66,7 @@ class TableRead:
         num_rows = batch.num_rows
 
         for field in target_schema:
-            if field.name in batch.column_names:
+            if field.name in batch.schema.names:
                 col = batch.column(field.name)
             else:
                 col = pyarrow.nulls(num_rows, type=field.type)
@@ -198,7 +198,7 @@ class TableRead:
         elif self.table.options.data_evolution_enabled():
             return DataEvolutionSplitRead(
                 table=self.table,
-                predicate=None,  # Never push predicate to split read
+                predicate=self.predicate,
                 read_type=self.read_type,
                 split=split,
                 row_tracking_enabled=True

--- a/paimon-python/pypaimon/tests/data_evolution_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_test.py
@@ -699,7 +699,6 @@ class DataEvolutionTest(unittest.TestCase):
 
         # is_null('c'): Arrow and row-by-row must return same rows
         pred_is_null = Predicate(method="isNull", index=1, field="c", literals=None)
-        self.assertFalse(pred_is_null.has_null_check())
         arrow_res = _filter_batch_arrow(batch, pred_is_null)
         row_res = _filter_batch_row_by_row(batch, pred_is_null, ncols)
         self.assertEqual(arrow_res.num_rows, row_res.num_rows)
@@ -717,7 +716,6 @@ class DataEvolutionTest(unittest.TestCase):
         self.assertEqual(arrow_res2.num_rows, 2)
 
         pred_eq_null = Predicate(method="equal", index=1, field="c", literals=[None])
-        self.assertTrue(pred_eq_null.has_null_check())
         row_res3 = _filter_batch_row_by_row(batch, pred_eq_null, ncols)
         self.assertEqual(row_res3.num_rows, 0)  # Paimon: val is None -> False, no row matches
         arrow_res3 = _filter_batch_arrow(batch, pred_eq_null)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes predicate pushdown and scan-time stats pruning for data-evolution reads, which can affect which files/rows are returned and may impact performance. Risk is moderated by added unit tests covering filters, projections, and NULL handling.
> 
> **Overview**
> Fixes filtering on *data-evolution-enabled* tables by **applying predicates after schema-merge** instead of trying to push them into per-file readers/stats.
> 
> Adds `FilterRecordBatchReader` to filter merged `RecordBatch` output via Arrow expressions, skips manifest-entry stats filtering when `data_evolution` is enabled, and only applies reader-side filtering when all predicate columns are present in the requested projection.
> 
> Also tightens Arrow batch padding logic (`batch.schema.names` check) and expands `data_evolution_test.py` with coverage for evolved-column filters, projection interactions, and Arrow vs row-by-row NULL semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d169da4155407571f023a679bb34d38983912dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->