### PR TITLE
[python] Fix blob descriptor conversion missing in to_arrow_batch_reader

### DIFF
--- a/paimon-python/pypaimon/read/reader/blob_descriptor_convert_reader.py
+++ b/paimon-python/pypaimon/read/reader/blob_descriptor_convert_reader.py
@@ -1,0 +1,81 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from typing import Optional
+
+from pyarrow import RecordBatch
+
+from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
+
+
+class BlobDescriptorConvertReader(RecordBatchReader):
+    def __init__(self, inner: RecordBatchReader, table):
+        self._inner = inner
+        self._table = table
+        self._descriptor_fields = CoreOptions.blob_descriptor_fields(table.options)
+
+    def read_arrow_batch(self) -> Optional[RecordBatch]:
+        import pyarrow
+        batch = self._inner.read_arrow_batch()
+        if batch is None:
+            return None
+        return self._convert_batch(batch, pyarrow)
+
+    def _convert_batch(self, batch, pyarrow):
+        from pypaimon.table.row.blob import Blob, BlobDescriptor
+
+        result = batch
+        for field_name in self._descriptor_fields:
+            if field_name not in result.schema.names:
+                continue
+            values = result.column(field_name).to_pylist()
+            converted_values = []
+            for value in values:
+                if value is None:
+                    converted_values.append(None)
+                    continue
+                if hasattr(value, 'as_py'):
+                    value = value.as_py()
+                if isinstance(value, str):
+                    value = value.encode('utf-8')
+                if isinstance(value, bytearray):
+                    value = bytes(value)
+                if not isinstance(value, bytes):
+                    converted_values.append(value)
+                    continue
+                try:
+                    descriptor = BlobDescriptor.deserialize(value)
+                    if descriptor.serialize() != value:
+                        converted_values.append(value)
+                        continue
+                    uri_reader = self._table.file_io.uri_reader_factory.create(descriptor.uri)
+                    converted_values.append(Blob.from_descriptor(uri_reader, descriptor).to_data())
+                except Exception:
+                    converted_values.append(value)
+
+            column_idx = result.schema.names.index(field_name)
+            result = result.set_column(
+                column_idx,
+                pyarrow.field(field_name, pyarrow.large_binary(), nullable=True),
+                pyarrow.array(converted_values, type=pyarrow.large_binary()),
+            )
+        return result
+
+    def close(self):
+        self._inner.close()

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -40,6 +40,7 @@ from pypaimon.read.reader.empty_record_reader import EmptyFileRecordReader
 from pypaimon.read.reader.field_bunch import BlobBunch, DataBunch, FieldBunch
 from pypaimon.read.reader.filter_record_reader import FilterRecordReader
 from pypaimon.read.reader.format_avro_reader import FormatAvroReader
+from pypaimon.read.reader.blob_descriptor_convert_reader import BlobDescriptorConvertReader
 from pypaimon.read.reader.filter_record_batch_reader import FilterRecordBatchReader
 from pypaimon.read.reader.row_range_filter_record_reader import RowIdFilterRecordBatchReader
 from pypaimon.read.reader.format_blob_reader import FormatBlobReader
@@ -511,13 +512,20 @@ class DataEvolutionSplitRead(SplitRead):
 
         merge_reader = ConcatBatchReader(suppliers)
         if self.predicate_for_reader is not None:
-            return FilterRecordBatchReader(
+            reader = FilterRecordBatchReader(
                 merge_reader,
                 self.predicate_for_reader,
                 field_names=[f.name for f in self.read_fields],
                 schema_fields=self.read_fields,
             )
-        return merge_reader
+        else:
+            reader = merge_reader
+
+        if (not CoreOptions.blob_as_descriptor(self.table.options)
+                and CoreOptions.blob_descriptor_fields(self.table.options)):
+            reader = BlobDescriptorConvertReader(reader, self.table)
+
+        return reader
 
     def _split_by_row_id(self, files: List[DataFileMeta]) -> List[List[DataFileMeta]]:
         """Split files by firstRowId for data evolution."""

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -159,6 +159,20 @@ class TableRead:
             )
         return result
 
+    def _convert_descriptor_stored_fields_for_read_batch(
+        self, batch: pyarrow.RecordBatch
+    ) -> pyarrow.RecordBatch:
+        if CoreOptions.blob_as_descriptor(self.table.options):
+            return batch
+
+        descriptor_fields = CoreOptions.blob_descriptor_fields(self.table.options)
+        if not descriptor_fields:
+            return batch
+
+        table = pyarrow.Table.from_batches([batch])
+        table = self._convert_descriptor_stored_fields_for_read(table)
+        return table.to_batches()[0]
+
     def _arrow_batch_generator(self, splits: List[Split], schema: pyarrow.Schema) -> Iterator[pyarrow.RecordBatch]:
         chunk_size = 65536
 
