### PR TITLE
add doc for filter by _ROW_ID

### DIFF
--- a/docs/content/pypaimon/data-evolution.md
+++ b/docs/content/pypaimon/data-evolution.md
@@ -100,7 +100,7 @@ table_commit.close()
 
 ## Filter by _ROW_ID
 
-On data evolution tables you can filter by `_ROW_ID` to prune files at scan time. Supported: `equal('_ROW_ID', id)`, `is_in('_ROW_ID', [id1, ...])`, `between('_ROW_ID', low, high)`.
+Requires the same [Prerequisites](#prerequisites) (row-tracking and data-evolution enabled). On such tables you can filter by `_ROW_ID` to prune files at scan time. Supported: `equal('_ROW_ID', id)`, `is_in('_ROW_ID', [id1, ...])`, `between('_ROW_ID', low, high)`.
 
 ```python
 pb = table.new_read_builder().new_predicate_builder()

--- a/docs/content/pypaimon/data-evolution.md
+++ b/docs/content/pypaimon/data-evolution.md
@@ -98,6 +98,16 @@ table_commit.close()
 #   'f1': [-1001, 1002]
 ```
 
+## Filter by _ROW_ID
+
+On data evolution tables you can filter by `_ROW_ID` to prune files at scan time. Supported: `equal('_ROW_ID', id)`, `is_in('_ROW_ID', [id1, ...])`, `between('_ROW_ID', low, high)`.
+
+```python
+pb = table.new_read_builder().new_predicate_builder()
+rb = table.new_read_builder().with_filter(pb.equal('_ROW_ID', 0))
+result = rb.new_read().to_arrow(rb.new_scan().plan().splits())
+```
+
 ## Update Columns By Shards
 
 If you want to **compute a derived column** (or **update an existing column based on other columns**) without providing

--- a/docs/content/pypaimon/python-api.md
+++ b/docs/content/pypaimon/python-api.md
@@ -258,7 +258,7 @@ predicate_5 = predicate_builder.and_predicates([predicate3, predicate4])
 read_builder = read_builder.with_filter(predicate_5)
 ```
 
-See [Predicate]({{< ref "python-api#predicate" >}}) for all supported filters and building methods.
+See [Predicate]({{< ref "python-api#predicate" >}}) for all supported filters and building methods. Filter by `_ROW_ID`: see [Data Evolution]({{< ref "pypaimon/data-evolution#filter-by-_row_id" >}}).
 
 You can also pushdown projection by `ReadBuilder`:
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds usage guidance and links; no runtime or API behavior is modified.
> 
> **Overview**
> Documents a new **"Filter by `_ROW_ID`"** section in `pypaimon/data-evolution`, describing prerequisites, supported predicates (`equal`, `is_in`, `between`), and a short read example.
> 
> Updates `pypaimon/python-api` to reference this `_ROW_ID` filtering guidance from the predicate pushdown section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c37bc04972d4d4366a6af2ebaa9a2835504cd7d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->