### PR TITLE
[python] Make sure primary key should not nullable

### DIFF
--- a/paimon-python/pypaimon/schema/schema.py
+++ b/paimon-python/pypaimon/schema/schema.py
@@ -55,6 +55,13 @@ class Schema:
         # Convert PyArrow schema to Paimon fields
         fields = PyarrowFieldParser.to_paimon_schema(pa_schema)
 
+        # Primary key fields must be NOT NULL
+        pk_set = set(primary_keys) if primary_keys else set()
+        if pk_set:
+            for field in fields:
+                if field.name in pk_set:
+                    field.type.nullable = False
+
         # Check if Blob type exists in the schema
         has_blob_type = any(
             'blob' in str(field.type).lower()

--- a/paimon-python/pypaimon/tests/binary_row_test.py
+++ b/paimon-python/pypaimon/tests/binary_row_test.py
@@ -44,7 +44,7 @@ class BinaryRowTest(unittest.TestCase):
         cls.catalog = CatalogFactory.create({'warehouse': cls.warehouse})
         cls.catalog.create_database('default', False)
         pa_schema = pa.schema([
-            ('f0', pa.int64()),
+            pa.field('f0', pa.int64(), nullable=False),
             ('f1', pa.string()),
             ('f2', pa.int64()),
         ])

--- a/paimon-python/pypaimon/tests/ray_data_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_test.py
@@ -419,7 +419,7 @@ class RayDataTest(unittest.TestCase):
     def test_ray_data_primary_key_basic(self):
         """Test Ray Data read from PrimaryKey table."""
         pa_schema = pa.schema([
-            ('id', pa.int32()),
+            pa.field('id', pa.int32(), nullable=False),
             ('name', pa.string()),
             ('value', pa.int64()),
         ])
@@ -464,7 +464,7 @@ class RayDataTest(unittest.TestCase):
     def test_ray_data_primary_key_update(self):
         """Test Ray Data read from PrimaryKey table with updates (upsert behavior)."""
         pa_schema = pa.schema([
-            ('id', pa.int32()),
+            pa.field('id', pa.int32(), nullable=False),
             ('name', pa.string()),
             ('value', pa.int64()),
         ])
@@ -524,10 +524,10 @@ class RayDataTest(unittest.TestCase):
     def test_ray_data_primary_key_with_predicate(self):
         """Test Ray Data read from PrimaryKey table with predicate filtering."""
         pa_schema = pa.schema([
-            ('id', pa.int32()),
+            pa.field('id', pa.int32(), nullable=False),
             ('category', pa.string()),
             ('amount', pa.int64()),
-            ('dt', pa.string()),
+            pa.field('dt', pa.string(), nullable=False),
         ])
 
         schema = Schema.from_pyarrow_schema(
@@ -592,7 +592,7 @@ class RayDataTest(unittest.TestCase):
         """Test Ray Data read from PrimaryKey table with small target_split_size."""
 
         pa_schema = pa.schema([
-            ('id', pa.int32()),
+            pa.field('id', pa.int32(), nullable=False),
             ('name', pa.string()),
             ('value', pa.int64()),
         ])

--- a/paimon-python/pypaimon/tests/ray_sink_test.py
+++ b/paimon-python/pypaimon/tests/ray_sink_test.py
@@ -42,7 +42,7 @@ class RaySinkTest(unittest.TestCase):
         self.catalog.create_database("test_db", ignore_if_exists=True)
 
         pa_schema = pa.schema([
-            ('id', pa.int64()),
+            pa.field('id', pa.int64(), nullable=False),
             ('name', pa.string()),
             ('value', pa.float64())
         ])
@@ -58,6 +58,7 @@ class RaySinkTest(unittest.TestCase):
         self.table_identifier = "test_db.test_table"
         self.catalog.create_table(self.table_identifier, schema, ignore_if_exists=False)
         self.table = self.catalog.get_table(self.table_identifier)
+        self.pk_pa_schema = pa_schema
 
     def tearDown(self):
         import shutil
@@ -142,7 +143,7 @@ class RaySinkTest(unittest.TestCase):
             'id': pa.array([], type=pa.int64()),
             'name': pa.array([], type=pa.string()),
             'value': pa.array([], type=pa.float64())
-        })
+        }, schema=self.pk_pa_schema)
         result = datasink.write([empty_table], ctx)
         self.assertEqual(result, [])
 
@@ -151,7 +152,7 @@ class RaySinkTest(unittest.TestCase):
             'id': [1, 2, 3],
             'name': ['Alice', 'Bob', 'Charlie'],
             'value': [1.1, 2.2, 3.3]
