### PR TITLE
[python] Light refactor: move  _is_blob_file check into DataFileMeta

### DIFF
--- a/paimon-python/pypaimon/manifest/schema/data_file_meta.py
+++ b/paimon-python/pypaimon/manifest/schema/data_file_meta.py
@@ -160,10 +160,6 @@ class DataFileMeta:
 
     @staticmethod
     def is_blob_file(file_name: str) -> bool:
-        """
-        True if the given file name is a blob data file (by extension).
-        Aligns with Java BlobFileFormat.isBlobFile(String fileName).
-        """
         return file_name.endswith(".blob")
 
     def assign_first_row_id(self, first_row_id: int) -> 'DataFileMeta':

--- a/paimon-python/pypaimon/manifest/schema/data_file_meta.py
+++ b/paimon-python/pypaimon/manifest/schema/data_file_meta.py
@@ -158,8 +158,13 @@ class DataFileMeta:
             file_path=self.file_path
         )
 
-    def is_blob_file(self) -> bool:
-        return self.file_name.endswith(".blob")
+    @staticmethod
+    def is_blob_file(file_name: str) -> bool:
+        """
+        True if the given file name is a blob data file (by extension).
+        Aligns with Java BlobFileFormat.isBlobFile(String fileName).
+        """
+        return file_name.endswith(".blob")
 
     def assign_first_row_id(self, first_row_id: int) -> 'DataFileMeta':
         """Create a new DataFileMeta with the assigned first_row_id."""

--- a/paimon-python/pypaimon/manifest/schema/data_file_meta.py
+++ b/paimon-python/pypaimon/manifest/schema/data_file_meta.py
@@ -158,6 +158,9 @@ class DataFileMeta:
             file_path=self.file_path
         )
 
+    def is_blob_file(self) -> bool:
+        return self.file_name.endswith(".blob")
+
     def assign_first_row_id(self, first_row_id: int) -> 'DataFileMeta':
         """Create a new DataFileMeta with the assigned first_row_id."""
         return DataFileMeta(

--- a/paimon-python/pypaimon/read/reader/field_bunch.py
+++ b/paimon-python/pypaimon/read/reader/field_bunch.py
@@ -64,7 +64,7 @@ class BlobBunch(FieldBunch):
 
     def add(self, file: DataFileMeta) -> None:
         """Add a blob file to this bunch."""
-        if not file.is_blob_file():
+        if not DataFileMeta.is_blob_file(file.file_name):
             raise ValueError("Only blob file can be added to a blob bunch.")
 
         if file.first_row_id == self.latest_first_row_id:

--- a/paimon-python/pypaimon/read/reader/field_bunch.py
+++ b/paimon-python/pypaimon/read/reader/field_bunch.py
@@ -64,7 +64,7 @@ class BlobBunch(FieldBunch):
 
     def add(self, file: DataFileMeta) -> None:
         """Add a blob file to this bunch."""
-        if not self._is_blob_file(file.file_name):
+        if not file.is_blob_file():
             raise ValueError("Only blob file can be added to a blob bunch.")
 
         if file.first_row_id == self.latest_first_row_id:
@@ -113,8 +113,3 @@ class BlobBunch(FieldBunch):
 
     def files(self) -> List[DataFileMeta]:
         return self._files
-
-    @staticmethod
-    def _is_blob_file(file_name: str) -> bool:
-        """Check if a file is a blob file based on its extension."""
-        return file_name.endswith('.blob')

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -54,7 +54,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                 if manifest_entry.file.first_row_id is not None
                 else float('-inf')
             )
-            is_blob = 1 if self._is_blob_file(manifest_entry.file.file_name) else 0
+            is_blob = 1 if manifest_entry.file.is_blob_file() else 0
             max_seq = manifest_entry.file.max_sequence_number
             return first_row_id, is_blob, -max_seq
 
@@ -341,7 +341,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                 split_by_row_id.append([file])
                 continue
 
-            if not self._is_blob_file(file.file_name) and first_row_id != last_row_id:
+            if not file.is_blob_file() and first_row_id != last_row_id:
                 if current_split:
                     split_by_row_id.append(current_split)
 
@@ -382,7 +382,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         current_pos = file_end_pos
         data_file_infos = []
         for file in split.files:
-            if self._is_blob_file(file.file_name):
+            if file.is_blob_file():
                 continue
             file_begin_pos = current_pos
             current_pos += file.row_count
