### PR TITLE
Empty dir delete

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -246,7 +246,14 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
             List<FileStatus> files = tryBestListingDirs(path);
 
             if (files.isEmpty()) {
-                emptyDirs.add(path);
+                try {
+                    FileStatus dirStatus = fileIO.getFileStatus(path);
+                    if (oldEnough(dirStatus)) {
+                        emptyDirs.add(path);
+                    }
+                } catch (IOException e) {
+                    LOG.warn("IOException during check dirStatus for {}, ignore it", path, e);
+                }
                 return Collections.emptyList();
             }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -376,7 +376,14 @@ public abstract class OrphanFilesClean implements Serializable {
 
         List<Path> result = new ArrayList<>();
         for (Path partitionPath : partitionPaths) {
-            result.addAll(listFileDirs(partitionPath, level - 1));
+            List<Path> sub = listFileDirs(partitionPath, level - 1);
+            if (sub.isEmpty()) {
+                // Empty partition (no bucket subdirs), include for empty-dir cleanup
+                LOG.info("Found empty partition directory for cleanup: {}", partitionPath);
+                result.add(partitionPath);
+            } else {
+                result.addAll(sub);
+            }
         }
         return result;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/OrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/OrphanFilesCleanTest.java
@@ -18,12 +18,42 @@
 
 package org.apache.paimon.operation;
 
-import org.junit.Test;
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.SchemaUtils;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Utils for {@link OrphanFilesClean}. */
 public class OrphanFilesCleanTest {
+
+    @Rule public TemporaryFolder tempDir = new TemporaryFolder();
 
     @Test
     public void testOlderThanMillis() {
@@ -36,5 +66,81 @@ public class OrphanFilesCleanTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(
                         "The arg olderThan must be less than now, because dataFiles that are currently being written and not referenced by snapshots will be mistakenly cleaned up.");
+    }
+
+    @Test
+    public void testListPaimonFileDirsWithEmptyPartition() throws Exception {
+        Path tablePath = new Path(tempDir.newFolder().toURI());
+        FileIO fileIO = LocalFileIO.create();
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {
+                            DataTypes.INT(), DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()
+                        },
+                        new String[] {"pk", "part1", "part2", "value"});
+        FileStoreTable table = createFileStoreTable(fileIO, tablePath, rowType, new Options());
+        String commitUser = UUID.randomUUID().toString();
+        try (TableWriteImpl<?> write = table.newWrite(commitUser);
+                TableCommitImpl commit = table.newCommit(commitUser)) {
+            write.write(
+                    GenericRow.ofKind(
+                            RowKind.INSERT,
+                            1,
+                            0,
+                            BinaryString.fromString("a"),
+                            BinaryString.fromString("v1")));
+            commit.commit(0, write.prepareCommit(true, 0));
+        }
+
+        Path emptyPartitionPath = new Path(tablePath, "part1=0/part2=b");
+        fileIO.mkdirs(emptyPartitionPath);
+        Path emptyNonLeafPartitionPath = new Path(tablePath, "part1=1");
+        fileIO.mkdirs(emptyNonLeafPartitionPath);
+
+        java.lang.reflect.Method method =
+                LocalOrphanFilesClean.class.getSuperclass().getDeclaredMethod("listPaimonFileDirs");
+        method.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<Path> dirs = (List<Path>) method.invoke(new LocalOrphanFilesClean(table));
+
+        assertThat(dirs)
+                .as(
+                        "Empty partition (no bucket subdirs) is listed by listPaimonFileDirs for empty-dir cleanup")
+                .contains(emptyPartitionPath);
+        assertThat(dirs)
+                .as(
+                        "Empty non-leaf partition dir (e.g. part1=1 with no part2) is listed by listPaimonFileDirs")
+                .contains(emptyNonLeafPartitionPath);
+    }
+
+    @Test
+    public void testDeleteNonEmptyDir() throws Exception {
+        Path dir = new Path(tempDir.newFolder().toURI().toString(), "part1=0");
+        FileIO fileIO = LocalFileIO.create();
+        fileIO.mkdirs(dir);
+        Path file = new Path(dir, "data.dat");
+        fileIO.writeFile(file, "x", true);
+
+        assertThat(fileIO.exists(dir)).isTrue();
+        assertThatThrownBy(() -> fileIO.delete(dir, false))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("not empty");
+        assertThat(fileIO.exists(dir)).isTrue();
+    }
+
+    private FileStoreTable createFileStoreTable(
+            FileIO fileIO, Path tablePath, RowType rowType, Options conf) throws Exception {
+        conf.set(CoreOptions.PATH, tablePath.toString());
+        conf.set(CoreOptions.BUCKET, 2);
+        TableSchema tableSchema =
+                SchemaUtils.forceCommit(
+                        new SchemaManager(fileIO, tablePath),
+                        new Schema(
+                                rowType.getFields(),
+                                Arrays.asList("part1", "part2"),
+                                Arrays.asList("pk", "part1", "part2"),
+                                conf.toMap(),
+                                ""));
+        return FileStoreTableFactory.create(fileIO, tablePath, tableSchema);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -290,7 +290,18 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                             }
                                         }
                                         if (files.isEmpty()) {
-                                            ctx.output(emptyDirOutputTag, dirPath);
+                                            try {
+                                                FileStatus dirStatus =
+                                                        fileIO.getFileStatus(dirPath);
+                                                if (oldEnough(dirStatus)) {
+                                                    ctx.output(emptyDirOutputTag, dirPath);
+                                                }
+                                            } catch (IOException e) {
+                                                LOG.warn(
+                                                        "IOException during check dirStatus for {}, ignore it",
+                                                        dirPath,
+                                                        e);
+                                            }
                                         }
                                     }
                                 })


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes directory-discovery and deletion behavior in orphan cleanup, which could remove additional partition directories if age checks or path classification are incorrect; coverage is improved with new UT/IT cases and `olderThanMillis` gating.
> 
> **Overview**
> Extends orphan-file cleanup to treat *empty partition directories* (including non-leaf partition paths without bucket subdirs) as candidates for empty-directory cleanup, so they can be removed when they contain no data.
> 
> Tightens empty-directory deletion in both `LocalOrphanFilesClean` and `FlinkOrphanFilesClean` by checking the directory’s `modificationTime` against `olderThanMillis` before enqueueing it for deletion, and adds unit/integration tests covering empty partitions, non-empty directory safeguards, and local-FS timestamp handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca36d9113910bd786e95f6d4d27f48d4c27a3c9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->