-        })
+        }, schema=self.pk_pa_schema)
         result = datasink.write([single_block], ctx)
         self.assertIsInstance(result, list)
         if result:
@@ -161,12 +162,12 @@ class RaySinkTest(unittest.TestCase):
             'id': [4, 5],
             'name': ['David', 'Eve'],
             'value': [4.4, 5.5]
-        })
+        }, schema=self.pk_pa_schema)
         block2 = pa.table({
             'id': [6, 7],
             'name': ['Frank', 'Grace'],
             'value': [6.6, 7.7]
-        })
+        }, schema=self.pk_pa_schema)
         result = datasink.write([block1, block2], ctx)
         self.assertIsInstance(result, list)
         if result:

--- a/paimon-python/pypaimon/tests/reader_base_test.py
+++ b/paimon-python/pypaimon/tests/reader_base_test.py
@@ -488,6 +488,11 @@ class ReaderBasicTest(unittest.TestCase):
             ('name', pa.string()),
             ('price', pa.float64()),
         ])
+        pk_write_schema = pa.schema([
+            pa.field('id', pa.int64(), nullable=False),
+            ('name', pa.string()),
+            ('price', pa.float64()),
+        ])
         pk_schema = Schema.from_pyarrow_schema(
             pk_pa_schema,
             primary_keys=['id'],
@@ -500,7 +505,7 @@ class ReaderBasicTest(unittest.TestCase):
             'id': [1, 2, 3],
             'name': ['Alice', 'Bob', 'Charlie'],
             'price': [10.5, 20.3, 30.7],
-        }, schema=pk_pa_schema)
+        }, schema=pk_write_schema)
 
         pk_write_builder = pk_table.new_batch_write_builder()
         pk_writer = pk_write_builder.new_write()
@@ -558,6 +563,11 @@ class ReaderBasicTest(unittest.TestCase):
             ('name', pa.string()),
             ('price', pa.float64()),
         ])
+        pk_pa_schema = pa.schema([
+            pa.field('id', pa.int64(), nullable=False),
+            ('name', pa.string()),
+            ('price', pa.float64()),
+        ])
         schema = Schema.from_pyarrow_schema(
             pa_schema,
             primary_keys=['id'],
@@ -570,7 +580,7 @@ class ReaderBasicTest(unittest.TestCase):
             'id': [1, 2, 3],
             'name': ['Alice', 'Bob', 'Charlie'],
             'price': [10.5, 20.3, 30.7],
-        }, schema=pa_schema)
+        }, schema=pk_pa_schema)
 
         write_builder = table.new_batch_write_builder()
         writer = write_builder.new_write()
@@ -1047,6 +1057,12 @@ class ReaderBasicTest(unittest.TestCase):
             ('price', pa.float64()),
             ('category', pa.string())
         ])
+        pk_pa_schema = pa.schema([
+            pa.field('id', pa.int64(), nullable=False),
+            ('name', pa.string()),
+            ('price', pa.float64()),
+            ('category', pa.string())
+        ])
         schema = Schema.from_pyarrow_schema(
             pa_schema,
             primary_keys=['id'],
@@ -1060,7 +1076,7 @@ class ReaderBasicTest(unittest.TestCase):
             'name': ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
             'price': [10.5, 20.3, 30.7, 40.1, 50.9],
             'category': ['A', 'B', 'C', 'D', 'E']
-        }, schema=pa_schema)
+        }, schema=pk_pa_schema)
 
         write_builder = table.new_batch_write_builder()
         writer = write_builder.new_write()

