### PR TITLE
[python] do not prune file when null_count stats are missing during i…

### DIFF
--- a/paimon-python/pypaimon/common/predicate.py
+++ b/paimon-python/pypaimon/common/predicate.py
@@ -76,7 +76,7 @@ class Predicate:
         null_count = stat.null_counts[self.index]
 
         if self.method == 'isNull':
-            return null_count is not None and null_count > 0
+            return null_count is None or null_count > 0
         if self.method == 'isNotNull':
             return null_count is None or row_count is None or null_count < row_count
 


### PR DESCRIPTION
…fNull filter

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes file pruning behavior for `isNull` predicates during stats-based filtering, which can impact query results and performance if incorrect. Scope is small and covered by a targeted unit test.
> 
> **Overview**
> Fixes stats-based predicate evaluation so `isNull` **does not prune files** when `null_count` is missing (`None`), treating absent null stats as unknown rather than zero.
> 
> Adds a focused unit test covering `isNull` behavior for missing, zero, and positive `null_count` values, and updates test imports accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9ce7983f7e3bdc745666add8860adbb8e9b57bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->