### PR TITLE
[python] Fix wrong file extension parsing for compressed json/csv files

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -674,6 +674,47 @@ public class JavaPyE2ETest {
         assertThat(result).containsExactlyInAnyOrder("v3", "v5");
     }
 
+    @Test
+    @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
+    public void testJavaWriteCompressedTextAppendTable() throws Exception {
+        for (String format : Arrays.asList("json", "csv")) {
+            String tableName = "mixed_test_append_tablej_" + format + "_gz";
+            Identifier identifier = identifier(tableName);
+            Schema schema =
+                    Schema.newBuilder()
+                            .column("id", DataTypes.INT())
+                            .column("name", DataTypes.STRING())
+                            .column("value", DataTypes.DOUBLE())
+                            .option("file.format", format)
+                            .option("file.compression", "gzip")
+                            .option("bucket", "-1")
+                            .build();
+
+            catalog.createTable(identifier, schema, true);
+            Table table = catalog.getTable(identifier);
+            FileStoreTable fileStoreTable = (FileStoreTable) table;
+
+            BatchWriteBuilder writeBuilder = fileStoreTable.newBatchWriteBuilder();
+            try (BatchTableWrite write = writeBuilder.newWrite();
+                    BatchTableCommit commit = writeBuilder.newCommit()) {
+                write.write(GenericRow.of(1, BinaryString.fromString("Apple"), 1.5));
+                write.write(GenericRow.of(2, BinaryString.fromString("Banana"), 0.8));
+                write.write(GenericRow.of(3, BinaryString.fromString("Carrot"), 0.6));
+                commit.commit(write.prepareCommit());
+            }
+
+            List<Split> splits =
+                    new ArrayList<>(fileStoreTable.newSnapshotReader().read().dataSplits());
+            TableRead read = fileStoreTable.newRead();
+            List<String> res =
+                    getResult(
+                            read,
+                            splits,
+                            row -> DataFormatTestUtil.toStringNoRowKind(row, table.rowType()));
+            assertThat(res).hasSize(3);
+        }
+    }
+
     // Helper method from TableTestBase
     protected Identifier identifier(String tableName) {
         return new Identifier(database, tableName);

--- a/paimon-python/dev/run_mixed_tests.sh
+++ b/paimon-python/dev/run_mixed_tests.sh
@@ -221,6 +221,29 @@ run_btree_index_test() {
     fi
 }
 
+run_compressed_text_test() {
+    echo -e "${YELLOW}=== Step 7: Running Compressed Text Test (Java Write, Python Read) ===${NC}"
+
+    cd "$PROJECT_ROOT"
+
+    echo "Running Maven test for JavaPyE2ETest.testJavaWriteCompressedTextAppendTable..."
+    if mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testJavaWriteCompressedTextAppendTable -pl paimon-core -q -Drun.e2e.tests=true; then
+        echo -e "${GREEN}✓ Java test completed successfully${NC}"
+    else
+        echo -e "${RED}✗ Java test failed${NC}"
+        return 1
+    fi
+    cd "$PAIMON_PYTHON_DIR"
+    echo "Running Python test for JavaPyReadWriteTest.test_read_compressed_text_append_table..."
+    if python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest -k "test_read_compressed_text_append_table" -v; then
+        echo -e "${GREEN}✓ Python test completed successfully${NC}"
+        return 0
+    else
+        echo -e "${RED}✗ Python test failed${NC}"
+        return 1
+    fi
+}
+
 # Main execution
 main() {
     local java_write_result=0
@@ -229,6 +252,7 @@ main() {
     local java_read_result=0
     local pk_dv_result=0
     local btree_index_result=0
+    local compressed_text_result=0
 
     echo -e "${YELLOW}Starting mixed language test execution...${NC}"
     echo ""
@@ -281,6 +305,12 @@ main() {
 
     echo ""
 
+    if ! run_compressed_text_test; then
+        compressed_text_result=1
+    fi
+
+    echo ""
+
     echo -e "${YELLOW}=== Test Results Summary ===${NC}"
 
     if [[ $java_write_result -eq 0 ]]; then
@@ -319,12 +349,18 @@ main() {
         echo -e "${RED}✗ BTree Index Test (Java Write, Python Read): FAILED${NC}"
     fi
 
+    if [[ $compressed_text_result -eq 0 ]]; then
+        echo -e "${GREEN}✓ Compressed Text Test (Java Write, Python Read): PASSED${NC}"
+    else
+        echo -e "${RED}✗ Compressed Text Test (Java Write, Python Read): FAILED${NC}"
+    fi
+
     echo ""
 
     # Clean up warehouse directory after all tests
     cleanup_warehouse
 
-    if [[ $java_write_result -eq 0 && $python_read_result -eq 0 && $python_write_result -eq 0 && $java_read_result -eq 0 && $pk_dv_result -eq 0 && $btree_index_result -eq 0 ]]; then
+    if [[ $java_write_result -eq 0 && $python_read_result -eq 0 && $python_write_result -eq 0 && $java_read_result -eq 0 && $pk_dv_result -eq 0 && $btree_index_result -eq 0 && $compressed_text_result -eq 0 ]]; then
         echo -e "${GREEN}🎉 All tests passed! Java-Python interoperability verified.${NC}"
         return 0
     else

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -64,6 +64,19 @@ KEY_PREFIX = "_KEY_"
 KEY_FIELD_ID_START = 1000000
 NULL_FIELD_INDEX = -1
 
+_COMPRESS_EXTENSIONS = frozenset(['gz', 'bz2', 'deflate', 'snappy', 'lz4', 'zst'])
+
+
+def format_identifier(file_name):
+    idx = file_name.rfind('.')
+    assert idx != -1, "%s is not a legal file name." % file_name
+    ext = file_name[idx + 1:]
+    if ext.lower() in _COMPRESS_EXTENSIONS:
+        second_idx = file_name.rfind('.', 0, idx)
+        assert second_idx != -1, "%s is not a legal file name." % file_name
+        return file_name[second_idx + 1:idx]
+    return ext
+
 
 class SplitRead(ABC):
     """Abstract base class for split reading operations."""
@@ -119,8 +132,7 @@ class SplitRead(ABC):
 
         # Use external_path if available, otherwise use file_path
         file_path = file.external_path if file.external_path else file.file_path
-        _, extension = os.path.splitext(file_path)
-        file_format = extension[1:]
+        file_format = format_identifier(os.path.basename(file_path))
 
         batch_size = self.table.options.read_batch_size()
 
@@ -142,6 +154,10 @@ class SplitRead(ABC):
             format_reader = FormatPyArrowReader(
                 self.table.file_io, file_format, file_path,
                 ordered_read_fields, read_arrow_predicate, batch_size=batch_size)
+        elif file_format in ('json', 'csv'):
+            raise NotImplementedError(
+                f"Reading '{file_format}' format is not yet supported in Python SDK. "
+                f"Supported formats: parquet, orc, avro, lance, blob.")
         else:
             raise ValueError(f"Unexpected file format: {file_format}")
 

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -429,3 +429,16 @@ class JavaPyReadWriteTest(unittest.TestCase):
             'v': ["v1", "v2", "v4"]
         })
         self.assertEqual(expected, actual)
+
+    @parameterized.expand([('json',), ('csv',)])
+    def test_read_compressed_text_append_table(self, file_format):
+        table = self.catalog.get_table(
+            f'default.mixed_test_append_tablej_{file_format}_gz')
+        read_builder = table.new_read_builder()
+        table_scan = read_builder.new_scan()
+        table_read = read_builder.new_read()
+        splits = table_scan.plan().splits()
+        with self.assertRaises(NotImplementedError) as ctx:
+            table_read.to_arrow(splits)
+        self.assertIn(file_format, str(ctx.exception))
+        self.assertIn("not yet supported", str(ctx.exception))


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Python split reader file-format detection for compressed filenames, which affects how all data files are routed to specific readers and could surface as unexpected format errors if parsing is wrong. Scope is small and covered by new Java/Python E2E tests.
> 
> **Overview**
> Fixes Python SDK file-format detection for compressed data files by extracting the *real* format (e.g., `json`/`csv` from `*.json.gz`) instead of treating the compression suffix as the format.
> 
> Adds mixed Java→Python E2E coverage that writes gzip-compressed `json`/`csv` append tables in Java and verifies Python raises a clear `NotImplementedError` for these formats, and wires this new scenario into `dev/run_mixed_tests.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa67ee50847e6fa54ea3afa23853238284fff635. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->