--- a/paimon-python/pypaimon/tests/reader_split_generator_test.py
+++ b/paimon-python/pypaimon/tests/reader_split_generator_test.py
@@ -51,7 +51,7 @@ class SplitGeneratorTest(unittest.TestCase):
                       deletion_vectors_enabled=False,
                       split_target_size=None, split_open_file_cost=None):
         pa_schema = pa.schema([
-            ('id', pa.int64()),
+            pa.field('id', pa.int64(), nullable=False),
             ('value', pa.string())
         ])
         options = {
@@ -81,7 +81,7 @@ class SplitGeneratorTest(unittest.TestCase):
     
     def _write_data(self, table, data_list):
         pa_schema = pa.schema([
-            ('id', pa.int64()),
+            pa.field('id', pa.int64(), nullable=False),
             ('value', pa.string())
         ])
         for data in data_list:
@@ -220,7 +220,7 @@ class SplitGeneratorTest(unittest.TestCase):
 
     def test_shard_with_empty_partition(self):
         pa_schema = pa.schema([
-            ('id', pa.int64()),
+            pa.field('id', pa.int64(), nullable=False),
             ('value', pa.string())
         ])
         schema = Schema.from_pyarrow_schema(
@@ -274,7 +274,7 @@ class SplitGeneratorTest(unittest.TestCase):
     def test_sliced_split_merged_row_count(self):
         """Test merged_row_count() for SlicedSplit with explicit slicing."""
         pa_schema = pa.schema([
-            ('id', pa.int64()),
+            pa.field('id', pa.int64(), nullable=False),
             ('value', pa.string())
         ])
         schema = Schema.from_pyarrow_schema(

--- a/paimon-python/pypaimon/tests/rest/rest_base_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_base_test.py
@@ -199,7 +199,7 @@ class RESTBaseTest(unittest.TestCase):
 
     def _write_test_table(self, table):
         write_builder = table.new_batch_write_builder()
-        table_pa_schema = self.pk_pa_schema
+        table_pa_schema = self.pk_pa_schema if table.primary_keys else self.pa_schema
 
         # first write
         table_write = write_builder.new_write()

--- a/paimon-python/pypaimon/tests/rest/rest_base_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_base_test.py
@@ -106,6 +106,8 @@ class RESTBaseTest(unittest.TestCase):
         # Shutdown server
         self.server.shutdown()
         print("Server stopped")
+        import gc
+        gc.collect()
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_rest_catalog(self):

--- a/paimon-python/pypaimon/tests/rest/rest_base_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_base_test.py
@@ -73,6 +73,13 @@ class RESTBaseTest(unittest.TestCase):
             ('dt', pa.string()),
             ('long-dt', pa.string())
         ])
+        self.pk_pa_schema = pa.schema([
+            pa.field('user_id', pa.int64(), nullable=False),
+            ('item_id', pa.int64()),
+            ('behavior', pa.string()),
+            pa.field('dt', pa.string(), nullable=False),
+            ('long-dt', pa.string())
+        ])
         self.raw_data = {
             'user_id': [1, 2, 3, 4, 5, 6, 7, 8],
             'item_id': [1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008],
@@ -82,6 +89,7 @@ class RESTBaseTest(unittest.TestCase):
                         'abcdefghijklmnopk', '2025-08-08']
         }
         self.expected = pa.Table.from_pydict(self.raw_data, schema=self.pa_schema)
+        self.pk_expected = pa.Table.from_pydict(self.raw_data, schema=self.pk_pa_schema)
 
         schema = Schema.from_pyarrow_schema(self.pa_schema)
         self.rest_catalog.create_table('default.test_reader_iterator', schema, False)
@@ -191,6 +199,7 @@ class RESTBaseTest(unittest.TestCase):
 
     def _write_test_table(self, table):
         write_builder = table.new_batch_write_builder()
+        table_pa_schema = self.pk_pa_schema
 
         # first write
         table_write = write_builder.new_write()
@@ -202,7 +211,7 @@ class RESTBaseTest(unittest.TestCase):
             'dt': ['p1', 'p1', 'p2', 'p1'],
             'long-dt': ['2024-10-10', '2024-10-10', '2024-10-10', '2024-01-01'],
         }
-        pa_table = pa.Table.from_pydict(data1, schema=self.pa_schema)
+        pa_table = pa.Table.from_pydict(data1, schema=table_pa_schema)
         table_write.write_arrow(pa_table)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -218,7 +227,7 @@ class RESTBaseTest(unittest.TestCase):
             'dt': ['p2', 'p1', 'p2', 'p2'],
             'long-dt': ['2024-10-10', '2025-01-23', 'abcdefghijklmnopk', '2025-08-08'],
         }
-        pa_table = pa.Table.from_pydict(data2, schema=self.pa_schema)
+        pa_table = pa.Table.from_pydict(data2, schema=table_pa_schema)
         table_write.write_arrow(pa_table)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()

--- a/paimon-python/pypaimon/tests/rest/rest_read_write_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_read_write_test.py
@@ -286,7 +286,7 @@ class RESTTableReadWriteTest(RESTBaseTest):
                                                 'bucket': '2',
                                                 'file.format': 'avro'
                                             })
-        self.rest_catalog.create_table('default.test_pk_avro', schema, True)
+        self.rest_catalog.create_table('default.test_pk_avro', schema, False)
         table = self.rest_catalog.get_table('default.test_pk_avro')
         self._write_test_table(table)
 

--- a/paimon-python/pypaimon/tests/rest/rest_read_write_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_read_write_test.py
@@ -255,7 +255,7 @@ class RESTTableReadWriteTest(RESTBaseTest):
 
         read_builder = table.new_read_builder()
         actual = self._read_test_table(read_builder).sort_by('user_id')