@@ -402,7 +402,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
         # Second pass: only blob files (data files already in shard_file_idx_map from first pass)
         for file in split.files:
-            if not self._is_blob_file(file.file_name):
+            if not file.is_blob_file():
                 continue
             blob_first_row_id = file.first_row_id if file.first_row_id is not None else 0
             data_file_range = None
@@ -489,7 +489,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         row_id_end = -1
 
         for file in files:
-            if not DataEvolutionSplitGenerator._is_blob_file(file.file_name):
+            if not file.is_blob_file():
                 if file.first_row_id is not None:
                     row_id_start = file.first_row_id
                     row_id_end = file.first_row_id + file.row_count

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -54,7 +54,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                 if manifest_entry.file.first_row_id is not None
                 else float('-inf')
             )
-            is_blob = 1 if manifest_entry.file.is_blob_file() else 0
+            is_blob = 1 if DataFileMeta.is_blob_file(manifest_entry.file.file_name) else 0
             max_seq = manifest_entry.file.max_sequence_number
             return first_row_id, is_blob, -max_seq
 
@@ -341,7 +341,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                 split_by_row_id.append([file])
                 continue
 
-            if not file.is_blob_file() and first_row_id != last_row_id:
+            if not DataFileMeta.is_blob_file(file.file_name) and first_row_id != last_row_id:
                 if current_split:
                     split_by_row_id.append(current_split)
 
@@ -382,7 +382,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         current_pos = file_end_pos
         data_file_infos = []
         for file in split.files:
-            if file.is_blob_file():
+            if DataFileMeta.is_blob_file(file.file_name):
                 continue
             file_begin_pos = current_pos
             current_pos += file.row_count
@@ -402,7 +402,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
         # Second pass: only blob files (data files already in shard_file_idx_map from first pass)
         for file in split.files:
-            if not file.is_blob_file():
+            if not DataFileMeta.is_blob_file(file.file_name):
                 continue
             blob_first_row_id = file.first_row_id if file.first_row_id is not None else 0
             data_file_range = None
@@ -489,7 +489,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         row_id_end = -1
 
         for file in files:
-            if not file.is_blob_file():
+            if not DataFileMeta.is_blob_file(file.file_name):
                 if file.first_row_id is not None:
                     row_id_start = file.first_row_id
                     row_id_end = file.first_row_id + file.row_count

--- a/paimon-python/pypaimon/read/scanner/split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/split_generator.py
@@ -240,8 +240,3 @@ class AbstractSplitGenerator(ABC):
             return -1, -1
         # File is completely within the shard range
         return None
-
-    @staticmethod
-    def _is_blob_file(file_name: str) -> bool:
-        """Check if a file is a blob file."""
-        return file_name.endswith('.blob')

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -475,7 +475,7 @@ class DataEvolutionSplitRead(SplitRead):
         # Sort files by firstRowId and then by maxSequenceNumber
         def sort_key(file: DataFileMeta) -> tuple:
             first_row_id = file.first_row_id if file.first_row_id is not None else float('-inf')
-            is_blob = 1 if file.is_blob_file() else 0
+            is_blob = 1 if DataFileMeta.is_blob_file(file.file_name) else 0
             max_seq = file.max_sequence_number
             return (first_row_id, is_blob, -max_seq)
 
@@ -493,7 +493,7 @@ class DataEvolutionSplitRead(SplitRead):
                 split_by_row_id.append([file])
                 continue
 
-            if not file.is_blob_file() and first_row_id != last_row_id:
+            if not DataFileMeta.is_blob_file(file.file_name) and first_row_id != last_row_id:
                 if current_split:
                     split_by_row_id.append(current_split)
                 if first_row_id < check_row_id_start:
@@ -541,7 +541,7 @@ class DataEvolutionSplitRead(SplitRead):
             first_file = bunch.files()[0]
 
             # Get field IDs for this bunch
-            if first_file.is_blob_file():
+            if DataFileMeta.is_blob_file(first_file.file_name):
                 # For blob files, we need to get the field ID from the write columns
                 field_ids = [self._get_field_id_from_write_cols(first_file)]
             elif first_file.write_cols:
@@ -615,7 +615,7 @@ class DataEvolutionSplitRead(SplitRead):
         row_count = -1
 
         for file in need_merge_files:
