### PR TITLE
Py36 path fix again

### DIFF
--- a/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
+++ b/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
@@ -43,6 +43,7 @@ from pypaimon.write.blob_format_writer import BlobFormatWriter
 def _pyarrow_lt_7():
     return parse(pyarrow.__version__) < parse("7.0.0")
 
+
 class PyArrowFileIO(FileIO):
     def __init__(self, path: str, catalog_options: Options):
         self.properties = catalog_options

--- a/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
+++ b/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
@@ -43,7 +43,6 @@ from pypaimon.write.blob_format_writer import BlobFormatWriter
 def _pyarrow_lt_7():
     return parse(pyarrow.__version__) < parse("7.0.0")
 
-
 class PyArrowFileIO(FileIO):
     def __init__(self, path: str, catalog_options: Options):
         self.properties = catalog_options

--- a/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
+++ b/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
@@ -212,6 +212,7 @@ class PyArrowFileIO(FileIO):
     def get_file_status(self, path: str):
         path_str = self.to_filesystem_path(path)
         file_info = self._get_file_info(path_str)
+
         if file_info.type == pafs.FileType.NotFound:
             raise FileNotFoundError(f"File {path} (resolved as {path_str}) does not exist")
 
@@ -236,6 +237,7 @@ class PyArrowFileIO(FileIO):
 
         if file_info.type == pafs.FileType.NotFound:
             return False
+
         if file_info.type == pafs.FileType.Directory:
             if not recursive:
                 selector = pafs.FileSelector(path_str, recursive=False, allow_not_found=True)

--- a/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
+++ b/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
@@ -188,7 +188,7 @@ class PyArrowFileIO(FileIO):
                 parent_dir = '/'.join(path_str.split('/')[:-1])
             else:
                 parent_dir = ''
-
+            
             if parent_dir and not self.exists(parent_dir):
                 self.mkdirs(parent_dir)
         else:
@@ -212,10 +212,10 @@ class PyArrowFileIO(FileIO):
     def get_file_status(self, path: str):
         path_str = self.to_filesystem_path(path)
         file_info = self._get_file_info(path_str)
-
+        
         if file_info.type == pafs.FileType.NotFound:
             raise FileNotFoundError(f"File {path} (resolved as {path_str}) does not exist")
-
+        
         return file_info
 
     def list_status(self, path: str):
@@ -234,10 +234,10 @@ class PyArrowFileIO(FileIO):
     def delete(self, path: str, recursive: bool = False) -> bool:
         path_str = self.to_filesystem_path(path)
         file_info = self._get_file_info(path_str)
-
+        
         if file_info.type == pafs.FileType.NotFound:
             return False
-
+        
         if file_info.type == pafs.FileType.Directory:
             if not recursive:
                 selector = pafs.FileSelector(path_str, recursive=False, allow_not_found=True)
@@ -256,7 +256,7 @@ class PyArrowFileIO(FileIO):
     def mkdirs(self, path: str) -> bool:
         path_str = self.to_filesystem_path(path)
         file_info = self._get_file_info(path_str)
-
+        
         if file_info.type == pafs.FileType.NotFound:
             self.filesystem.create_dir(path_str, recursive=True)
             return True
@@ -264,7 +264,7 @@ class PyArrowFileIO(FileIO):
             return True
         elif file_info.type == pafs.FileType.File:
             raise FileExistsError(f"Path exists but is not a directory: {path}")
-
+        
         self.filesystem.create_dir(path_str, recursive=True)
         return True
 
@@ -273,13 +273,13 @@ class PyArrowFileIO(FileIO):
         dst_parent = Path(dst_str).parent
         if str(dst_parent) and not self.exists(str(dst_parent)):
             self.mkdirs(str(dst_parent))
-
+        
         src_str = self.to_filesystem_path(src)
-
+        
         try:
             if hasattr(self.filesystem, 'rename'):
                 return self.filesystem.rename(src_str, dst_str)