-        self.assertEqual(actual, self.expected)
+        self.assertEqual(actual, self.pk_expected)
 
     def test_pk_orc_reader(self):
         schema = Schema.from_pyarrow_schema(self.pa_schema,
@@ -286,13 +286,13 @@ class RESTTableReadWriteTest(RESTBaseTest):
                                                 'bucket': '2',
                                                 'file.format': 'avro'
                                             })
-        self.rest_catalog.create_table('default.test_pk_avro', schema, False)
+        self.rest_catalog.create_table('default.test_pk_avro', schema, True)
         table = self.rest_catalog.get_table('default.test_pk_avro')
         self._write_test_table(table)
 
         read_builder = table.new_read_builder()
         actual = self._read_test_table(read_builder).sort_by('user_id')
-        self.assertEqual(actual, self.expected)
+        self.assertEqual(actual, self.pk_expected)
 
     def test_pk_lance_reader(self):
         schema = Schema.from_pyarrow_schema(self.pa_schema,
@@ -312,7 +312,7 @@ class RESTTableReadWriteTest(RESTBaseTest):
 
         read_builder = table.new_read_builder()
         actual = self._read_test_table(read_builder).sort_by('user_id')
-        self.assertEqual(actual, self.expected)
+        self.assertEqual(actual, self.pk_expected)
 
     def test_lance_ao_reader_with_filter(self):
         schema = Schema.from_pyarrow_schema(self.pa_schema, partition_keys=['dt'], options={'file.format': 'lance'})
@@ -357,8 +357,8 @@ class RESTTableReadWriteTest(RESTBaseTest):
         read_builder = table.new_read_builder().with_filter(g1)
         actual = self._read_test_table(read_builder).sort_by('user_id')
         expected = pa.concat_tables([
-            self.expected.slice(1, 1),  # 2/b
-            self.expected.slice(5, 1)  # 7/g
+            self.pk_expected.slice(1, 1),  # 2/b
+            self.pk_expected.slice(5, 1)  # 7/g
         ])
         self.assertEqual(actual, expected)
 
@@ -377,7 +377,7 @@ class RESTTableReadWriteTest(RESTBaseTest):
 
         read_builder = table.new_read_builder()
         actual = self._read_test_table(read_builder).sort_by('user_id')
-        self.assertEqual(actual, self.expected)
+        self.assertEqual(actual, self.pk_expected)
 
     def test_pk_reader_with_filter(self):
         schema = Schema.from_pyarrow_schema(self.pa_schema,
@@ -396,8 +396,8 @@ class RESTTableReadWriteTest(RESTBaseTest):
         read_builder = table.new_read_builder().with_filter(g1)
         actual = self._read_test_table(read_builder).sort_by('user_id')
         expected = pa.concat_tables([
-            self.expected.slice(1, 1),  # 2/b
-            self.expected.slice(5, 1)  # 7/g
+            self.pk_expected.slice(1, 1),  # 2/b
+            self.pk_expected.slice(5, 1)  # 7/g
         ])
         self.assertEqual(actual, expected)
 
@@ -412,7 +412,7 @@ class RESTTableReadWriteTest(RESTBaseTest):
 
         read_builder = table.new_read_builder().with_projection(['dt', 'user_id', 'behavior'])
         actual = self._read_test_table(read_builder).sort_by('user_id')
-        expected = self.expected.select(['dt', 'user_id', 'behavior'])
+        expected = self.pk_expected.select(['dt', 'user_id', 'behavior'])
         self.assertEqual(actual, expected)
 
     def test_write_wrong_schema(self):

--- a/paimon-python/pypaimon/tests/rest/rest_server.py
+++ b/paimon-python/pypaimon/tests/rest/rest_server.py
@@ -972,6 +972,14 @@ class RESTCatalogServer:
                                schema: Schema, uuid_str: str, is_external: bool) -> TableMetadata:
         """Create table metadata"""
         options = schema.options.copy()
+
+        fields = schema.fields
+        if schema.primary_keys:
+            pk_set = set(schema.primary_keys)
+            for field in fields:
+                if field.name in pk_set:
+                    field.type.nullable = False
+
         table_schema = TableSchema(
             version=TableSchema.CURRENT_VERSION,
             id=schema_id,

--- a/paimon-python/pypaimon/tests/rest/rest_simple_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_simple_test.py
@@ -45,6 +45,12 @@ class RESTSimpleTest(RESTBaseTest):
             ('behavior', pa.string()),
             ('dt', pa.string()),
         ])