-            if file.is_blob_file():
+            if DataFileMeta.is_blob_file(file.file_name):
                 field_id = self._get_field_id_from_write_cols(file)
                 if field_id not in blob_bunch_map:
                     blob_bunch_map[field_id] = BlobBunch(row_count)

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -475,7 +475,7 @@ class DataEvolutionSplitRead(SplitRead):
         # Sort files by firstRowId and then by maxSequenceNumber
         def sort_key(file: DataFileMeta) -> tuple:
             first_row_id = file.first_row_id if file.first_row_id is not None else float('-inf')
-            is_blob = 1 if self._is_blob_file(file.file_name) else 0
+            is_blob = 1 if file.is_blob_file() else 0
             max_seq = file.max_sequence_number
             return (first_row_id, is_blob, -max_seq)
 
@@ -493,7 +493,7 @@ class DataEvolutionSplitRead(SplitRead):
                 split_by_row_id.append([file])
                 continue
 
-            if not self._is_blob_file(file.file_name) and first_row_id != last_row_id:
+            if not file.is_blob_file() and first_row_id != last_row_id:
                 if current_split:
                     split_by_row_id.append(current_split)
                 if first_row_id < check_row_id_start:
@@ -541,7 +541,7 @@ class DataEvolutionSplitRead(SplitRead):
             first_file = bunch.files()[0]
 
             # Get field IDs for this bunch
-            if self._is_blob_file(first_file.file_name):
+            if first_file.is_blob_file():
                 # For blob files, we need to get the field ID from the write columns
                 field_ids = [self._get_field_id_from_write_cols(first_file)]
             elif first_file.write_cols:
@@ -615,7 +615,7 @@ class DataEvolutionSplitRead(SplitRead):
         row_count = -1
 
         for file in need_merge_files:
-            if self._is_blob_file(file.file_name):
+            if file.is_blob_file():
                 field_id = self._get_field_id_from_write_cols(file)
                 if field_id not in blob_bunch_map:
                     blob_bunch_map[field_id] = BlobBunch(row_count)
@@ -649,11 +649,6 @@ class DataEvolutionSplitRead(SplitRead):
         field_ids.append(SpecialFields.ROW_ID.id)
         field_ids.append(SpecialFields.SEQUENCE_NUMBER.id)
         return field_ids
-
-    @staticmethod
-    def _is_blob_file(file_name: str) -> bool:
-        """Check if a file is a blob file based on its extension."""
-        return file_name.endswith('.blob')
 
     def _get_all_data_fields(self):
         return SpecialFields.row_type_with_row_tracking(self.table.fields)

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -648,7 +648,7 @@ class FileStoreCommit:
                     entry.file.file_source == 0 and  # APPEND file source
                     entry.file.first_row_id is None):  # No existing first_row_id
 
-                if self._is_blob_file(entry.file.file_name):
+                if entry.file.is_blob_file():
                     # Handle blob files specially
                     if blob_start >= start:
                         raise RuntimeError(
@@ -669,8 +669,3 @@ class FileStoreCommit:
                 row_id_assigned.append(entry)
 
         return row_id_assigned, start
-
-    @staticmethod
-    def _is_blob_file(file_name: str) -> bool:
-        """Check if a file is a blob file based on its extension."""
-        return file_name.endswith('.blob')

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -25,6 +25,7 @@ from typing import Dict, List, Optional
 from pypaimon.common.predicate_builder import PredicateBuilder
 from pypaimon.manifest.manifest_file_manager import ManifestFileManager
 from pypaimon.manifest.manifest_list_manager import ManifestListManager
+from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.manifest.schema.manifest_file_meta import ManifestFileMeta
 from pypaimon.manifest.schema.simple_stats import SimpleStats
@@ -648,7 +649,7 @@ class FileStoreCommit:
                     entry.file.file_source == 0 and  # APPEND file source
                     entry.file.first_row_id is None):  # No existing first_row_id
 
-                if entry.file.is_blob_file():
+                if DataFileMeta.is_blob_file(entry.file.file_name):
                     # Handle blob files specially
                     if blob_start >= start:
                         raise RuntimeError(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes the `.blob` extension check into `DataFileMeta` and updates call sites; behavior should remain the same, but incorrect blob classification would affect split/commit logic.
> 
> **Overview**
> Centralizes blob-file detection by adding `DataFileMeta.is_blob_file()` and switching readers/scanners/commit code to use it.
> 
> Removes duplicated `_is_blob_file` helpers from `field_bunch.py`, `split_read.py`, `split_generator.py`, and `file_store_commit.py`, and updates the affected split sorting/grouping and row-id assignment paths accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1f9402af44632b54a8d003239de6b6823ae620c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->