### PR TITLE
[core] Fix ClassCastException when paimon_incremental_query with limi…

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -138,6 +138,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
         long scannedRowCount = 0;
         SnapshotReader.Plan plan = ((ScannedResult) result).plan();
         List<Split> planSplits = plan.splits();
+        // Limit pushdown only supports DataSplit. Skip for IncrementalSplit.
         if (planSplits.stream().anyMatch(s -> !(s instanceof DataSplit))) {
             return Optional.of(result);
         }
@@ -200,6 +201,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
 
         SnapshotReader.Plan plan = ((ScannedResult) result).plan();
         List<Split> planSplits = plan.splits();
+        // TopN pushdown only supports DataSplit. Skip for IncrementalSplit.
         if (planSplits.stream().anyMatch(s -> !(s instanceof DataSplit))) {
             return Optional.of(result);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -135,6 +135,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
             return Optional.of(result);
         }
 
+        long scannedRowCount = 0;
         SnapshotReader.Plan plan = ((ScannedResult) result).plan();
         List<Split> planSplits = plan.splits();
         if (planSplits.stream().anyMatch(s -> !(s instanceof DataSplit))) {
@@ -143,7 +144,6 @@ public class DataTableBatchScan extends AbstractDataTableScan {
         @SuppressWarnings("unchecked")
         List<DataSplit> splits = (List<DataSplit>) (List<?>) planSplits;
 
-        long scannedRowCount = 0;
         LOG.info("Applying limit pushdown. Original splits count: {}", splits.size());
         if (splits.isEmpty()) {
             return Optional.of(result);
@@ -200,7 +200,6 @@ public class DataTableBatchScan extends AbstractDataTableScan {
 
         SnapshotReader.Plan plan = ((ScannedResult) result).plan();
         List<Split> planSplits = plan.splits();
-        // TopN pushdown only supports DataSplit. Skip for IncrementalSplit.
         if (planSplits.stream().anyMatch(s -> !(s instanceof DataSplit))) {
             return Optional.of(result);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -138,7 +138,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
         SnapshotReader.Plan plan = ((ScannedResult) result).plan();
         List<Split> planSplits = plan.splits();
         if (planSplits.stream().anyMatch(s -> !(s instanceof DataSplit))) {
-            return Optional.empty();
+            return Optional.of(result);
         }
         @SuppressWarnings("unchecked")
         List<DataSplit> splits = (List<DataSplit>) (List<?>) planSplits;
@@ -202,7 +202,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
         List<Split> planSplits = plan.splits();
         // TopN pushdown only supports DataSplit. Skip for IncrementalSplit.
         if (planSplits.stream().anyMatch(s -> !(s instanceof DataSplit))) {
-            return Optional.empty();
+            return Optional.of(result);
         }
         @SuppressWarnings("unchecked")
         List<DataSplit> splits = (List<DataSplit>) (List<?>) planSplits;

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
@@ -344,8 +344,7 @@ class TableValuedFunctionsTest extends PaimonHiveTestBase {
     }
   }
 
-  test(
-    "incremental query by tag with LIMIT - no ClassCastException (IncrementalSplit handled in applyPushDownLimit)") {
+  test("incremental query by tag with LIMIT") {
     sql("use paimon")
     withTable("t") {
       spark.sql("""

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
@@ -344,8 +344,7 @@ class TableValuedFunctionsTest extends PaimonHiveTestBase {
     }
   }
 
-  test(
-    "incremental query by tag with LIMIT") {
+  test("incremental query by tag with LIMIT") {
     sql("use paimon")
     withTable("t") {
       spark.sql("""

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
@@ -361,7 +361,7 @@ class TableValuedFunctionsTest extends PaimonHiveTestBase {
 
       checkAnswer(
         spark.sql(
-          "SELECT * FROM paimon_incremental_query('t', 'tag1', 'tag2') LIMIT 5 ORDER BY a, b"),
+          "SELECT * FROM paimon_incremental_query('t', 'tag1', 'tag2') ORDER BY a, b LIMIT 5"),
         Seq(Row(1, 3, "3"), Row(2, 4, "4")))
     }
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
@@ -344,6 +344,28 @@ class TableValuedFunctionsTest extends PaimonHiveTestBase {
     }
   }
 
+  test(
+    "incremental query by tag with LIMIT - no ClassCastException (IncrementalSplit handled in applyPushDownLimit)") {
+    sql("use paimon")
+    withTable("t") {
+      spark.sql("""
+                  |CREATE TABLE t (a INT, b INT, c STRING)
+                  |USING paimon
+                  |TBLPROPERTIES ('primary-key'='a,b', 'bucket' = '2')
+                  |PARTITIONED BY (a)
+                  |""".stripMargin)
+      spark.sql("INSERT INTO t VALUES (1, 1, '1'), (2, 2, '2')")
+      sql("CALL sys.create_tag('t', 'tag1')")
+      spark.sql("INSERT INTO t VALUES (1, 3, '3'), (2, 4, '4')")
+      sql("CALL sys.create_tag('t', 'tag2')")
+
+      checkAnswer(
+        spark.sql(
+          "SELECT * FROM paimon_incremental_query('t', 'tag1', 'tag2') LIMIT 5 ORDER BY a, b"),
+        Seq(Row(1, 3, "3"), Row(2, 4, "4")))
+    }
+  }
+
   private def incrementalDF(tableIdent: String, start: Int, end: Int): DataFrame = {
     spark.read
       .format("paimon")

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
@@ -345,7 +345,7 @@ class TableValuedFunctionsTest extends PaimonHiveTestBase {
   }
 
   test(
-    "incremental query by tag with LIMIT - no ClassCastException (IncrementalSplit handled in applyPushDownLimit)") {
+    "incremental query by tag with LIMIT") {
     sql("use paimon")
     withTable("t") {
       spark.sql("""

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
@@ -344,7 +344,8 @@ class TableValuedFunctionsTest extends PaimonHiveTestBase {
     }
   }
 
-  test("incremental query by tag with LIMIT") {
+  test(
+    "incremental query by tag with LIMIT - no ClassCastException (IncrementalSplit handled in applyPushDownLimit)") {
     sql("use paimon")
     withTable("t") {
       spark.sql("""


### PR DESCRIPTION
…t pushdown

(cherry picked from commit 1ee09d67e89898764fa3587217b301d219ba1b73)

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the scan planning path for `LIMIT`/`TopN` pushdown to conditionally bypass optimization when non-`DataSplit` (e.g., incremental) splits are present, which could affect query planning behavior for incremental scans but is narrowly scoped and covered by a new Spark test.
> 
> **Overview**
> Prevents `ClassCastException` during `LIMIT` and `TopN` pushdown in `DataTableBatchScan` by using `plan.splits()` and *skipping pushdown* when the plan contains non-`DataSplit` entries (e.g., incremental splits), rather than blindly casting.
> 
> Adds a Spark UT covering `paimon_incremental_query` between tags with an `ORDER BY ... LIMIT` to ensure incremental queries work with limit pushdown present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1513e5d873b26119d02aaf8631b3fcd244d392c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->