@@ -169,9 +183,11 @@ class TableRead:
                     # Add row kind column if requested (default to +I for RecordBatchReader)
                     if self.include_row_kind:
                         for batch in iter(reader.read_arrow_batch, None):
-                            yield self._add_row_kind_column_to_batch(batch, "+I")
+                            yield self._convert_descriptor_stored_fields_for_read_batch(
+                                self._add_row_kind_column_to_batch(batch, "+I"))
                     else:
-                        yield from iter(reader.read_arrow_batch, None)
+                        for batch in iter(reader.read_arrow_batch, None):
+                            yield self._convert_descriptor_stored_fields_for_read_batch(batch)
                 else:
                     row_tuple_chunk = []
                     row_kind_chunk = []
@@ -187,7 +203,7 @@ class TableRead:
                                 batch = self._convert_rows_to_arrow_batch_with_row_kind(
                                     row_tuple_chunk, row_kind_chunk, schema
                                 )
-                                yield batch
+                                yield self._convert_descriptor_stored_fields_for_read_batch(batch)
                                 row_tuple_chunk = []
                                 row_kind_chunk = []
 
@@ -195,7 +211,7 @@ class TableRead:
                         batch = self._convert_rows_to_arrow_batch_with_row_kind(
                             row_tuple_chunk, row_kind_chunk, schema
                         )
-                        yield batch
+                        yield self._convert_descriptor_stored_fields_for_read_batch(batch)
             finally:
                 reader.close()
 

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -20,7 +20,6 @@ from typing import Any, Dict, Iterator, List, Optional
 import pandas
 import pyarrow
 
-from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.common.predicate import Predicate
 from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
 from pypaimon.read.split import Split
@@ -108,70 +107,7 @@ class TableRead:
         if not table_list:
             return pyarrow.Table.from_arrays([pyarrow.array([], type=field.type) for field in schema], schema=schema)
         else:
-            table = pyarrow.Table.from_batches(table_list)
-            return self._convert_descriptor_stored_fields_for_read(table)
-
-    def _convert_descriptor_stored_fields_for_read(self, table: pyarrow.Table) -> pyarrow.Table:
-        if CoreOptions.blob_as_descriptor(self.table.options):
-            return table
-
-        descriptor_fields = CoreOptions.blob_descriptor_fields(self.table.options)
-        if not descriptor_fields:
-            return table
-
-        from pypaimon.table.row.blob import Blob, BlobDescriptor
-
-        result = table
-        for field_name in descriptor_fields:
-            if field_name not in result.column_names:
-                continue
-            values = result.column(field_name).to_pylist()
-            converted_values = []
-            for value in values:
-                if value is None:
-                    converted_values.append(None)
-                    continue
-                if hasattr(value, 'as_py'):
-                    value = value.as_py()
-                if isinstance(value, str):
-                    value = value.encode('utf-8')
-                if isinstance(value, bytearray):
-                    value = bytes(value)
-                if not isinstance(value, bytes):
-                    converted_values.append(value)
-                    continue
-
-                try:
-                    descriptor = BlobDescriptor.deserialize(value)
-                    if descriptor.serialize() != value:
-                        converted_values.append(value)
-                        continue
-                    uri_reader = self.table.file_io.uri_reader_factory.create(descriptor.uri)
-                    converted_values.append(Blob.from_descriptor(uri_reader, descriptor).to_data())
-                except Exception:
-                    converted_values.append(value)
-
-            column_idx = result.column_names.index(field_name)
-            result = result.set_column(
-                column_idx,
-                pyarrow.field(field_name, pyarrow.large_binary(), nullable=True),
-                pyarrow.array(converted_values, type=pyarrow.large_binary()),
-            )
-        return result
-
-    def _convert_descriptor_stored_fields_for_read_batch(
-        self, batch: pyarrow.RecordBatch
-    ) -> pyarrow.RecordBatch:
-        if CoreOptions.blob_as_descriptor(self.table.options):
-            return batch
-
-        descriptor_fields = CoreOptions.blob_descriptor_fields(self.table.options)
-        if not descriptor_fields:
-            return batch
-
-        table = pyarrow.Table.from_batches([batch])
-        table = self._convert_descriptor_stored_fields_for_read(table)
-        return table.to_batches()[0]
+            return pyarrow.Table.from_batches(table_list)
 
     def _arrow_batch_generator(self, splits: List[Split], schema: pyarrow.Schema) -> Iterator[pyarrow.RecordBatch]:
         chunk_size = 65536
