### PR TITLE
support dynamic bucket

### DIFF
--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -107,6 +107,25 @@ class CoreOptions:
         )
     )
 
+    DYNAMIC_BUCKET_TARGET_ROW_NUM: ConfigOption[int] = (
+        ConfigOptions.key("dynamic-bucket.target-row-num")
+        .int_type()
+        .default_value(2000000)
+        .with_description(
+            "In dynamic bucket mode (bucket=-1), target row number per bucket; "
+            "when exceeded, a new bucket is created (aligned with Java SimpleHashBucketAssigner)."
+        )
+    )
+
+    DYNAMIC_BUCKET_MAX_BUCKETS: ConfigOption[int] = (
+        ConfigOptions.key("dynamic-bucket.max-buckets")
+        .int_type()
+        .default_value(-1)
+        .with_description(
+            "In dynamic bucket mode, max buckets per partition. -1 means unlimited."
+        )
+    )
+
     SCAN_MANIFEST_PARALLELISM: ConfigOption[int] = (
         ConfigOptions.key("scan.manifest.parallelism")
         .int_type()
@@ -466,6 +485,12 @@ class CoreOptions:
 
     def bucket_key(self, default=None):
         return self.options.get(CoreOptions.BUCKET_KEY, default)
+
+    def dynamic_bucket_target_row_num(self, default=None):
+        return self.options.get(CoreOptions.DYNAMIC_BUCKET_TARGET_ROW_NUM, default)
+
+    def dynamic_bucket_max_buckets(self, default=None):
+        return self.options.get(CoreOptions.DYNAMIC_BUCKET_MAX_BUCKETS, default)
 
     def scan_manifest_parallelism(self, default=None):
         return self.options.get(CoreOptions.SCAN_MANIFEST_PARALLELISM, default)

--- a/paimon-python/pypaimon/tests/rest/rest_read_write_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_read_write_test.py
@@ -20,7 +20,6 @@ import logging
 
 import pandas as pd
 import pyarrow as pa
-import unittest
 
 from pypaimon.common.options import Options
 from pypaimon.catalog.catalog_context import CatalogContext

--- a/paimon-python/pypaimon/tests/rest/rest_read_write_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_read_write_test.py
@@ -363,7 +363,6 @@ class RESTTableReadWriteTest(RESTBaseTest):
         ])
         self.assertEqual(actual, expected)
 