+        self.pk_pa_schema = pa.schema([
+            pa.field('user_id', pa.int64(), nullable=False),
+            ('item_id', pa.int64()),
+            ('behavior', pa.string()),
+            pa.field('dt', pa.string(), nullable=False),
+        ])
         self.data = {
             'user_id': [2, 4, 6, 8, 10],
             'item_id': [1001, 1002, 1003, 1004, 1005],
@@ -597,13 +603,14 @@ class RESTSimpleTest(RESTBaseTest):
         self.rest_catalog.drop_table('default.test_with_shard', True)
         self.rest_catalog.create_table('default.test_with_shard', schema, False)
         table = self.rest_catalog.get_table('default.test_with_shard')
+        table_pa_schema = self.pk_pa_schema
 
         write_builder = table.new_batch_write_builder()
         table_write = write_builder.new_write()
         table_commit = write_builder.new_commit()
         self.assertIsInstance(table_write.row_key_extractor, DynamicBucketRowKeyExtractor)
 
-        pa_table = pa.Table.from_pydict(self.data, schema=self.pa_schema)
+        pa_table = pa.Table.from_pydict(self.data, schema=table_pa_schema)
         table_write.write_arrow(pa_table)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -616,7 +623,7 @@ class RESTSimpleTest(RESTBaseTest):
         splits.extend(read_builder.new_scan().with_shard(2, 3).plan().splits())
         table_read = read_builder.new_read()
         actual = table_read.to_arrow(splits)
-        expected_sorted = table_sort_by(self.expected, 'user_id')
+        expected_sorted = table_sort_by(self.expected.cast(self.pk_pa_schema), 'user_id')
         actual_sorted = table_sort_by(actual, 'user_id')
         self.assertEqual(actual_sorted, expected_sorted)
 
@@ -626,13 +633,14 @@ class RESTSimpleTest(RESTBaseTest):
         self.rest_catalog.drop_table('default.test_with_shard', True)
         self.rest_catalog.create_table('default.test_with_shard', schema, False)
         table = self.rest_catalog.get_table('default.test_with_shard')
+        table_pa_schema = self.pk_pa_schema
 
         write_builder = table.new_batch_write_builder()
         table_write = write_builder.new_write()
         table_commit = write_builder.new_commit()
         self.assertIsInstance(table_write.row_key_extractor, FixedBucketRowKeyExtractor)
 
-        pa_table = pa.Table.from_pydict(self.data, schema=self.pa_schema)
+        pa_table = pa.Table.from_pydict(self.data, schema=table_pa_schema)
         table_write.write_arrow(pa_table)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -652,7 +660,7 @@ class RESTSimpleTest(RESTBaseTest):
             'behavior': ['b', 'c', 'a', 'd', 'e'],
             'dt': ['2025-08-10', '2025-08-11', '2000-10-10', '2025-08-12', '2025-08-13']
         }
-        expected = pa.Table.from_pydict(data_expected, schema=self.pa_schema)
+        expected = pa.Table.from_pydict(data_expected, schema=table_pa_schema)
         self.assertEqual(actual.combine_chunks(), expected.combine_chunks())
 
     def test_with_shard_uniform_division(self):

--- a/paimon-python/pypaimon/tests/serializable_test.py
+++ b/paimon-python/pypaimon/tests/serializable_test.py
@@ -43,12 +43,18 @@ class SerializableTest(unittest.TestCase):
             ('behavior', pa.string()),
             ('dt', pa.string())
         ])
+        cls.pk_pa_schema = pa.schema([
+            pa.field('user_id', pa.int32(), nullable=False),
+            ('item_id', pa.int32()),
+            ('behavior', pa.string()),
+            pa.field('dt', pa.string(), nullable=False)
+        ])
         cls.expected = pa.Table.from_pydict({
             'user_id': [1, 2, 3, 4, 5, 7, 8],
             'item_id': [1001, 1002, 1003, 1004, 1005, 1007, 1008],
             'behavior': ['a', 'b-new', 'c', None, 'e', 'g', 'h'],
             'dt': ['p1', 'p1', 'p2', 'p1', 'p2', 'p1', 'p2'],
-        }, schema=cls.pa_schema)
+        }, schema=cls.pk_pa_schema)
 
     @classmethod
     def tearDownClass(cls):
@@ -86,7 +92,7 @@ class SerializableTest(unittest.TestCase):
             'behavior': ['a', 'b', 'c', None],
             'dt': ['p1', 'p1', 'p2', 'p1'],
         }