@@ -183,11 +119,9 @@ class TableRead:
                     # Add row kind column if requested (default to +I for RecordBatchReader)
                     if self.include_row_kind:
                         for batch in iter(reader.read_arrow_batch, None):
-                            yield self._convert_descriptor_stored_fields_for_read_batch(
-                                self._add_row_kind_column_to_batch(batch, "+I"))
+                            yield self._add_row_kind_column_to_batch(batch, "+I")
                     else:
-                        for batch in iter(reader.read_arrow_batch, None):
-                            yield self._convert_descriptor_stored_fields_for_read_batch(batch)
+                        yield from iter(reader.read_arrow_batch, None)
                 else:
                     row_tuple_chunk = []
                     row_kind_chunk = []
@@ -203,7 +137,7 @@ class TableRead:
                                 batch = self._convert_rows_to_arrow_batch_with_row_kind(
                                     row_tuple_chunk, row_kind_chunk, schema
                                 )
-                                yield self._convert_descriptor_stored_fields_for_read_batch(batch)
+                                yield batch
                                 row_tuple_chunk = []
                                 row_kind_chunk = []
 
@@ -211,7 +145,7 @@ class TableRead:
                         batch = self._convert_rows_to_arrow_batch_with_row_kind(
                             row_tuple_chunk, row_kind_chunk, schema
                         )
-                        yield self._convert_descriptor_stored_fields_for_read_batch(batch)
+                        yield batch
             finally:
                 reader.close()
 

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1138,6 +1138,69 @@ class DataBlobWriterTest(unittest.TestCase):
         self.assertEqual(result.column('pic1').to_pylist()[0], pic1_data)
         self.assertEqual(result.column('pic2').to_pylist()[0], pic2_data)
 
+    def test_to_arrow_batch_reader(self):
+        import random
+        from pypaimon import Schema
+        from pypaimon.table.row.blob import BlobDescriptor
+
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('pic1', pa.large_binary()),
+            ('pic2', pa.large_binary()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'blob-descriptor-field': 'pic2'
+            }
+        )
+        self.catalog.create_table('test_db.test_to_arrow_batch_reader', schema, False)
+        table = self.catalog.get_table('test_db.test_to_arrow_batch_reader')
+
+        random.seed(8)
+        pic1_data = bytes(bytearray([random.randint(0, 255) for _ in range(1024)]))
+
+        external_blob_path = os.path.join(self.temp_dir, 'mixed_external_blob_batch_reader')
+        pic2_data = b'pic2_batch_reader_payload'
+        with open(external_blob_path, 'wb') as f:
+            f.write(pic2_data)
+        descriptor = BlobDescriptor(external_blob_path, 0, len(pic2_data))
+
+        test_data = pa.Table.from_pydict({
+            'id': [1],
+            'pic1': [pic1_data],
+            'pic2': [descriptor.serialize()]
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(test_data)
+        commit_messages = writer.prepare_commit()
+        write_builder.new_commit().commit(commit_messages)
+        writer.close()
+
+        read_builder = table.new_read_builder()
+        splits = read_builder.new_scan().plan().splits()
+        batch_reader = read_builder.new_read().to_arrow_batch_reader(splits)
+
+        batches = []
+        while True:
+            try:
+                batch = batch_reader.read_next_batch()
+            except StopIteration:
+                break
+            if batch.num_rows > 0:
+                batches.append(batch)
+
+        self.assertGreater(len(batches), 0, "Should have at least one batch")
+        result = pa.Table.from_batches(batches)
+        self.assertEqual(result.num_rows, 1)
+        self.assertEqual(result.column('pic1').to_pylist()[0], pic1_data)
+        self.assertEqual(result.column('pic2').to_pylist()[0], pic2_data)
+
     def test_blob_descriptor_fields_rejects_non_descriptor_input(self):
         from pypaimon import Schema
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Arrow batch read path for data-evolution scans and can change how `large_binary` columns are materialized (descriptor vs blob bytes), which may impact performance and correctness for blob-heavy tables if conversion triggers unexpectedly.
> 
> **Overview**
> Fixes missing blob-descriptor materialization when reading via `to_arrow_batch_reader` by moving descriptor-to-bytes conversion from `TableRead.to_arrow()` into the split reader pipeline.
> 
> Adds `BlobDescriptorConvertReader`, a `RecordBatchReader` wrapper that detects configured `blob-descriptor-field`s and replaces valid serialized `BlobDescriptor` values with the referenced blob payload bytes, and wires it into `DataEvolutionSplitRead.create_reader()` when `blob-as-descriptor` is disabled.
> 
> Removes the now-redundant table-level conversion in `table_read.py` and adds a regression test covering mixed-mode reads through `to_arrow_batch_reader`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 644660c06c3035a732d8c4eafd814b053bb701e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->