### PR TITLE
[python] fix reading on legacy manifest list without _MIN_ROW_ID/_MAX_ROW_ID

### DIFF
--- a/paimon-python/pypaimon/manifest/manifest_list_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_list_manager.py
@@ -81,8 +81,8 @@ class ManifestListManager:
                 num_deleted_files=record['_NUM_DELETED_FILES'],
                 partition_stats=partition_stats,
                 schema_id=record['_SCHEMA_ID'],
-                min_row_id=record['_MIN_ROW_ID'],
-                max_row_id=record['_MAX_ROW_ID'],
+                min_row_id=record.get('_MIN_ROW_ID'),
+                max_row_id=record.get('_MAX_ROW_ID'),
             )
             manifest_files.append(manifest_file_meta)
 

--- a/paimon-python/pypaimon/tests/manifest/manifest_schema_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_schema_test.py
@@ -231,4 +231,3 @@ class ManifestSchemaTest(unittest.TestCase):
         self.assertEqual(meta.schema_id, 0)
         self.assertIsNone(meta.min_row_id)
         self.assertIsNone(meta.max_row_id)
-


### PR DESCRIPTION
…_ROW_ID

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, backward-compatible change to manifest list deserialization plus targeted tests; primary risk is subtle schema/Avro compatibility expectations when reading older files.
> 
> **Overview**
> `ManifestListManager.read` now treats `_MIN_ROW_ID` and `_MAX_ROW_ID` as optional when decoding Avro manifest lists, using `record.get(...)` so legacy files without these fields no longer raise `KeyError`.
> 
> Tests are extended to assert the manifest schema includes nullable row-id fields with `None` defaults and to write/read a legacy manifest-list Avro record (without row ids) to verify the reader returns `None` for `min_row_id`/`max_row_id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 556cac16efcae9708105c5454a79201b90d8c249. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->