-    @unittest.skip("does not support dynamic bucket in dummy rest server")
     def test_pk_lance_reader_no_bucket(self):
         """Test Lance format with PrimaryKey table without specifying bucket."""
         schema = Schema.from_pyarrow_schema(self.pa_schema,

--- a/paimon-python/pypaimon/tests/rest/rest_simple_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_simple_test.py
@@ -600,14 +600,25 @@ class RESTSimpleTest(RESTBaseTest):
 
         write_builder = table.new_batch_write_builder()
         table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
         self.assertIsInstance(table_write.row_key_extractor, DynamicBucketRowKeyExtractor)
 
         pa_table = pa.Table.from_pydict(self.data, schema=self.pa_schema)
+        table_write.write_arrow(pa_table)
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
 
-        with self.assertRaises(ValueError) as context:
-            table_write.write_arrow(pa_table)
-
-        self.assertEqual(str(context.exception), "Can't extract bucket from row in dynamic bucket mode")
+        splits = []
+        read_builder = table.new_read_builder()
+        splits.extend(read_builder.new_scan().with_shard(0, 3).plan().splits())
+        splits.extend(read_builder.new_scan().with_shard(1, 3).plan().splits())
+        splits.extend(read_builder.new_scan().with_shard(2, 3).plan().splits())
+        table_read = read_builder.new_read()
+        actual = table_read.to_arrow(splits)
+        expected_sorted = table_sort_by(self.expected, 'user_id')
+        actual_sorted = table_sort_by(actual, 'user_id')
+        self.assertEqual(actual_sorted, expected_sorted)
 
     def test_with_shard_pk_fixed_bucket(self):
         schema = Schema.from_pyarrow_schema(self.pa_schema, partition_keys=['user_id'], primary_keys=['user_id', 'dt'],

--- a/paimon-python/pypaimon/tests/write/simple_hash_bucket_assigner_test.py
+++ b/paimon-python/pypaimon/tests/write/simple_hash_bucket_assigner_test.py
@@ -1,0 +1,56 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import unittest
+
+from pypaimon.write.row_key_extractor import _dynamic_bucket_assign
+
+
+class SimpleHashBucketAssignerTest(unittest.TestCase):
+
+    def test_assign(self):
+        hashes = list(range(301))
+        buckets = _dynamic_bucket_assign([()] * len(hashes), hashes, 100, -1, 2, 0)
+        for b in buckets[:100]:
+            self.assertEqual(b, 0)
+        for b in buckets[100:200]:
+            self.assertEqual(b, 2)
+        self.assertEqual(buckets[200], 4)
+
+    def test_assign_with_upper_bound(self):
+        hashes = list(range(400))
+        buckets = _dynamic_bucket_assign([()] * len(hashes), hashes, 100, 3, 1, 0)
+        for b in buckets[:100]:
+            self.assertEqual(b, 0)
+        for b in buckets[100:200]:
+            self.assertEqual(b, 1)
+        for b in buckets[200:300]:
+            self.assertEqual(b, 2)
+        for b in buckets[300:]:
+            self.assertIn(b, [0, 1, 2])
+
+    def test_assign_with_same_hash(self):
+        for max_buckets in [-1, 1, 2]:
+            with self.subTest(max_buckets=max_buckets):
+                hashes = list(range(100)) + list(range(100))
+                buckets = _dynamic_bucket_assign([()] * len(hashes), hashes, 100, max_buckets, 1, 0)
+                for b in buckets[100:]:
+                    self.assertEqual(b, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/write/simple_hash_bucket_assigner_test.py
+++ b/paimon-python/pypaimon/tests/write/simple_hash_bucket_assigner_test.py
@@ -17,14 +17,15 @@
 ################################################################################
 import unittest
 
-from pypaimon.write.row_key_extractor import _dynamic_bucket_assign
+from pypaimon.write.row_key_extractor import SimpleHashBucketAssigner
 
 
 class SimpleHashBucketAssignerTest(unittest.TestCase):
 
     def test_assign(self):
-        hashes = list(range(301))
-        buckets = _dynamic_bucket_assign([()] * len(hashes), hashes, 100, -1, 2, 0)
+        assigner = SimpleHashBucketAssigner(2, 0, 100, -1)
+        partition = ()
+        buckets = [assigner.assign(partition, h) for h in range(301)]
         for b in buckets[:100]:
             self.assertEqual(b, 0)
         for b in buckets[100:200]:
@@ -32,8 +33,9 @@ class SimpleHashBucketAssignerTest(unittest.TestCase):
         self.assertEqual(buckets[200], 4)
 
     def test_assign_with_upper_bound(self):
-        hashes = list(range(400))
-        buckets = _dynamic_bucket_assign([()] * len(hashes), hashes, 100, 3, 1, 0)
+        assigner = SimpleHashBucketAssigner(1, 0, 100, 3)
+        partition = ()
+        buckets = [assigner.assign(partition, h) for h in range(400)]
         for b in buckets[:100]:
             self.assertEqual(b, 0)
         for b in buckets[100:200]:
@@ -46,8 +48,10 @@ class SimpleHashBucketAssignerTest(unittest.TestCase):
     def test_assign_with_same_hash(self):
         for max_buckets in [-1, 1, 2]:
             with self.subTest(max_buckets=max_buckets):
+                assigner = SimpleHashBucketAssigner(1, 0, 100, max_buckets)
+                partition = ()
                 hashes = list(range(100)) + list(range(100))
-                buckets = _dynamic_bucket_assign([()] * len(hashes), hashes, 100, max_buckets, 1, 0)
+                buckets = [assigner.assign(partition, h) for h in hashes]
                 for b in buckets[100:]:
                     self.assertEqual(b, 0)
 

--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -379,4 +379,8 @@ class TableWriteTest(unittest.TestCase):
         table_read = read_builder.new_read()
         splits = read_builder.new_scan().plan().splits()
         actual = table_read.to_arrow(splits)
-        self.assertEqual(actual.num_rows, self.expected.num_rows)
+        sort_keys = [('user_id', 'ascending'), ('dt', 'ascending')]
+        self.assertEqual(
+            self.expected.sort_by(sort_keys),
+            actual.sort_by(sort_keys),
+        )

--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -354,3 +354,29 @@ class TableWriteTest(unittest.TestCase):
         for file_name in data_files:
             self.assertRegex(file_name, expected_pattern,
                              f"File name '{file_name}' does not match expected prefix format")
+
+    def test_dynamic_bucket_write(self):
+        schema = Schema.from_pyarrow_schema(
+            self.pa_schema,
+            partition_keys=['dt'],
+            primary_keys=['user_id', 'dt'],
+            options={'bucket': '-1'}
+        )
+        self.catalog.create_table(
+            'default.test_dynamic_bucket', schema, False)
+        table = self.catalog.get_table(
+            'default.test_dynamic_bucket')
+        write_builder = table.new_batch_write_builder()
+
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        table_write.write_arrow(self.expected)
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+
+        read_builder = table.new_read_builder()
+        table_read = read_builder.new_read()
+        splits = read_builder.new_scan().plan().splits()
+        actual = table_read.to_arrow(splits)
+        self.assertEqual(actual.num_rows, self.expected.num_rows)

--- a/paimon-python/pypaimon/write/row_key_extractor.py
+++ b/paimon-python/pypaimon/write/row_key_extractor.py
@@ -180,11 +180,12 @@ def _pick_randomly(bucket_list: List[int]) -> int:
 
 
 class _SimplePartitionIndex:
-    def __init__(self) -> None:
+    def __init__(self, num_assigners: int, assign_id: int, max_buckets_num: int) -> None:
         self.hash2bucket: Dict[int, int] = {}
         self.bucket_information: Dict[int, int] = {}
         self.bucket_list: List[int] = []
         self.current_bucket: int = 0
+        self._load_new_bucket(max_buckets_num, num_assigners, assign_id)
 
     def assign(
         self,
@@ -248,7 +249,8 @@ class SimpleHashBucketAssigner:
 
     def assign(self, partition: Tuple, hash_value: int) -> int:
         if partition not in self._partition_index:
-            self._partition_index[partition] = _SimplePartitionIndex()
+            self._partition_index[partition] = _SimplePartitionIndex(
+                self.num_assigners, self.assign_id, self.max_buckets_num)
         index = self._partition_index[partition]
 
         assigned, self.max_bucket_id = index.assign(

--- a/paimon-python/pypaimon/write/row_key_extractor.py
+++ b/paimon-python/pypaimon/write/row_key_extractor.py
@@ -196,7 +196,8 @@ class _SimplePartitionIndex:
         assign_id: int,
     ) -> Tuple[int, int]:
         if hash_value in self.hash2bucket:
-            return self.hash2bucket[hash_value], max_bucket_id
+            assigned = self.hash2bucket[hash_value]
+            return assigned, max(max_bucket_id, assigned)
 
         if self.current_bucket not in self.bucket_information:
             self.bucket_list.append(self.current_bucket)
@@ -223,7 +224,6 @@ class _SimplePartitionIndex:
     def _load_new_bucket(
         self, max_buckets_num: int, num_assigners: int, assign_id: int
     ) -> None:
-        """Java: loadNewBucket() — uses outer maxBucketsNum, numAssigners, assignId."""
         for i in range(_SHORT_MAX_VALUE):
             if _is_my_bucket(i, num_assigners, assign_id) and (
                 i not in self.bucket_information
@@ -237,37 +237,43 @@ class _SimplePartitionIndex:
         )
 
 
+class SimpleHashBucketAssigner:
+    def __init__(self, num_assigners, assign_id, target_bucket_row_number, max_buckets_num):
+        self.num_assigners = num_assigners
+        self.assign_id = assign_id
+        self.target_bucket_row_number = target_bucket_row_number
+        self.max_buckets_num = max_buckets_num
+        self.max_bucket_id = 0
+        self._partition_index: Dict[Tuple, _SimplePartitionIndex] = {}
+
+    def assign(self, partition: Tuple, hash_value: int) -> int:
+        if partition not in self._partition_index:
+            self._partition_index[partition] = _SimplePartitionIndex()
+        index = self._partition_index[partition]
+
+        assigned, self.max_bucket_id = index.assign(
+            hash_value,
+            self.max_bucket_id,
+            self.target_bucket_row_number,
+            self.max_buckets_num,
+            self.num_assigners,
+            self.assign_id,
+        )
+        return assigned
+
+
 def _dynamic_bucket_assign(
     partitions: List[Tuple],
     key_hashes: List[int],
     target_bucket_row_number: int,
     max_buckets_num: int,
-    num_assigners: int = 1,
-    assign_id: int = 0,
+    num_assigners: int,
+    assign_id: int,
 ) -> List[int]:
-    partition_index: Dict[Tuple, _SimplePartitionIndex] = {}
-    max_bucket_id = -1
-    buckets_out: List[int] = []
-
-    for row_idx in range(len(partitions)):
-        partition = partitions[row_idx]
-        hash_value = key_hashes[row_idx]
-
-        if partition not in partition_index:
-            partition_index[partition] = _SimplePartitionIndex()
-        index = partition_index[partition]
-
-        assigned, max_bucket_id = index.assign(
-            hash_value,
-            max_bucket_id,
-            target_bucket_row_number,
-            max_buckets_num,
-            num_assigners,
-            assign_id,
-        )
-        buckets_out.append(assigned)
-
-    return buckets_out
+    assigner = SimpleHashBucketAssigner(
+        num_assigners, assign_id, target_bucket_row_number, max_buckets_num)
+    return [assigner.assign(partitions[i], key_hashes[i])
+            for i in range(len(partitions))]
 
 
 class DynamicBucketRowKeyExtractor(RowKeyExtractor):
@@ -285,13 +291,14 @@ class DynamicBucketRowKeyExtractor(RowKeyExtractor):
                 + str(num_buckets)
             )
         opts = CoreOptions.from_dict(table_schema.options)
-        self._target_bucket_row_number = opts.dynamic_bucket_target_row_num() or 2_000_000
-        self._max_buckets_num = opts.dynamic_bucket_max_buckets()
-        if self._max_buckets_num is None:
-            self._max_buckets_num = -1
-        bucket_key_option = opts.bucket_key()
-        if bucket_key_option and bucket_key_option.strip():
-            self._bucket_keys = [k.strip() for k in bucket_key_option.split(',')]
+        self._assigner = SimpleHashBucketAssigner(
+            num_assigners=1,
+            assign_id=0,
+            target_bucket_row_number=opts.dynamic_bucket_target_row_num(),
+            max_buckets_num=opts.dynamic_bucket_max_buckets(),
+        )
+        if opts.bucket_key() and opts.bucket_key().strip():
+            self._bucket_keys = [k.strip() for k in opts.bucket_key().split(',')]
         else:
             self._bucket_keys = [
                 pk for pk in table_schema.primary_keys
@@ -303,11 +310,12 @@ class DynamicBucketRowKeyExtractor(RowKeyExtractor):
             field_map[name] for name in self._bucket_keys if name in field_map
         ]
 
-    def _extract_buckets_batch(self, data: pa.RecordBatch) -> List[int]:
+    def extract_partition_bucket_batch(self, data: pa.RecordBatch) -> Tuple[List[Tuple], List[int]]:
         partitions = self._extract_partitions_batch(data)
         columns = [data.column(i) for i in self._bucket_key_indices]
-        key_hashes = [
-            _hash_bytes_by_words(
+        buckets = []
+        for row_idx in range(data.num_rows):
+            key_hash = _hash_bytes_by_words(
                 GenericRowSerializer.to_bytes(
                     GenericRow(
                         [columns[j][row_idx].as_py() for j in range(len(columns))],
@@ -316,16 +324,11 @@ class DynamicBucketRowKeyExtractor(RowKeyExtractor):
                     )
                 )[4:]
             )
-            for row_idx in range(data.num_rows)
-        ]
-        return _dynamic_bucket_assign(
-            partitions,
-            key_hashes,
-            self._target_bucket_row_number,
-            self._max_buckets_num,
-            num_assigners=1,
-            assign_id=0,
-        )
+            buckets.append(self._assigner.assign(partitions[row_idx], key_hash))
+        return partitions, buckets
+
+    def _extract_buckets_batch(self, data: pa.RecordBatch) -> List[int]:
+        raise NotImplementedError
 
 
 class PostponeBucketRowKeyExtractor(RowKeyExtractor):

--- a/paimon-python/pypaimon/write/row_key_extractor.py
+++ b/paimon-python/pypaimon/write/row_key_extractor.py
@@ -264,20 +264,6 @@ class SimpleHashBucketAssigner:
         return assigned
 
 
-def _dynamic_bucket_assign(
-    partitions: List[Tuple],
-    key_hashes: List[int],
-    target_bucket_row_number: int,
-    max_buckets_num: int,
-    num_assigners: int,
-    assign_id: int,
-) -> List[int]:
-    assigner = SimpleHashBucketAssigner(
-        num_assigners, assign_id, target_bucket_row_number, max_buckets_num)
-    return [assigner.assign(partitions[i], key_hashes[i])
-            for i in range(len(partitions))]
-
-
 class DynamicBucketRowKeyExtractor(RowKeyExtractor):
     """
     Row key extractor for dynamic bucket mode
@@ -299,22 +285,24 @@ class DynamicBucketRowKeyExtractor(RowKeyExtractor):
             target_bucket_row_number=opts.dynamic_bucket_target_row_num(),
             max_buckets_num=opts.dynamic_bucket_max_buckets(),
         )
-        if opts.bucket_key() and opts.bucket_key().strip():
-            self._bucket_keys = [k.strip() for k in opts.bucket_key().split(',')]
+        # TODO: extract bucket key init logic to base class (shared with FixedBucketRowKeyExtractor)
+        bucket_key_option = opts.bucket_key()
+        if bucket_key_option and bucket_key_option.strip():
+            self.bucket_keys = [k.strip() for k in bucket_key_option.split(',')]
         else:
-            self._bucket_keys = [
+            self.bucket_keys = [
                 pk for pk in table_schema.primary_keys
                 if pk not in table_schema.partition_keys
             ]
-        self._bucket_key_indices = self._get_field_indices(self._bucket_keys)
+        self.bucket_key_indices = self._get_field_indices(self.bucket_keys)
         field_map = {f.name: f for f in table_schema.fields}
         self._bucket_key_fields = [
-            field_map[name] for name in self._bucket_keys if name in field_map
+            field_map[name] for name in self.bucket_keys if name in field_map
         ]
 
     def _extract_buckets_batch(self, data: pa.RecordBatch) -> List[int]:
         partitions = self._extract_partitions_batch(data)
-        columns = [data.column(i) for i in self._bucket_key_indices]
+        columns = [data.column(i) for i in self.bucket_key_indices]
         buckets = []
         for row_idx in range(data.num_rows):
             key_hash = _hash_bytes_by_words(

--- a/paimon-python/pypaimon/write/row_key_extractor.py
+++ b/paimon-python/pypaimon/write/row_key_extractor.py
@@ -285,10 +285,10 @@ class DynamicBucketRowKeyExtractor(RowKeyExtractor):
     def __init__(self, table_schema: 'TableSchema'):
         super().__init__(table_schema)
         num_buckets = int(table_schema.options.get(CoreOptions.BUCKET.key(), -1))
+
         if num_buckets != -1:
             raise ValueError(
-                "Only 'bucket' = '-1' is allowed for 'DynamicBucketRowKeyExtractor', but found: "
-                + str(num_buckets)
+                f"Only 'bucket' = '-1' is allowed for 'DynamicBucketRowKeyExtractor', but found: {num_buckets}"
             )
         opts = CoreOptions.from_dict(table_schema.options)
         self._assigner = SimpleHashBucketAssigner(
@@ -310,7 +310,7 @@ class DynamicBucketRowKeyExtractor(RowKeyExtractor):
             field_map[name] for name in self._bucket_keys if name in field_map
         ]
 
-    def extract_partition_bucket_batch(self, data: pa.RecordBatch) -> Tuple[List[Tuple], List[int]]:
+    def _extract_buckets_batch(self, data: pa.RecordBatch) -> List[int]:
         partitions = self._extract_partitions_batch(data)
         columns = [data.column(i) for i in self._bucket_key_indices]
         buckets = []
@@ -324,11 +324,9 @@ class DynamicBucketRowKeyExtractor(RowKeyExtractor):
                     )
                 )[4:]
             )
-            buckets.append(self._assigner.assign(partitions[row_idx], key_hash))
-        return partitions, buckets
-
-    def _extract_buckets_batch(self, data: pa.RecordBatch) -> List[int]:
-        raise NotImplementedError
+            buckets.append(
+                self._assigner.assign(partitions[row_idx], key_hash))
+        return buckets
 
 
 class PostponeBucketRowKeyExtractor(RowKeyExtractor):

--- a/paimon-python/pypaimon/write/row_key_extractor.py
+++ b/paimon-python/pypaimon/write/row_key_extractor.py
@@ -17,9 +17,10 @@
 ################################################################################
 
 import math
+import random
 import struct
 from abc import ABC, abstractmethod
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import pyarrow as pa
 
@@ -167,6 +168,108 @@ class UnawareBucketRowKeyExtractor(RowKeyExtractor):
         return [0] * data.num_rows
 
 
+_SHORT_MAX_VALUE = 32767
+
+
+def _is_my_bucket(bucket: int, num_assigners: int, assign_id: int) -> bool:
+    return bucket % num_assigners == assign_id % num_assigners
+
+
+def _pick_randomly(bucket_list: List[int]) -> int:
+    return random.choice(bucket_list)
+
+
+class _SimplePartitionIndex:
+    def __init__(self) -> None:
+        self.hash2bucket: Dict[int, int] = {}
+        self.bucket_information: Dict[int, int] = {}
+        self.bucket_list: List[int] = []
+        self.current_bucket: int = 0
+
+    def assign(
+        self,
+        hash_value: int,
+        max_bucket_id: int,
+        target_bucket_row_number: int,
+        max_buckets_num: int,
+        num_assigners: int,
+        assign_id: int,
+    ) -> Tuple[int, int]:
+        if hash_value in self.hash2bucket:
+            return self.hash2bucket[hash_value], max_bucket_id
+
+        if self.current_bucket not in self.bucket_information:
+            self.bucket_list.append(self.current_bucket)
+            self.bucket_information[self.current_bucket] = 0
+        num = self.bucket_information[self.current_bucket]
+
+        if num >= target_bucket_row_number:
+            if (
+                max_buckets_num == -1
+                or not self.bucket_information
+                or max_bucket_id < max_buckets_num - 1
+            ):
+                self._load_new_bucket(max_buckets_num, num_assigners, assign_id)
+            else:
+                self.current_bucket = _pick_randomly(self.bucket_list)
+
+        self.bucket_information[self.current_bucket] = (
+            self.bucket_information.get(self.current_bucket, 0) + 1
+        )
+        self.hash2bucket[hash_value] = self.current_bucket
+        new_max = max(max_bucket_id, self.current_bucket)
+        return self.current_bucket, new_max
+
+    def _load_new_bucket(
+        self, max_buckets_num: int, num_assigners: int, assign_id: int
+    ) -> None:
+        """Java: loadNewBucket() — uses outer maxBucketsNum, numAssigners, assignId."""
+        for i in range(_SHORT_MAX_VALUE):
+            if _is_my_bucket(i, num_assigners, assign_id) and (
+                i not in self.bucket_information
+            ):
+                if max_buckets_num == -1 or i <= max_buckets_num - 1:
+                    self.current_bucket = i
+                    return
+                return
+        raise RuntimeError(
+            "Can't find a suitable bucket to assign, all the bucket are assigned?"
+        )
+
+
+def _dynamic_bucket_assign(
+    partitions: List[Tuple],
+    key_hashes: List[int],
+    target_bucket_row_number: int,
+    max_buckets_num: int,
+    num_assigners: int = 1,
+    assign_id: int = 0,
+) -> List[int]:
+    partition_index: Dict[Tuple, _SimplePartitionIndex] = {}
+    max_bucket_id = -1
+    buckets_out: List[int] = []
+
+    for row_idx in range(len(partitions)):
+        partition = partitions[row_idx]
+        hash_value = key_hashes[row_idx]
+
+        if partition not in partition_index:
+            partition_index[partition] = _SimplePartitionIndex()
+        index = partition_index[partition]
+
+        assigned, max_bucket_id = index.assign(
+            hash_value,
+            max_bucket_id,
+            target_bucket_row_number,
+            max_buckets_num,
+            num_assigners,
+            assign_id,
+        )
+        buckets_out.append(assigned)
+
+    return buckets_out
+
+
 class DynamicBucketRowKeyExtractor(RowKeyExtractor):
     """
     Row key extractor for dynamic bucket mode
@@ -176,14 +279,53 @@ class DynamicBucketRowKeyExtractor(RowKeyExtractor):
     def __init__(self, table_schema: 'TableSchema'):
         super().__init__(table_schema)
         num_buckets = int(table_schema.options.get(CoreOptions.BUCKET.key(), -1))
-
         if num_buckets != -1:
             raise ValueError(
-                f"Only 'bucket' = '-1' is allowed for 'DynamicBucketRowKeyExtractor', but found: {num_buckets}"
+                "Only 'bucket' = '-1' is allowed for 'DynamicBucketRowKeyExtractor', but found: "
+                + str(num_buckets)
             )
+        opts = CoreOptions.from_dict(table_schema.options)
+        self._target_bucket_row_number = opts.dynamic_bucket_target_row_num() or 2_000_000
+        self._max_buckets_num = opts.dynamic_bucket_max_buckets()
+        if self._max_buckets_num is None:
+            self._max_buckets_num = -1
+        bucket_key_option = opts.bucket_key()
+        if bucket_key_option and bucket_key_option.strip():
+            self._bucket_keys = [k.strip() for k in bucket_key_option.split(',')]
+        else:
+            self._bucket_keys = [
+                pk for pk in table_schema.primary_keys
+                if pk not in table_schema.partition_keys
+            ]
+        self._bucket_key_indices = self._get_field_indices(self._bucket_keys)
+        field_map = {f.name: f for f in table_schema.fields}
+        self._bucket_key_fields = [
+            field_map[name] for name in self._bucket_keys if name in field_map
+        ]
 
     def _extract_buckets_batch(self, data: pa.RecordBatch) -> List[int]:
-        raise ValueError("Can't extract bucket from row in dynamic bucket mode")
+        partitions = self._extract_partitions_batch(data)
+        columns = [data.column(i) for i in self._bucket_key_indices]
+        key_hashes = [
+            _hash_bytes_by_words(
+                GenericRowSerializer.to_bytes(
+                    GenericRow(
+                        [columns[j][row_idx].as_py() for j in range(len(columns))],
+                        self._bucket_key_fields,
+                        RowKind.INSERT,
+                    )
+                )[4:]
+            )
+            for row_idx in range(data.num_rows)
+        ]
+        return _dynamic_bucket_assign(
+            partitions,
+            key_hashes,
+            self._target_bucket_row_number,
+            self._max_buckets_num,
+            num_assigners=1,
+            assign_id=0,
+        )
 
 
 class PostponeBucketRowKeyExtractor(RowKeyExtractor):

--- a/paimon-python/pypaimon/write/table_write.py
+++ b/paimon-python/pypaimon/write/table_write.py
@@ -45,6 +45,7 @@ class TableWrite:
             self.write_arrow_batch(batch)
 
     def write_arrow_batch(self, data: pa.RecordBatch):
+        self._validate_pyarrow_schema(data.schema)
         partitions, buckets = self.row_key_extractor.extract_partition_bucket_batch(data)
 
         partition_bucket_groups = defaultdict(list)

--- a/paimon-python/pypaimon/write/table_write.py
+++ b/paimon-python/pypaimon/write/table_write.py
@@ -45,7 +45,6 @@ class TableWrite:
             self.write_arrow_batch(batch)
 
     def write_arrow_batch(self, data: pa.RecordBatch):
-        self._validate_pyarrow_schema(data.schema)
         partitions, buckets = self.row_key_extractor.extract_partition_bucket_batch(data)
 
         partition_bucket_groups = defaultdict(list)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core bucket assignment logic in the write path for primary-key tables, which can affect data layout and read/write correctness if hashing/assignment differs from expectations.
> 
> **Overview**
> Adds **dynamic bucket mode** support for Python writes by implementing `SimpleHashBucketAssigner` and updating `DynamicBucketRowKeyExtractor` to compute per-row bucket IDs from bucket keys and partitions instead of raising an error.
> 
> Introduces new table options `dynamic-bucket.target-row-num` and `dynamic-bucket.max-buckets` to control bucket growth, and updates REST + local write tests to validate dynamic-bucket writes and sharded reads (including a new `simple_hash_bucket_assigner_test`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 728c1291f36c8b92f17263005e61e6aab2757aaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->