-        pa_table = pa.Table.from_pydict(data1, schema=self.pa_schema)
+        pa_table = pa.Table.from_pydict(data1, schema=self.pk_pa_schema)
         table_write.write_arrow(pa_table)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -100,7 +106,7 @@ class SerializableTest(unittest.TestCase):
             'behavior': ['e', 'b-new', 'g', 'h'],
             'dt': ['p2', 'p1', 'p1', 'p2']
         }
-        pa_table = pa.Table.from_pydict(data1, schema=self.pa_schema)
+        pa_table = pa.Table.from_pydict(data1, schema=self.pk_pa_schema)
         table_write.write_arrow(pa_table)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()

--- a/paimon-python/pypaimon/tests/table/simple_table_test.py
+++ b/paimon-python/pypaimon/tests/table/simple_table_test.py
@@ -41,6 +41,11 @@ class SimpleTableTest(unittest.TestCase):
             ('k', pa.int32()),
             ('v', pa.int64())
         ])
+        cls.pk_pa_schema = pa.schema([
+            pa.field('pt', pa.int32(), nullable=False),
+            pa.field('k', pa.int32(), nullable=False),
+            ('v', pa.int64())
+        ])
 
     @classmethod
     def tearDownClass(cls):
@@ -72,7 +77,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [1, 1],
             'k': [10, 20],
             'v': [100, 200]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
         table_write.write_arrow(data1)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -85,7 +90,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [2, 2],
             'k': [30, 40],
             'v': [101, 201]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
         table_write.write_arrow(data2)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -98,7 +103,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [3, 3],
             'k': [50, 60],
             'v': [500, 600]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
         table_write.write_arrow(data3)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -122,7 +127,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [1, 1, 2, 2],
             'k': [10, 20, 30, 40],
             'v': [100, 200, 101, 201]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
 
         self.assertEqual(result_sorted.num_rows, 4)
         self.assertEqual(result_sorted.column('pt').to_pylist(), expected.column('pt').to_pylist())
@@ -173,7 +178,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [1, 1],
             'k': [10, 20],
             'v': [100, 200]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
         table_write.write_arrow(data)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -197,7 +202,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [1, 1],
             'k': [10, 20],
             'v': [100, 200]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
         table_write.write_arrow(data)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -237,7 +242,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [1],
             'k': [10],
             'v': [100]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
         table_write.write_arrow(data)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -274,7 +279,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [1],
             'k': [10],
             'v': [100]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
         table_write.write_arrow(data)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -317,7 +322,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [1],
             'k': [10],
             'v': [100]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
         table_write.write_arrow(data)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -348,7 +353,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [1],
             'k': [10],
             'v': [100]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
         table_write.write_arrow(data)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -388,7 +393,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [1, 1],
             'k': [10, 20],
             'v': [100, 200]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
         table_write.write_arrow(data1)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -401,7 +406,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [2, 2],
             'k': [30, 40],
             'v': [101, 201]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
         table_write.write_arrow(data2)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -427,7 +432,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [1, 1],
             'k': [10, 20],
             'v': [100, 200]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
 
         self.assertEqual(result_sorted.num_rows, 2)
         self.assertEqual(result_sorted.column('pt').to_pylist(), expected.column('pt').to_pylist())
@@ -559,7 +564,7 @@ class SimpleTableTest(unittest.TestCase):
                 'pt': [1],
                 'k': [i],
                 'v': [i * 100]
-            }, schema=self.pa_schema)
+            }, schema=self.pk_pa_schema)
             table_write.write_arrow(data)
             table_commit.commit(table_write.prepare_commit())
             table_write.close()
@@ -596,7 +601,7 @@ class SimpleTableTest(unittest.TestCase):
                 'pt': [1],
                 'k': [i],
                 'v': [i * 100]
-            }, schema=self.pa_schema)
+            }, schema=self.pk_pa_schema)
             table_write.write_arrow(data)
             table_commit.commit(table_write.prepare_commit())
             table_write.close()
@@ -638,7 +643,7 @@ class SimpleTableTest(unittest.TestCase):
                 'pt': [1],
                 'k': [i],
                 'v': [i * 100]
-            }, schema=self.pa_schema)
+            }, schema=self.pk_pa_schema)
             table_write.write_arrow(data)
             table_commit.commit(table_write.prepare_commit())
             table_write.close()
@@ -670,7 +675,7 @@ class SimpleTableTest(unittest.TestCase):
             'pt': [1],
             'k': [10],
             'v': [100]
-        }, schema=self.pa_schema)
+        }, schema=self.pk_pa_schema)
         table_write.write_arrow(data)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()

