### PR TITLE
[python] Fix _apply_push_down_limit not considering non-raw-convertib…

### DIFF
--- a/paimon-python/pypaimon/read/scanner/file_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/file_scanner.py
@@ -400,7 +400,7 @@ class FileScanner:
                 if scanned_row_count >= self.limit:
                     return limited_splits
 
-        return limited_splits
+        return splits
 
     def _filter_manifest_file(self, file: ManifestFileMeta) -> bool:
         if not self.partition_key_predicate:

--- a/paimon-python/pypaimon/tests/reader_primary_key_test.py
+++ b/paimon-python/pypaimon/tests/reader_primary_key_test.py
@@ -271,6 +271,61 @@ class PkReaderTest(unittest.TestCase):
         expected = self.expected.select(['dt', 'user_id', 'behavior'])
         self.assertEqual(actual, expected)
 
+    def test_pk_reader_with_limit(self):
+        schema = Schema.from_pyarrow_schema(self.pa_schema,
+                                            partition_keys=['dt'],
+                                            primary_keys=['user_id', 'dt'],
+                                            options={'bucket': '1'})
+        self.catalog.create_table('default.test_pk_limit', schema, False)
+        table = self.catalog.get_table('default.test_pk_limit')
+
+        num_commits = 5
+        rows_per_commit = 25
+
+        for commit_idx in range(num_commits):
+            write_builder = table.new_batch_write_builder()
+            writer = write_builder.new_write()
+
+            start_id = commit_idx * rows_per_commit
+            end_id = start_id + rows_per_commit
+
+            if commit_idx > 0:
+                start_id -= 10
+
+            batch = pa.Table.from_pydict({
+                'user_id': list(range(start_id, end_id)),
+                'item_id': [1000 + i for i in range(start_id, end_id)],
+                'behavior': [f'val-{i}' for i in range(start_id, end_id)],
+                'dt': ['p1' if i % 2 == 0 else 'p2' for i in range(start_id, end_id)],
+            }, schema=self.pa_schema)
+
+            writer.write_arrow(batch)
+            commit_messages = writer.prepare_commit()
+            commit = write_builder.new_commit()
+            commit.commit(commit_messages)
+            writer.close()
+
+        read_builder = table.new_read_builder()
+        table_scan = read_builder.new_scan()
+        all_splits = table_scan.plan().splits()
+        merge_splits = [s for s in all_splits if not s.raw_convertible]
+        self.assertGreater(len(merge_splits), 0,
+                          "Should have at least one merge split to test limit with merge scenario")
+
+        total_unique_rows = 125
+        for limit in [5, 10, 20, 50]:
+            read_builder = table.new_read_builder().with_limit(limit)
+            table_read = read_builder.new_read()
+            table_scan = read_builder.new_scan()
+            splits = table_scan.plan().splits()
+            self.assertGreater(len(splits), 0,
+                              f"with_limit({limit}) should not produce empty splits for PK table")
+            result = table_read.to_arrow(splits)
+            row_count = result.num_rows if result is not None else 0
+            self.assertEqual(row_count, total_unique_rows,
+                            f"with_limit({limit}) should return all rows for PK table "
+                            f"(read-level limit not yet implemented)")
+
     def test_incremental_timestamp(self):
         schema = Schema.from_pyarrow_schema(self.pa_schema,
                                             partition_keys=['dt'],

--- a/paimon-python/pypaimon/tests/reader_primary_key_test.py
+++ b/paimon-python/pypaimon/tests/reader_primary_key_test.py
@@ -309,8 +309,9 @@ class PkReaderTest(unittest.TestCase):
         table_scan = read_builder.new_scan()
         all_splits = table_scan.plan().splits()
         merge_splits = [s for s in all_splits if not s.raw_convertible]
-        self.assertGreater(len(merge_splits), 0,
-                          "Should have at least one merge split to test limit with merge scenario")
+        self.assertGreater(
+            len(merge_splits), 0,
+            "Should have at least one merge split to test limit with merge scenario")
 
         total_unique_rows = 125
         for limit in [5, 10, 20, 50]:
@@ -318,13 +319,15 @@ class PkReaderTest(unittest.TestCase):
             table_read = read_builder.new_read()
             table_scan = read_builder.new_scan()
             splits = table_scan.plan().splits()
-            self.assertGreater(len(splits), 0,
-                              f"with_limit({limit}) should not produce empty splits for PK table")
+            self.assertGreater(
+                len(splits), 0,
+                f"with_limit({limit}) should not produce empty splits for PK table")
             result = table_read.to_arrow(splits)
             row_count = result.num_rows if result is not None else 0
-            self.assertEqual(row_count, total_unique_rows,
-                            f"with_limit({limit}) should return all rows for PK table "
-                            f"(read-level limit not yet implemented)")
+            self.assertEqual(
+                row_count, total_unique_rows,
+                f"with_limit({limit}) should return all rows for PK table "
+                f"(read-level limit not yet implemented)")
 
     def test_incremental_timestamp(self):
         schema = Schema.from_pyarrow_schema(self.pa_schema,


### PR DESCRIPTION
…le splits issue

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scan planning behavior when `with_limit()` is used, which can affect which splits are read (especially for PK/merge scans). Scoped to limit pushdown and covered by a new PK-table regression test.
> 
> **Overview**
> Fixes `_apply_push_down_limit` in `file_scanner.py` so `with_limit()` no longer returns only the accumulated `raw_convertible` splits (potentially an empty list) when the planned splits include non-raw/merge splits; if the limit can’t be safely applied, it now keeps the full `splits` list.
> 
> Adds `test_pk_reader_with_limit` to ensure PK tables that produce merge (non-`raw_convertible`) splits still plan non-empty splits under various limits and continue returning all rows (since read-level limiting isn’t implemented yet).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be7c65a3b043d2f1f23921af36296c21782fb463. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->