### PR TITLE
[python] add more log

### DIFF
--- a/paimon-python/pypaimon/snapshot/catalog_snapshot_commit.py
+++ b/paimon-python/pypaimon/snapshot/catalog_snapshot_commit.py
@@ -16,9 +16,12 @@
 # limitations under the License.
 ################################################################################
 
+import logging
 from typing import List
 
 from pypaimon.catalog.catalog import Catalog
+
+logger = logging.getLogger(__name__)
 from pypaimon.common.identifier import Identifier
 from pypaimon.snapshot.snapshot import Snapshot
 from pypaimon.snapshot.snapshot_commit import (PartitionStatistics,
@@ -64,7 +67,10 @@ class CatalogSnapshotCommit(SnapshotCommit):
 
         # Call catalog's commit_snapshot method
         if hasattr(self.catalog, 'commit_snapshot'):
-            return self.catalog.commit_snapshot(new_identifier, self.uuid, snapshot, statistics)
+            success = self.catalog.commit_snapshot(new_identifier, self.uuid, snapshot, statistics)
+            if success:
+                logger.info("Catalog snapshot commit succeeded for %s, snapshot id %d", new_identifier, snapshot.id)
+            return success
         else:
             # Fallback for catalogs that don't support snapshot commits
             raise NotImplementedError(

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -51,19 +51,6 @@ class TableCommit:
         if not non_empty_messages:
             return
 
-<<<<<<< HEAD
-        if self.overwrite_partition is not None:
-            self.file_store_commit.overwrite(
-                overwrite_partition=self.overwrite_partition,
-                commit_messages=non_empty_messages,
-                commit_identifier=commit_identifier
-            )
-        else:
-            self.file_store_commit.commit(
-                commit_messages=non_empty_messages,
-                commit_identifier=commit_identifier
-            )
-=======
         logger.info(
             "Committing batch table %s, %d non-empty messages",
             self.table.identifier, len(non_empty_messages)
@@ -83,7 +70,6 @@ class TableCommit:
         except Exception as e:
             self.file_store_commit.abort(commit_messages)
             raise RuntimeError(f"Failed to commit: {str(e)}") from e
->>>>>>> 15fcebca9 ([python] add more log)
 
     def abort(self, commit_messages: List[CommitMessage]):
         self.file_store_commit.abort(commit_messages)

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -55,21 +55,17 @@ class TableCommit:
             "Committing batch table %s, %d non-empty messages",
             self.table.identifier, len(non_empty_messages)
         )
-        try:
-            if self.overwrite_partition is not None:
-                self.file_store_commit.overwrite(
-                    overwrite_partition=self.overwrite_partition,
-                    commit_messages=non_empty_messages,
-                    commit_identifier=commit_identifier
-                )
-            else:
-                self.file_store_commit.commit(
-                    commit_messages=non_empty_messages,
-                    commit_identifier=commit_identifier
-                )
-        except Exception as e:
-            self.file_store_commit.abort(commit_messages)
-            raise RuntimeError(f"Failed to commit: {str(e)}") from e
+        if self.overwrite_partition is not None:
+            self.file_store_commit.overwrite(
+                overwrite_partition=self.overwrite_partition,
+                commit_messages=non_empty_messages,
+                commit_identifier=commit_identifier
+            )
+        else:
+            self.file_store_commit.commit(
+                commit_messages=non_empty_messages,
+                commit_identifier=commit_identifier
+            )
 
     def abort(self, commit_messages: List[CommitMessage]):
         self.file_store_commit.abort(commit_messages)

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -16,9 +16,12 @@
 # limitations under the License.
 ################################################################################
 
+import logging
 from typing import Dict, List, Optional
 
 from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
+
+logger = logging.getLogger(__name__)
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.file_store_commit import FileStoreCommit
 
@@ -48,6 +51,7 @@ class TableCommit:
         if not non_empty_messages:
             return
 
+<<<<<<< HEAD
         if self.overwrite_partition is not None:
             self.file_store_commit.overwrite(
                 overwrite_partition=self.overwrite_partition,
@@ -59,6 +63,27 @@ class TableCommit:
                 commit_messages=non_empty_messages,
                 commit_identifier=commit_identifier
             )
+=======
+        logger.info(
+            "Committing batch table %s, %d non-empty messages",
+            self.table.identifier, len(non_empty_messages)
+        )
+        try:
+            if self.overwrite_partition is not None:
+                self.file_store_commit.overwrite(
+                    overwrite_partition=self.overwrite_partition,
+                    commit_messages=non_empty_messages,
+                    commit_identifier=commit_identifier
+                )
+            else:
+                self.file_store_commit.commit(
+                    commit_messages=non_empty_messages,
+                    commit_identifier=commit_identifier
+                )
+        except Exception as e:
+            self.file_store_commit.abort(commit_messages)
+            raise RuntimeError(f"Failed to commit: {str(e)}") from e
+>>>>>>> 15fcebca9 ([python] add more log)
 
     def abort(self, commit_messages: List[CommitMessage]):
         self.file_store_commit.abort(commit_messages)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds/adjusts logging and minor control-flow around missing snapshots; low behavioral risk but could increase log volume in hot paths like commits/scans.
> 
> **Overview**
> Adds additional operational logging across the Python read/write stack to make table scans and snapshot commits easier to observe and debug.
> 
> `FileScanner.scan` now logs total planning time and number of planned files. Commit paths (`FileStoreCommit`/`TableCommit`) log start/end of append/overwrite operations, collected entry counts, commit duration, and richer retry/atomic-commit failure context (including user, identifier, kind, and elapsed time). Snapshot commit implementations (`CatalogSnapshotCommit`, `RenamingSnapshotCommit`) log successful commits, and `SnapshotManager.try_get_earliest_snapshot` now warns when a previously identified earliest snapshot is missing; the LATEST-hint update warning switches from `print` to structured logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4d41df5e0914a8bdcebecd64b30e69cad4ce25c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->