-
+            
             dst_file_info = self._get_file_info(dst_str)
             if dst_file_info.type != pafs.FileType.NotFound:
                 if dst_file_info.type == pafs.FileType.File:
@@ -291,7 +291,7 @@ class PyArrowFileIO(FileIO):
                 final_dst_info = self._get_file_info(dst_str)
                 if final_dst_info.type != pafs.FileType.NotFound:
                     return False
-
+            
             self.filesystem.move(src_str, dst_str)
             return True
         except FileNotFoundError:
@@ -329,7 +329,7 @@ class PyArrowFileIO(FileIO):
             file_info = self._get_file_info(path_str)
             if file_info.type == pafs.FileType.Directory:
                 return False
-
+        
         temp_path = path + str(uuid.uuid4()) + ".tmp"
         success = False
         try:
@@ -347,7 +347,7 @@ class PyArrowFileIO(FileIO):
         source_str = self.to_filesystem_path(source_path)
         target_str = self.to_filesystem_path(target_path)
         target_parent = Path(target_str).parent
-
+        
         if str(target_parent) and not self.exists(str(target_parent)):
             self.mkdirs(str(target_parent))
 
@@ -371,7 +371,7 @@ class PyArrowFileIO(FileIO):
                   zstd_level: int = 1, **kwargs):
         try:
             """Write ORC file using PyArrow ORC writer.
-
+            
             Note: PyArrow's ORC writer doesn't support compression_level parameter.
             ORC files will use zstd compression with default level
             (which is 3, see https://github.com/facebook/zstd/blob/dev/programs/zstdcli.c)
@@ -430,7 +430,7 @@ class PyArrowFileIO(FileIO):
             'zstd': 'zstandard',  # zstd is commonly used in Paimon
         }
         compression_lower = compression.lower()
-
+        
         codec = codec_map.get(compression_lower)
         if codec is None:
             raise ValueError(

--- a/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
+++ b/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
@@ -215,8 +215,14 @@ class PyArrowFileIO(FileIO):
 
     def exists(self, path: str) -> bool:
         path_str = self.to_filesystem_path(path)
-        file_info = self.filesystem.get_file_info([path_str])[0]
-        return file_info.type != pafs.FileType.NotFound
+        try:
+            file_info = self.filesystem.get_file_info([path_str])[0]
+            return file_info.type != pafs.FileType.NotFound
+        except OSError:
+            # OSS + PyArrow 6: get_file_info on a key prefix (no object) raises OSError.
+            if self._is_oss and not self._pyarrow_gte_7:
+                return False
+            raise
 
     def delete(self, path: str, recursive: bool = False) -> bool:
         path_str = self.to_filesystem_path(path)
@@ -241,6 +247,9 @@ class PyArrowFileIO(FileIO):
         return True
 
     def mkdirs(self, path: str) -> bool:
+        if self._is_oss and not self._pyarrow_gte_7:
+            # OSS has no real directories; writing the object key is enough.
+            return True
         path_str = self.to_filesystem_path(path)
         file_info = self.filesystem.get_file_info([path_str])[0]
         
@@ -509,9 +518,8 @@ class PyArrowFileIO(FileIO):
                 if parsed.netloc:
                     path_part = normalized_path.lstrip('/')
                     if self._is_oss and not self._pyarrow_gte_7:
-                        # For PyArrow 6.x + OSS, endpoint_override already contains bucket,
-                        result = path_part if path_part else '.'
-                        return result
+                        # PyArrow 6 splits on first '/'; return netloc/path_part so bucket=OSS bucket, key=path_part.
+                        return f"{parsed.netloc}/{path_part}" if path_part else parsed.netloc
                     else:
                         result = f"{parsed.netloc}/{path_part}" if path_part else parsed.netloc
                         return result

--- a/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
+++ b/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
@@ -17,6 +17,7 @@
 ################################################################################
 import logging
 import os
+import re
 import subprocess
 import uuid
 from datetime import datetime, timezone
@@ -205,7 +206,8 @@ class PyArrowFileIO(FileIO):
         except OSError as e:
             # this is for compatible with pyarrow < 7
             msg = str(e).lower()
-            if "does not exist" in msg or "not exist" in msg or "nosuchkey" in msg or "133" in msg:
+            if ("does not exist" in msg or "not exist" in msg or "nosuchkey" in msg
+                    or re.search(r'\b133\b', msg) or "notfound" in msg):
                 return pafs.FileInfo(path_str, pafs.FileType.NotFound)
             raise
 

--- a/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
+++ b/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
@@ -63,7 +63,7 @@ class PyArrowFileIO(FileIO):
             self.filesystem = self._initialize_hdfs_fs(scheme, netloc)
         else:
             raise ValueError(f"Unrecognized filesystem type in URI: {scheme}")
-        
+
     @staticmethod
     def parse_location(location: str):
         uri = urlparse(location)
@@ -73,7 +73,7 @@ class PyArrowFileIO(FileIO):
             return uri.scheme, uri.netloc, uri.path
         else:
             return uri.scheme, uri.netloc, f"{uri.netloc}{uri.path}"
-        
+
     def _create_s3_retry_config(
             self,
             max_attempts: int = 10,
@@ -93,19 +93,19 @@ class PyArrowFileIO(FileIO):
             return config
         else:
             return {}
-        
+
     def _extract_oss_bucket(self, location) -> str:
         uri = urlparse(location)
         if uri.scheme and uri.scheme != "oss":
             raise ValueError("Not an OSS URI: {}".format(location))
-        
+
         netloc = uri.netloc or ""
         if (getattr(uri, "username", None) or getattr(uri, "password", None)) or ("@" in netloc):
             first_segment = uri.path.lstrip("/").split("/", 1)[0]
             if not first_segment:
                 raise ValueError("Invalid OSS URI without bucket: {}".format(location))
             return first_segment
-        
+
         host = getattr(uri, "hostname", None) or netloc
         if not host:
             raise ValueError("Invalid OSS URI without host: {}".format(location))
@@ -113,7 +113,7 @@ class PyArrowFileIO(FileIO):
         if not bucket:
             raise ValueError("Invalid OSS URI without bucket: {}".format(location))
         return bucket
-        
+
     def _initialize_oss_fs(self, path) -> FileSystem:
         client_kwargs = {
             "access_key": self.properties.get(OssOptions.OSS_ACCESS_KEY_ID),
@@ -121,19 +121,19 @@ class PyArrowFileIO(FileIO):
             "session_token": self.properties.get(OssOptions.OSS_SECURITY_TOKEN),
             "region": self.properties.get(OssOptions.OSS_REGION),
         }
-        
+
         if self._pyarrow_gte_7:
             client_kwargs['force_virtual_addressing'] = True
             client_kwargs['endpoint_override'] = self.properties.get(OssOptions.OSS_ENDPOINT)
         else:
             client_kwargs['endpoint_override'] = (self._oss_bucket + "." +
                                                   self.properties.get(OssOptions.OSS_ENDPOINT))
-        
+
         retry_config = self._create_s3_retry_config()
         client_kwargs.update(retry_config)
-        
+
         return pafs.S3FileSystem(**client_kwargs)
-        
+
     def _initialize_s3_fs(self) -> FileSystem:
         client_kwargs = {
             "endpoint_override": self.properties.get(S3Options.S3_ENDPOINT),
@@ -144,22 +144,22 @@ class PyArrowFileIO(FileIO):
         }
         if self._pyarrow_gte_7:
             client_kwargs["force_virtual_addressing"] = True
-        
+
         retry_config = self._create_s3_retry_config()
         client_kwargs.update(retry_config)
-        
+
         return pafs.S3FileSystem(**client_kwargs)
-        
+
     def _initialize_hdfs_fs(self, scheme: str, netloc: Optional[str]) -> FileSystem:
         if 'HADOOP_HOME' not in os.environ:
             raise RuntimeError("HADOOP_HOME environment variable is not set.")
         if 'HADOOP_CONF_DIR' not in os.environ:
             raise RuntimeError("HADOOP_CONF_DIR environment variable is not set.")
-        
+
         hadoop_home = os.environ.get("HADOOP_HOME")
         native_lib_path = f"{hadoop_home}/lib/native"
         os.environ['LD_LIBRARY_PATH'] = f"{native_lib_path}:{os.environ.get('LD_LIBRARY_PATH', '')}"
-        
+
         class_paths = subprocess.run(
             [f'{hadoop_home}/bin/hadoop', 'classpath', '--glob'],
             capture_output=True,
@@ -167,37 +167,37 @@ class PyArrowFileIO(FileIO):
             check=True
         )
         os.environ['CLASSPATH'] = class_paths.stdout.strip()
-        
+
         host, port_str = splitport(netloc)
         return pafs.HadoopFileSystem(
             host=host,
             port=int(port_str),
             user=os.environ.get('HADOOP_USER_NAME', 'hadoop')
         )
-        
+
     def new_input_stream(self, path: str):
         path_str = self.to_filesystem_path(path)
         return self.filesystem.open_input_file(path_str)
-        
+
     def new_output_stream(self, path: str):
         path_str = self.to_filesystem_path(path)
-        
+
         if self._is_oss and not self._pyarrow_gte_7:
             # For PyArrow 6.x + OSS, path_str is already just the key part
             if '/' in path_str:
                 parent_dir = '/'.join(path_str.split('/')[:-1])
             else:
                 parent_dir = ''
-            
+
             if parent_dir and not self.exists(parent_dir):
                 self.mkdirs(parent_dir)
         else:
             parent_dir = Path(path_str).parent
             if str(parent_dir) and not self.exists(str(parent_dir)):
                 self.mkdirs(str(parent_dir))
-        
+
         return self.filesystem.open_output_stream(path_str)
-        
+
     def _get_file_info(self, path_str: str):
         try:
             file_infos = self.filesystem.get_file_info([path_str])
@@ -208,36 +208,36 @@ class PyArrowFileIO(FileIO):
             if "does not exist" in msg or "not exist" in msg or "nosuchkey" in msg or "133" in msg:
                 return pafs.FileInfo(path_str, pafs.FileType.NotFound)
             raise
-        
+
     def get_file_status(self, path: str):
         path_str = self.to_filesystem_path(path)
         file_info = self._get_file_info(path_str)
-        
+
         if file_info.type == pafs.FileType.NotFound:
             raise FileNotFoundError(f"File {path} (resolved as {path_str}) does not exist")
-        
+
         return file_info
-        
+
     def list_status(self, path: str):
         path_str = self.to_filesystem_path(path)
         selector = pafs.FileSelector(path_str, recursive=False, allow_not_found=True)
         return self.filesystem.get_file_info(selector)
-        
+
     def list_directories(self, path: str):
         file_infos = self.list_status(path)
         return [info for info in file_infos if info.type == pafs.FileType.Directory]
-        
+
     def exists(self, path: str) -> bool:
         path_str = self.to_filesystem_path(path)
         return self._get_file_info(path_str).type != pafs.FileType.NotFound
-        
+
     def delete(self, path: str, recursive: bool = False) -> bool:
         path_str = self.to_filesystem_path(path)
         file_info = self._get_file_info(path_str)
-        
+
         if file_info.type == pafs.FileType.NotFound:
             return False
-        
+
         if file_info.type == pafs.FileType.Directory:
             if not recursive:
                 selector = pafs.FileSelector(path_str, recursive=False, allow_not_found=True)
@@ -252,11 +252,11 @@ class PyArrowFileIO(FileIO):
         else:
             self.filesystem.delete_file(path_str)
         return True
-        
+
     def mkdirs(self, path: str) -> bool:
         path_str = self.to_filesystem_path(path)
         file_info = self._get_file_info(path_str)
-        
+
         if file_info.type == pafs.FileType.NotFound:
             self.filesystem.create_dir(path_str, recursive=True)
             return True
@@ -264,22 +264,22 @@ class PyArrowFileIO(FileIO):
             return True
         elif file_info.type == pafs.FileType.File:
             raise FileExistsError(f"Path exists but is not a directory: {path}")
-        
+
         self.filesystem.create_dir(path_str, recursive=True)
         return True
-        
+
     def rename(self, src: str, dst: str) -> bool:
         dst_str = self.to_filesystem_path(dst)
         dst_parent = Path(dst_str).parent
         if str(dst_parent) and not self.exists(str(dst_parent)):
             self.mkdirs(str(dst_parent))
-        
+
         src_str = self.to_filesystem_path(src)
-        
+
         try:
             if hasattr(self.filesystem, 'rename'):
                 return self.filesystem.rename(src_str, dst_str)
-            
+
             dst_file_info = self._get_file_info(dst_str)
             if dst_file_info.type != pafs.FileType.NotFound:
                 if dst_file_info.type == pafs.FileType.File:
@@ -291,45 +291,45 @@ class PyArrowFileIO(FileIO):
                 final_dst_info = self._get_file_info(dst_str)
                 if final_dst_info.type != pafs.FileType.NotFound:
                     return False
-            
+
             self.filesystem.move(src_str, dst_str)
             return True
         except FileNotFoundError:
             return False
         except (PermissionError, OSError):
             return False
-        
+
     def delete_quietly(self, path: str):
         if self.logger.isEnabledFor(logging.DEBUG):
             self.logger.debug(f"Ready to delete {path}")
-        
+
         try:
             if not self.delete(path, False) and self.exists(path):
                 self.logger.warning(f"Failed to delete file {path}")
         except Exception:
             self.logger.warning(f"Exception occurs when deleting file {path}", exc_info=True)
-        
+
     def delete_files_quietly(self, files: List[str]):
         for file_path in files:
             self.delete_quietly(file_path)
-        
+
     def delete_directory_quietly(self, directory: str):
         if self.logger.isEnabledFor(logging.DEBUG):
             self.logger.debug(f"Ready to delete {directory}")
-        
+
         try:
             if not self.delete(directory, True) and self.exists(directory):
                 self.logger.warning(f"Failed to delete directory {directory}")
         except Exception:
             self.logger.warning(f"Exception occurs when deleting directory {directory}", exc_info=True)
-        
+
     def try_to_write_atomic(self, path: str, content: str) -> bool:
         if self.exists(path):
             path_str = self.to_filesystem_path(path)
             file_info = self._get_file_info(path_str)
             if file_info.type == pafs.FileType.Directory:
                 return False
-        
+
         temp_path = path + str(uuid.uuid4()) + ".tmp"
         success = False
         try:
@@ -339,39 +339,39 @@ class PyArrowFileIO(FileIO):
             if not success:
                 self.delete_quietly(temp_path)
         return success
-        
+
     def copy_file(self, source_path: str, target_path: str, overwrite: bool = False):
         if not overwrite and self.exists(target_path):
             raise FileExistsError(f"Target file {target_path} already exists and overwrite=False")
-        
+
         source_str = self.to_filesystem_path(source_path)
         target_str = self.to_filesystem_path(target_path)
         target_parent = Path(target_str).parent
-        
+
         if str(target_parent) and not self.exists(str(target_parent)):
             self.mkdirs(str(target_parent))
-        
+
         self.filesystem.copy_file(source_str, target_str)
-        
+
     def write_parquet(self, path: str, data: pyarrow.Table, compression: str = 'zstd',
                       zstd_level: int = 1, **kwargs):
         try:
             import pyarrow.parquet as pq
-            
+
             with self.new_output_stream(path) as output_stream:
                 if compression.lower() == 'zstd':
                     kwargs['compression_level'] = zstd_level
                 pq.write_table(data, output_stream, compression=compression, **kwargs)
-        
+
         except Exception as e:
             self.delete_quietly(path)
             raise RuntimeError(f"Failed to write Parquet file {path}: {e}") from e
-        
+
     def write_orc(self, path: str, data: pyarrow.Table, compression: str = 'zstd',
                   zstd_level: int = 1, **kwargs):
         try:
             """Write ORC file using PyArrow ORC writer.