--- a/paimon-python/pypaimon/tests/torch_read_test.py
+++ b/paimon-python/pypaimon/tests/torch_read_test.py
@@ -44,6 +44,12 @@ class TorchReadTest(unittest.TestCase):
             ('behavior', pa.string()),
             ('dt', pa.string())
         ])
+        cls.pk_pa_schema = pa.schema([
+            pa.field('user_id', pa.int32(), nullable=False),
+            ('item_id', pa.int64()),
+            pa.field('behavior', pa.string(), nullable=False),
+            ('dt', pa.string())
+        ])
         cls.expected = pa.Table.from_pydict({
             'user_id': [1, 2, 3, 4, 5, 6, 7, 8],
             'item_id': [1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008],
@@ -382,6 +388,12 @@ class TorchReadTest(unittest.TestCase):
         """Test torch read with large data volume on primary key table."""
 
         # Create PK table
+        large_pk_pa_schema = pa.schema([
+            pa.field('user_id', pa.int32(), nullable=False),
+            ('item_id', pa.int64()),
+            ('behavior', pa.string()),
+            ('dt', pa.string())
+        ])
         schema = Schema.from_pyarrow_schema(
             self.pa_schema,
             primary_keys=['user_id'],
@@ -414,7 +426,7 @@ class TorchReadTest(unittest.TestCase):
                 'behavior': [chr(ord('a') + (i % 26)) for i in range(batch_size)],
                 'dt': [f'p{i % 4}' for i in range(batch_size)],
             }
-            pa_table = pa.Table.from_pydict(data, schema=self.pa_schema)
+            pa_table = pa.Table.from_pydict(data, schema=large_pk_pa_schema)
             table_write.write_arrow(pa_table)
             table_commit.commit(table_write.prepare_commit())
             table_write.close()
@@ -634,6 +646,7 @@ class TorchReadTest(unittest.TestCase):
 
     def _write_test_table(self, table):
         write_builder = table.new_batch_write_builder()
+        table_pa_schema = self.pk_pa_schema if table.primary_keys else self.pa_schema
 
         # first write
         table_write = write_builder.new_write()
@@ -644,7 +657,7 @@ class TorchReadTest(unittest.TestCase):
             'behavior': ['a', 'b', 'c', 'd'],
             'dt': ['p1', 'p1', 'p2', 'p1'],
         }
-        pa_table = pa.Table.from_pydict(data1, schema=self.pa_schema)
+        pa_table = pa.Table.from_pydict(data1, schema=table_pa_schema)
         table_write.write_arrow(pa_table)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
@@ -659,7 +672,7 @@ class TorchReadTest(unittest.TestCase):
             'behavior': ['e', 'f', 'g', 'h'],
             'dt': ['p2', 'p1', 'p2', 'p1'],
         }
-        pa_table = pa.Table.from_pydict(data2, schema=self.pa_schema)
+        pa_table = pa.Table.from_pydict(data2, schema=table_pa_schema)
         table_write.write_arrow(pa_table)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()

--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -44,12 +44,24 @@ class TableWriteTest(unittest.TestCase):
             ('behavior', pa.string()),
             ('dt', pa.string())
         ])
+        cls.pk_pa_schema = pa.schema([
+            pa.field('user_id', pa.int32(), nullable=False),
+            ('item_id', pa.int64()),
+            ('behavior', pa.string()),
+            pa.field('dt', pa.string(), nullable=False)
+        ])
         cls.expected = pa.Table.from_pydict({
             'user_id': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             'item_id': [1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010],
             'behavior': ['a', 'b', 'c', None, 'e', 'f', 'g', 'h', 'i', 'j'],
             'dt': ['p1', 'p1', 'p2', 'p1', 'p2', 'p1', 'p2', 'p2', 'p2', 'p1']
         }, schema=cls.pa_schema)
+        cls.pk_expected = pa.Table.from_pydict({
+            'user_id': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            'item_id': [1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010],
+            'behavior': ['a', 'b', 'c', None, 'e', 'f', 'g', 'h', 'i', 'j'],
+            'dt': ['p1', 'p1', 'p2', 'p1', 'p2', 'p1', 'p2', 'p2', 'p2', 'p1']
+        }, schema=cls.pk_pa_schema)
 
     @classmethod
     def tearDownClass(cls):
@@ -147,7 +159,7 @@ class TableWriteTest(unittest.TestCase):
             'behavior': ['a', 'b', 'c', None],
             'dt': ['p1', 'p1', 'p2', 'p1'],
         }
-        pa_table = pa.Table.from_pydict(data1, schema=self.pa_schema)
+        pa_table = pa.Table.from_pydict(data1, schema=self.pk_pa_schema)
         table_write.write_arrow(pa_table)
         table_write.prepare_commit(0)
         # write 2
