### PR TITLE
[python] Do not return row id without projection explicitly

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionTableTest.java
@@ -135,6 +135,22 @@ public class DataEvolutionTableTest extends DataEvolutionTestBase {
     }
 
     @Test
+    void testRowIdProjection() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        ReadBuilder readBuilder = table.newReadBuilder();
+        assertThat(readBuilder.readType()).isEqualTo(table.rowType());
+        assertThat(readBuilder.readType().getFieldNames().contains(SpecialFields.ROW_ID.name()))
+                .isFalse();
+
+        RowType withRowId = SpecialFields.rowTypeWithRowId(table.rowType());
+        readBuilder = table.newReadBuilder().withReadType(withRowId);
+        assertThat(readBuilder.readType()).isEqualTo(withRowId);
+        assertThat(readBuilder.readType().getFieldNames().contains(SpecialFields.ROW_ID.name()))
+                .isTrue();
+    }
+
+    @Test
     public void testMultipleAppends() throws Exception {
         createTableDefault();
 

--- a/paimon-python/pypaimon/read/read_builder.py
+++ b/paimon-python/pypaimon/read/read_builder.py
@@ -67,7 +67,8 @@ class ReadBuilder:
         return TableRead(
             table=self.table,
             predicate=self._predicate,
-            read_type=self.read_type()
+            read_type=self.read_type(),
+            projection=self._projection,
         )
 
     def new_predicate_builder(self) -> PredicateBuilder:

--- a/paimon-python/pypaimon/read/read_builder.py
+++ b/paimon-python/pypaimon/read/read_builder.py
@@ -68,7 +68,6 @@ class ReadBuilder:
             table=self.table,
             predicate=self._predicate,
             read_type=self.read_type(),
-            projection=self._projection,
         )
 
     def new_predicate_builder(self) -> PredicateBuilder:
@@ -78,7 +77,7 @@ class ReadBuilder:
         table_fields = self.table.fields
 
         if not self._projection:
-            return [f for f in table_fields if not SpecialFields.is_system_field(f.name)]
+            return table_fields
         else:
             if self.table.options.row_tracking_enabled():
                 table_fields = SpecialFields.row_type_with_row_tracking(table_fields)

--- a/paimon-python/pypaimon/read/read_builder.py
+++ b/paimon-python/pypaimon/read/read_builder.py
@@ -78,7 +78,7 @@ class ReadBuilder:
         table_fields = self.table.fields
 
         if not self._projection:
-            return table_fields
+            return [f for f in table_fields if not SpecialFields.is_system_field(f.name)]
         else:
             if self.table.options.row_tracking_enabled():
                 table_fields = SpecialFields.row_type_with_row_tracking(table_fields)

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -28,7 +28,6 @@ from pypaimon.read.split_read import (DataEvolutionSplitRead,
                                       SplitRead)
 from pypaimon.schema.data_types import DataField, PyarrowFieldParser
 from pypaimon.table.row.offset_row import OffsetRow
-from pypaimon.table.special_fields import SpecialFields
 
 
 class TableRead:
@@ -91,14 +90,6 @@ class TableRead:
             result = pyarrow.Table.from_arrays([pyarrow.array([], type=field.type) for field in schema], schema=schema)
         else:
             result = pyarrow.Table.from_batches(table_list)
-
-        if self.projection is None:
-            table_field_names = set(f.name for f in self.table.fields)
-            keep = [
-                c for c in result.column_names
-                if not SpecialFields.is_system_field(c) or c in table_field_names
-            ]
-            result = result.select(keep)
         return result
 
     def _arrow_batch_generator(self, splits: List[Split], schema: pyarrow.Schema) -> Iterator[pyarrow.RecordBatch]:

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -88,9 +88,7 @@ class TableRead:
             table_list.append(self._try_to_pad_batch_by_schema(batch, schema))
 
         if not table_list:
-            result = pyarrow.Table.from_arrays(
-                [pyarrow.array([], type=field.type) for field in schema], schema=schema
-            )
+            result = pyarrow.Table.from_arrays([pyarrow.array([], type=field.type) for field in schema], schema=schema)
         else:
             result = pyarrow.Table.from_batches(table_list)
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect Python result schemas and Arrow materialization (casting and concatenation), which could impact downstream consumers and memory usage despite being well-covered by new tests.
> 
> **Overview**
> Python `ReadBuilder`/`TableRead` behavior is tightened so row-tracking system columns (notably `_ROW_ID`) are only included in results when explicitly requested via projection, with new tests covering the default vs projected behavior.
> 
> Arrow conversion is made more robust by padding batches to the target schema with *type-aware* casting/fallback-to-nulls and by concatenating batches into a single `RecordBatch` using the intended schema (preserving field ordering and nullability semantics). A small core-side Java test is added to assert the same row-id projection contract on the JVM API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f499a00ef7411c921ab2b0f9f12ba67d76505c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->