### PR TITLE
[python] Use streaming yield when reading ray data for better perform…

### DIFF
--- a/paimon-python/pypaimon/read/datasource/ray_datasource.py
+++ b/paimon-python/pypaimon/read/datasource/ray_datasource.py
@@ -137,16 +137,19 @@ class RayDatasource(Datasource):
             from pypaimon.read.table_read import TableRead
             worker_table_read = TableRead(table, predicate, read_type)
 
-            arrow_table = worker_table_read.to_arrow(splits)
+            batch_reader = worker_table_read.to_arrow_batch_reader(splits)
+            has_data = False
+            for batch in iter(batch_reader.read_next_batch, None):
+                if batch.num_rows == 0:
+                    continue
+                has_data = True
+                yield pyarrow.Table.from_batches([batch], schema=schema)
 
-            if arrow_table is not None and arrow_table.num_rows > 0:
-                return [arrow_table]
-            else:
-                empty_table = pyarrow.Table.from_arrays(
+            if not has_data:
+                yield pyarrow.Table.from_arrays(
                     [pyarrow.array([], type=field.type) for field in schema],
                     schema=schema
                 )
-                return [empty_table]
 
         # Use partial to create read function without capturing self
         get_read_task = partial(


### PR DESCRIPTION
…ance

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core Ray read-task output from single-table materialization to streaming yields, which can affect Ray block boundaries and downstream assumptions about per-task output shape.
> 
> **Overview**
> Updates `RayDatasource` read tasks to **stream data as it is read** by switching from `TableRead.to_arrow(...)` (materialize full table) to `to_arrow_batch_reader(...)` and `yield`ing a `pyarrow.Table` per non-empty record batch.
> 
> If a task produces no rows, it now yields a schema-correct empty `pyarrow.Table` instead of returning a singleton list, reducing peak memory and improving parallel read performance for large splits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e1c45537a3ab4a74ea7ac3b86a65b8e14a377d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->