@@ -157,7 +169,7 @@ class TableWriteTest(unittest.TestCase):
             'behavior': ['e', 'f', 'g', 'h'],
             'dt': ['p2', 'p1', 'p2', 'p2'],
         }
-        pa_table = pa.Table.from_pydict(data2, schema=self.pa_schema)
+        pa_table = pa.Table.from_pydict(data2, schema=self.pk_pa_schema)
         table_write.write_arrow(pa_table)
         table_write.prepare_commit(1)
         # write 3
@@ -167,7 +179,7 @@ class TableWriteTest(unittest.TestCase):
             'behavior': ['i', 'j'],
             'dt': ['p2', 'p1'],
         }
-        pa_table = pa.Table.from_pydict(data3, schema=self.pa_schema)
+        pa_table = pa.Table.from_pydict(data3, schema=self.pk_pa_schema)
         table_write.write_arrow(pa_table)
         cm = table_write.prepare_commit(2)
         # commit
@@ -180,7 +192,7 @@ class TableWriteTest(unittest.TestCase):
         table_read = read_builder.new_read()
         splits = read_builder.new_scan().plan().splits()
         actual = table_read.to_arrow(splits).sort_by('user_id')
-        self.assertEqual(self.expected, actual)
+        self.assertEqual(self.pk_expected, actual)
 
     def test_postpone_read_write(self):
         schema = Schema.from_pyarrow_schema(self.pa_schema, partition_keys=['user_id'], primary_keys=['user_id', 'dt'],
@@ -193,7 +205,7 @@ class TableWriteTest(unittest.TestCase):
             'behavior': ['a', 'b', 'c', None],
             'dt': ['p1', 'p1', 'p2', 'p1'],
         }
-        expect = pa.Table.from_pydict(data, schema=self.pa_schema)
+        expect = pa.Table.from_pydict(data, schema=self.pk_pa_schema)
 
         write_builder = table.new_batch_write_builder()
         table_write = write_builder.new_write()
@@ -234,7 +246,7 @@ class TableWriteTest(unittest.TestCase):
             'behavior': ['a', 'b'],
             'dt': ['p1', 'p1'],
         }
-        pa_table = pa.Table.from_pydict(data, schema=self.pa_schema)
+        pa_table = pa.Table.from_pydict(data, schema=self.pk_pa_schema)
         table_write.write_arrow(pa_table)
 
         commit_messages = table_write.prepare_commit()
@@ -368,11 +380,17 @@ class TableWriteTest(unittest.TestCase):
             'default.test_dynamic_bucket', schema, False)
         table = self.catalog.get_table(
             'default.test_dynamic_bucket')
+        expected = pa.Table.from_pydict({
+            'user_id': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            'item_id': [1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010],
+            'behavior': ['a', 'b', 'c', None, 'e', 'f', 'g', 'h', 'i', 'j'],
+            'dt': ['p1', 'p1', 'p2', 'p1', 'p2', 'p1', 'p2', 'p2', 'p2', 'p1']
+        }, schema=self.pk_pa_schema)
         write_builder = table.new_batch_write_builder()
 
         table_write = write_builder.new_write()
         table_commit = write_builder.new_commit()
-        table_write.write_arrow(self.expected)
+        table_write.write_arrow(expected)
         table_commit.commit(table_write.prepare_commit())
         table_write.close()
         table_commit.close()
@@ -383,7 +401,7 @@ class TableWriteTest(unittest.TestCase):
         actual = table_read.to_arrow(splits)
         sort_keys = [('user_id', 'ascending'), ('dt', 'ascending')]
         self.assertEqual(
-            self.expected.sort_by(sort_keys),
+            self.pk_expected.sort_by(sort_keys),
             actual.sort_by(sort_keys),
         )
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes schema normalization for primary key tables, which can affect table creation and write-path schema validation for existing callers passing nullable PK fields. Test updates suggest intended behavior but downstream compatibility may need verification.
> 
> **Overview**
> **Primary-key columns are now forced to be NOT NULL** when building a `Schema` from a PyArrow schema (`Schema.from_pyarrow_schema`) and when creating REST test table metadata (`RESTCatalogServer._create_table_metadata`).
> 
> Tests across Ray/REST/reader/write paths were updated to use explicit non-nullable PyArrow fields for PK columns (and, where needed, separate “write schemas”/expected tables), ensuring writes and assertions match the new PK nullability requirements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e05cfbb6186fd8ecae73a2618d28b665693d2aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->