### PR TITLE
Abort fix

### DIFF
--- a/paimon-python/pypaimon/tests/ray_sink_test.py
+++ b/paimon-python/pypaimon/tests/ray_sink_test.py
@@ -250,7 +250,7 @@ class RaySinkTest(unittest.TestCase):
         self.assertEqual(len(commit_args), 2)  # Empty message filtered out
         mock_commit.close.assert_called_once()
 
-        # Test commit failure: abort should be called
+        # Test commit failure: abort should not be called
         datasink = PaimonDatasink(self.table, overwrite=False)
         datasink.on_write_start()
         commit_msg1 = Mock(spec=CommitMessage)
@@ -271,9 +271,7 @@ class RaySinkTest(unittest.TestCase):
         with self.assertRaises(Exception):
             datasink.on_write_complete(write_result)
 
-        mock_commit.abort.assert_called_once()
-        abort_args = mock_commit.abort.call_args[0][0]
-        self.assertEqual(len(abort_args), 2)
+        mock_commit.abort.assert_not_called()
         mock_commit.close.assert_called_once()
 
         # Test table_commit creation failure

--- a/paimon-python/pypaimon/tests/rest/rest_catalog_commit_snapshot_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_catalog_commit_snapshot_test.py
@@ -22,6 +22,9 @@ import time
 import unittest
 from unittest.mock import Mock, patch
 
+import pyarrow as pa
+
+from pypaimon import Schema
 from pypaimon.api.api_response import CommitTableResponse
 from pypaimon.common.options import Options
 from pypaimon.api.rest_exception import NoSuchResourceException
@@ -31,6 +34,7 @@ from pypaimon.catalog.rest.rest_catalog import RESTCatalog
 from pypaimon.common.identifier import Identifier
 from pypaimon.snapshot.snapshot import Snapshot
 from pypaimon.snapshot.snapshot_commit import PartitionStatistics
+from pypaimon.tests.rest.rest_base_test import RESTBaseTest
 
 
 class TestRESTCatalogCommitSnapshot(unittest.TestCase):
@@ -290,6 +294,48 @@ class TestRESTCatalogCommitSnapshot(unittest.TestCase):
         finally:
             server.shutdown()
             shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+class TestRESTCommit(RESTBaseTest):
+
+    def test_commit_succeeded_on_server_but_client_fails(self):
+        pa_schema = pa.schema([('id', pa.int32()), ('name', pa.string())])
+        opts = {
+            'bucket': '1',
+            'file.format': 'parquet',
+            'commit.max-retries': '1',
+            'commit.timeout': '1000',
+        }
+        schema = Schema.from_pyarrow_schema(
+            pa_schema, partition_keys=['id'], options=opts)
+        self.rest_catalog.create_table('default.test_abort_bug', schema, False)
+        table = self.rest_catalog.get_table('default.test_abort_bug')
+
+        tw = table.new_batch_write_builder().new_write()
+        tc = table.new_batch_write_builder().new_commit()
+        data = pa.Table.from_pydict(
+            {'id': [1, 2, 3], 'name': ['a', 'b', 'c']}, schema=pa_schema)
+        tw.write_arrow(data)
+        cm = tw.prepare_commit()
+
+        real_commit = tc.file_store_commit.snapshot_commit.commit
+
+        def commit_then_raise(_, sn, br, st):
+            real_commit(sn, br, st)
+            raise RuntimeError("simulated")
+
+        tc.file_store_commit.snapshot_commit.commit = commit_then_raise
+        with self.assertRaises(RuntimeError):
+            tc.commit(cm)
+        tw.close()
+        tc.close()
+
+        # We no longer abort on failure. Data was committed on server.
+        rb = table.new_read_builder()
+        actual = rb.new_read().to_arrow(rb.new_scan().plan().splits())
+        self.assertEqual(actual.num_rows, 3)
+        self.assertEqual(actual.column('id').to_pylist(), [1, 2, 3])
+        self.assertEqual(actual.column('name').to_pylist(), ['a', 'b', 'c'])
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/write/ray_datasink.py
+++ b/paimon-python/pypaimon/write/ray_datasink.py
@@ -155,7 +155,8 @@ class PaimonDatasink(_DatasinkBase):
                 f"Error committing write job for table {self._table_name}: {e}",
                 exc_info=e
             )
-            self._pending_commit_messages = []
+            if table_commit is not None:
+                self._pending_commit_messages = []
             raise
         finally:
             if table_commit is not None:

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -48,21 +48,18 @@ class TableCommit:
         if not non_empty_messages:
             return
 
-        try:
-            if self.overwrite_partition is not None:
-                self.file_store_commit.overwrite(
-                    overwrite_partition=self.overwrite_partition,
-                    commit_messages=non_empty_messages,
-                    commit_identifier=commit_identifier
-                )
-            else:
-                self.file_store_commit.commit(
-                    commit_messages=non_empty_messages,
-                    commit_identifier=commit_identifier
-                )
-        except Exception as e:
-            self.file_store_commit.abort(commit_messages)
-            raise RuntimeError(f"Failed to commit: {str(e)}") from e
+        # Align with Java: no abort on commit failure.
+        if self.overwrite_partition is not None:
+            self.file_store_commit.overwrite(
+                overwrite_partition=self.overwrite_partition,
+                commit_messages=non_empty_messages,
+                commit_identifier=commit_identifier
+            )
+        else:
+            self.file_store_commit.commit(
+                commit_messages=non_empty_messages,
+                commit_identifier=commit_identifier
+            )
 
     def abort(self, commit_messages: List[CommitMessage]):
         self.file_store_commit.abort(commit_messages)

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -48,7 +48,6 @@ class TableCommit:
         if not non_empty_messages:
             return
 
-        # Align with Java: no abort on commit failure.
         if self.overwrite_partition is not None:
             self.file_store_commit.overwrite(
                 overwrite_partition=self.overwrite_partition,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes commit failure semantics and could leave partially committed data/resources if exceptions occur after commit begins; mitigated by added regression tests around REST and Ray sink paths.
> 
> **Overview**
> Prevents client-side failures during commit from triggering `abort()`, avoiding accidental rollback/cleanup when the commit may have already succeeded (notably with REST-backed commits).
> 
> This removes the automatic abort-on-exception behavior from `TableCommit._commit()` and `PaimonDatasink.on_write_complete()`, leaving abort handling only for explicit job failures via `on_write_failed()`. Tests were updated and extended to assert abort is not called on commit exceptions and to cover the “server committed but client errored” scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e41b9123d38d8fa390a4953a05d0d69e2c326f16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->