-            
+
             Note: PyArrow's ORC writer doesn't support compression_level parameter.
             ORC files will use zstd compression with default level
             (which is 3, see https://github.com/facebook/zstd/blob/dev/programs/zstdcli.c)
@@ -379,7 +379,7 @@ class PyArrowFileIO(FileIO):
             """
             import sys
             import pyarrow.orc as orc
-            
+
             with self.new_output_stream(path) as output_stream:
                 # Check Python version - if 3.6, don't use compression parameter
                 if sys.version_info[:2] == (3, 6):
@@ -391,11 +391,11 @@ class PyArrowFileIO(FileIO):
                         compression=compression,
                         **kwargs
                     )
-        
+
         except Exception as e:
             self.delete_quietly(path)
             raise RuntimeError(f"Failed to write ORC file {path}: {e}") from e
-        
+
     def write_avro(
             self, path: str, data: pyarrow.Table,
             avro_schema: Optional[Dict[str, Any]] = None,
@@ -404,9 +404,9 @@ class PyArrowFileIO(FileIO):
         if avro_schema is None:
             from pypaimon.schema.data_types import PyarrowFieldParser
             avro_schema = PyarrowFieldParser.to_avro_schema(data.schema)
-        
+
         records_dict = data.to_pydict()
-        
+
         def record_generator():
             num_rows = len(list(records_dict.values())[0])
             for i in range(num_rows):
@@ -417,9 +417,9 @@ class PyArrowFileIO(FileIO):
                         value = value.replace(tzinfo=timezone.utc)
                     record[col] = value
                 yield record
-        
+
         records = record_generator()
-        
+
         codec_map = {
             'null': 'null',
             'deflate': 'deflate',
@@ -430,25 +430,25 @@ class PyArrowFileIO(FileIO):
             'zstd': 'zstandard',  # zstd is commonly used in Paimon
         }
         compression_lower = compression.lower()
-        
+
         codec = codec_map.get(compression_lower)
         if codec is None:
             raise ValueError(
                 f"Unsupported compression '{compression}' for Avro format. "
                 f"Supported compressions: {', '.join(sorted(codec_map.keys()))}."
             )
-        
+
         with self.new_output_stream(path) as output_stream:
             if codec == 'zstandard':
                 kwargs['codec_compression_level'] = zstd_level
             fastavro.writer(output_stream, avro_schema, records, codec=codec, **kwargs)
-        
+
     def write_lance(self, path: str, data: pyarrow.Table, **kwargs):
         try:
             import lance
             from pypaimon.read.reader.lance_utils import to_lance_specified
             file_path_for_lance, storage_options = to_lance_specified(self, path)
-            
+
             writer = lance.file.LanceFileWriter(
                 file_path_for_lance, data.schema, storage_options=storage_options, **kwargs)
             try:
@@ -460,7 +460,7 @@ class PyArrowFileIO(FileIO):
         except Exception as e:
             self.delete_quietly(path)
             raise RuntimeError(f"Failed to write Lance file {path}: {e}") from e
-        
+
     def write_blob(self, path: str, data: pyarrow.Table, blob_as_descriptor: bool, **kwargs):
         try:
             if data.num_columns != 1:
@@ -500,26 +500,26 @@ class PyArrowFileIO(FileIO):
                     row = GenericRow(row_values, fields, RowKind.INSERT)
                     writer.add_element(row)
                 writer.close()
-        
+
         except Exception as e:
             self.delete_quietly(path)
             raise RuntimeError(f"Failed to write blob file {path}: {e}") from e
-        
+
     def to_filesystem_path(self, path: str) -> str:
         from pyarrow.fs import S3FileSystem
         import re
-        
+
         parsed = urlparse(path)
         normalized_path = re.sub(r'/+', '/', parsed.path) if parsed.path else ''
-        
+
         if parsed.scheme and len(parsed.scheme) == 1 and not parsed.netloc:
             return str(path)
-        
+
         if parsed.scheme == 'file' and parsed.netloc and parsed.netloc.endswith(':'):
             drive_letter = parsed.netloc.rstrip(':')
             path_part = normalized_path.lstrip('/')
             return f"{drive_letter}:/{path_part}" if path_part else f"{drive_letter}:"
-        
+
         if isinstance(self.filesystem, S3FileSystem):
             if parsed.scheme:
                 if parsed.netloc:
@@ -534,10 +534,10 @@ class PyArrowFileIO(FileIO):
                     return result if result else '.'
             else:
                 return str(path)
-        
+
         if parsed.scheme:
             if not normalized_path:
                 return '.'
             return normalized_path
-        
+
         return str(path)

--- a/paimon-python/pypaimon/tests/file_io_test.py
+++ b/paimon-python/pypaimon/tests/file_io_test.py
@@ -97,7 +97,7 @@ class FileIOTest(unittest.TestCase):
         mock_fs.create_dir.assert_called_once()
         path_str = oss_io.to_filesystem_path("oss://test-bucket/path/to/file.txt")
         if lt7:
-            expected_parent = "/".join(path_str.split("/")[:-1]) if "/" in path_str else ""
+            expected_parent = '/'.join(path_str.split('/')[:-1]) if '/' in path_str else ''
         else:
             expected_parent = "/".join(path_str.split("/")[:-1]) if "/" in path_str else str(Path(path_str).parent)
         self.assertEqual(mock_fs.create_dir.call_args[0][0], expected_parent)

--- a/paimon-python/pypaimon/tests/file_io_test.py
+++ b/paimon-python/pypaimon/tests/file_io_test.py
@@ -94,13 +94,13 @@ class FileIOTest(unittest.TestCase):
         mock_fs.open_output_stream.return_value = MagicMock()
         oss_io.filesystem = mock_fs
         oss_io.new_output_stream("oss://test-bucket/path/to/file.txt")
+        mock_fs.create_dir.assert_called_once()
+        path_str = oss_io.to_filesystem_path("oss://test-bucket/path/to/file.txt")
         if lt7:
-            mock_fs.create_dir.assert_not_called()
+            expected_parent = "/".join(path_str.split("/")[:-1]) if "/" in path_str else ""
         else:
-            mock_fs.create_dir.assert_called_once()
-            path_str = oss_io.to_filesystem_path("oss://test-bucket/path/to/file.txt")
             expected_parent = "/".join(path_str.split("/")[:-1]) if "/" in path_str else str(Path(path_str).parent)
-            self.assertEqual(mock_fs.create_dir.call_args[0][0], expected_parent)
+        self.assertEqual(mock_fs.create_dir.call_args[0][0], expected_parent)
         if lt7:
             for call_paths in get_file_info_calls:
                 for p in call_paths:


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core file-IO path resolution and existence checks across multiple operations; mistakes could redirect writes (OSS bucket/key) or change error-handling semantics on older PyArrow versions.
> 
> **Overview**
> Fixes `PyArrowFileIO` behavior on **PyArrow < 7**, especially for OSS-backed `S3FileSystem`, by centralizing version detection (`_pyarrow_lt_7`) and ensuring OSS paths pass *key-only* (not `bucket/key`) where required.
> 
> Adds `_get_file_info` to treat older `pyarrow.fs.get_file_info` “missing path” `OSError`s as `FileType.NotFound`, and updates `exists`, `get_file_status`, `delete`, `mkdirs`, `rename`, and `try_to_write_atomic` to use it for consistent missing-file behavior.
> 
> Extends unit coverage in `file_io_test.py` for OSS+PyArrow<7 manifest/path correctness, `get_file_info` call expectations, and a new `exists` regression test for nonexistent local paths across PyArrow versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 532040373ba38636d8b4cec289acb4213dd8e071. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->