### PR TITLE
[python] Support partition.default-name

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -235,6 +235,22 @@ public class JavaPyE2ETest {
                         createRow7Cols(
                                 6, "Beef", "Meat", 8.0, 1000005L, 2000005L, 6000, "store3", 1006L,
                                 "London", "UK"));
+                // Row with null partition value -> __DEFAULT_PARTITION__
+                write.write(
+                        GenericRow.of(
+                                7,
+                                BinaryString.fromString("Tofu"),
+                                null,
+                                3.0,
+                                org.apache.paimon.data.Timestamp.fromEpochMillis(1000006L),
+                                org.apache.paimon.data.Timestamp.fromEpochMillis(2000006L),
+                                7000,
+                                GenericRow.of(
+                                        BinaryString.fromString("store4"),
+                                        1007L,
+                                        GenericRow.of(
+                                                BinaryString.fromString("Paris"),
+                                                BinaryString.fromString("France")))));
 
                 commit.commit(0, write.prepareCommit(true, 0));
             }
@@ -251,7 +267,8 @@ public class JavaPyE2ETest {
                             "+I[3, Carrot, Vegetable, 0.6, 1970-01-01T00:16:40.002, 1970-01-01T00:33:20.002, 3000, (store2, 1003, (Tokyo, Japan))]",
                             "+I[4, Broccoli, Vegetable, 1.2, 1970-01-01T00:16:40.003, 1970-01-01T00:33:20.003, 4000, (store2, 1004, (Seoul, Korea))]",
                             "+I[5, Chicken, Meat, 5.0, 1970-01-01T00:16:40.004, 1970-01-01T00:33:20.004, 5000, (store3, 1005, (NewYork, USA))]",
-                            "+I[6, Beef, Meat, 8.0, 1970-01-01T00:16:40.005, 1970-01-01T00:33:20.005, 6000, (store3, 1006, (London, UK))]");
+                            "+I[6, Beef, Meat, 8.0, 1970-01-01T00:16:40.005, 1970-01-01T00:33:20.005, 6000, (store3, 1006, (London, UK))]",
+                            "+I[7, Tofu, NULL, 3.0, 1970-01-01T00:16:40.006, 1970-01-01T00:33:20.006, 7000, (store4, 1007, (Paris, France))]");
         }
     }
 

--- a/paimon-lance/src/test/java/org/apache/paimon/JavaPyLanceE2ETest.java
+++ b/paimon-lance/src/test/java/org/apache/paimon/JavaPyLanceE2ETest.java
@@ -237,6 +237,8 @@ public class JavaPyLanceE2ETest {
             write.write(createRow(4, "Broccoli", "Vegetable", 1.2));
             write.write(createRow(5, "Chicken", "Meat", 5.0));
             write.write(createRow(6, "Beef", "Meat", 8.0));
+            // Row with null partition value -> __DEFAULT_PARTITION__
+            write.write(GenericRow.of(7, BinaryString.fromString("Tofu"), null, 3.0));
 
             commit.commit(0, write.prepareCommit(true, 0));
         }
@@ -256,7 +258,8 @@ public class JavaPyLanceE2ETest {
                         "3, Carrot, Vegetable, 0.6",
                         "4, Broccoli, Vegetable, 1.2",
                         "5, Chicken, Meat, 5.0",
-                        "6, Beef, Meat, 8.0");
+                        "6, Beef, Meat, 8.0",
+                        "7, Tofu, NULL, 3.0");
     }
 
     @Test

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -404,6 +404,16 @@ class CoreOptions:
         )
     )
 
+    PARTITION_DEFAULT_NAME: ConfigOption[str] = (
+        ConfigOptions.key("partition.default-name")
+        .string_type()
+        .default_value("__DEFAULT_PARTITION__")
+        .with_description(
+            "The default partition name in case the dynamic partition"
+            " column value is null/empty string."
+        )
+    )
+
     def __init__(self, options: Options):
         self.options = options
 

--- a/paimon-python/pypaimon/manifest/schema/data_file_meta.py
+++ b/paimon-python/pypaimon/manifest/schema/data_file_meta.py
@@ -26,6 +26,7 @@ from pypaimon.data.timestamp import Timestamp
 from pypaimon.manifest.schema.simple_stats import (KEY_STATS_SCHEMA, VALUE_STATS_SCHEMA,
                                                    SimpleStats)
 from pypaimon.table.row.generic_row import GenericRow
+from pypaimon.utils.file_store_path_factory import _is_null_or_whitespace_only
 
 
 @dataclass
@@ -130,20 +131,13 @@ class DataFileMeta:
             file_path=file_path,
         )
 
-    @staticmethod
-    def _is_null_or_whitespace_only(value) -> bool:
-        if value is None:
-            return True
-        s = str(value)
-        return len(s) == 0 or s.isspace()
-
     def set_file_path(
             self, table_path: str, partition: GenericRow, bucket: int,
             default_part_value: str = "__DEFAULT_PARTITION__"):
         path_builder = table_path.rstrip('/')
         partition_dict = partition.to_dict()
         for field_name, field_value in partition_dict.items():
-            part_value = default_part_value if self._is_null_or_whitespace_only(field_value) else str(field_value)
+            part_value = default_part_value if _is_null_or_whitespace_only(field_value) else str(field_value)
             path_builder = f"{path_builder}/{field_name}={part_value}"
         path_builder = f"{path_builder}/bucket-{str(bucket)}/{self.file_name}"
         self.file_path = path_builder

--- a/paimon-python/pypaimon/manifest/schema/data_file_meta.py
+++ b/paimon-python/pypaimon/manifest/schema/data_file_meta.py
@@ -130,11 +130,20 @@ class DataFileMeta:
             file_path=file_path,
         )
 
-    def set_file_path(self, table_path: str, partition: GenericRow, bucket: int):
+    @staticmethod
+    def _is_null_or_whitespace_only(value) -> bool:
+        if value is None:
+            return True
+        s = str(value)
+        return len(s) == 0 or s.isspace()
+
+    def set_file_path(self, table_path: str, partition: GenericRow, bucket: int,
+                     default_part_value: str = "__DEFAULT_PARTITION__"):
         path_builder = table_path.rstrip('/')
         partition_dict = partition.to_dict()
         for field_name, field_value in partition_dict.items():
-            path_builder = f"{path_builder}/{field_name}={str(field_value)}"
+            part_value = default_part_value if self._is_null_or_whitespace_only(field_value) else str(field_value)
+            path_builder = f"{path_builder}/{field_name}={part_value}"
         path_builder = f"{path_builder}/bucket-{str(bucket)}/{self.file_name}"
         self.file_path = path_builder
 

--- a/paimon-python/pypaimon/manifest/schema/data_file_meta.py
+++ b/paimon-python/pypaimon/manifest/schema/data_file_meta.py
@@ -137,8 +137,9 @@ class DataFileMeta:
         s = str(value)
         return len(s) == 0 or s.isspace()
 
-    def set_file_path(self, table_path: str, partition: GenericRow, bucket: int,
-                     default_part_value: str = "__DEFAULT_PARTITION__"):
+    def set_file_path(
+            self, table_path: str, partition: GenericRow, bucket: int,
+            default_part_value: str = "__DEFAULT_PARTITION__"):
         path_builder = table_path.rstrip('/')
         partition_dict = partition.to_dict()
         for field_name, field_value in partition_dict.items():

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -133,7 +133,8 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                 data_file.set_file_path(
                     self.table.table_path,
                     file_entries[0].partition,
-                    file_entries[0].bucket
+                    file_entries[0].bucket,
+                    self.default_part_value
                 )
 
             if file_group:

--- a/paimon-python/pypaimon/read/scanner/split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/split_generator.py
@@ -18,6 +18,7 @@ limitations under the License.
 from abc import ABC, abstractmethod
 from typing import Callable, List, Optional, Dict, Tuple
 
+from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.read.split import Split
@@ -45,6 +46,8 @@ class AbstractSplitGenerator(ABC):
         self.target_split_size = target_split_size
         self.open_file_cost = open_file_cost
         self.deletion_files_map = deletion_files_map or {}
+        self.default_part_value = table.options.options.get(
+            CoreOptions.PARTITION_DEFAULT_NAME, "__DEFAULT_PARTITION__")
         
         # Shard configuration
         self.idx_of_this_subtask = None
@@ -102,7 +105,8 @@ class AbstractSplitGenerator(ABC):
                 data_file.set_file_path(
                     self.table.table_path,
                     file_entries[0].partition,
-                    file_entries[0].bucket
+                    file_entries[0].bucket,
+                    self.default_part_value
                 )
 
             if file_group:

--- a/paimon-python/pypaimon/table/file_store_table.py
+++ b/paimon-python/pypaimon/table/file_store_table.py
@@ -298,7 +298,8 @@ class FileStoreTable(Table):
         return FileStorePathFactory(
             root=str(self.table_path),
             partition_keys=self.partition_keys,
-            default_part_value="__DEFAULT_PARTITION__",
+            default_part_value=self.options.options.get(
+                CoreOptions.PARTITION_DEFAULT_NAME, "__DEFAULT_PARTITION__"),
             format_identifier=format_identifier,
             data_file_prefix="data-",
             changelog_file_prefix="changelog-",

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -235,7 +235,7 @@ class JavaPyReadWriteTest(unittest.TestCase):
         print(f"Format: {file_format}, Result:\n{res}")
 
         # Verify data
-        self.assertEqual(len(res), 6)
+        self.assertEqual(len(res), 7)
         if file_format != "lance":
             self.assertEqual(table.fields[4].type.type, "TIMESTAMP(6)")
             self.assertEqual(table.fields[5].type.type, "TIMESTAMP(6) WITH LOCAL TIME ZONE")
@@ -250,9 +250,14 @@ class JavaPyReadWriteTest(unittest.TestCase):
             self.assertIsInstance(metadata_fields[2].type, RowType)
         
         # Data order may vary due to partitioning/bucketing, so compare as sets
-        expected_names = {'Apple', 'Banana', 'Carrot', 'Broccoli', 'Chicken', 'Beef'}
+        expected_names = {'Apple', 'Banana', 'Carrot', 'Broccoli', 'Chicken', 'Beef', 'Tofu'}
         actual_names = set(res['name'].tolist())
         self.assertEqual(actual_names, expected_names)
+
+        # Verify null partition value (default partition) is readable
+        tofu_row = res[res['name'] == 'Tofu']
+        self.assertEqual(len(tofu_row), 1)
+        self.assertTrue(pd.isna(tofu_row['category'].iloc[0]))
 
         # Verify metadata column can be read and contains nested structures
         if 'metadata' in res.columns:

--- a/paimon-python/pypaimon/utils/file_store_path_factory.py
+++ b/paimon-python/pypaimon/utils/file_store_path_factory.py
@@ -91,7 +91,11 @@ class FileStorePathFactory:
         if partition:
             partition_parts = []
             for i, field_name in enumerate(self.partition_keys):
-                partition_parts.append(f"{field_name}={partition[i]}")
+                val = partition[i]
+                if val is None or (isinstance(val, str) and
+                                   (len(val) == 0 or val.isspace())):
+                    val = self.default_part_value
+                partition_parts.append(f"{field_name}={val}")
             if partition_parts:
                 relative_parts = partition_parts + relative_parts
 

--- a/paimon-python/pypaimon/utils/file_store_path_factory.py
+++ b/paimon-python/pypaimon/utils/file_store_path_factory.py
@@ -21,6 +21,13 @@ from pypaimon.common.external_path_provider import ExternalPathProvider
 from pypaimon.table.bucket_mode import BucketMode
 
 
+def _is_null_or_whitespace_only(value) -> bool:
+    if value is None:
+        return True
+    s = str(value)
+    return len(s) == 0 or s.isspace()
+
+
 class FileStorePathFactory:
     MANIFEST_PATH = "manifest"
     MANIFEST_PREFIX = "manifest-"
@@ -92,9 +99,10 @@ class FileStorePathFactory:
             partition_parts = []
             for i, field_name in enumerate(self.partition_keys):
                 val = partition[i]
-                if val is None or (isinstance(val, str) and
-                                   (len(val) == 0 or val.isspace())):
+                if _is_null_or_whitespace_only(val):
                     val = self.default_part_value
+                else:
+                    val = str(val)
                 partition_parts.append(f"{field_name}={val}")
             if partition_parts:
                 relative_parts = partition_parts + relative_parts


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes partition path generation used by Python readers/scanners; misconfiguration or edge cases (null/whitespace) could cause reads to miss data if paths don’t match how files were written.
> 
> **Overview**
> Adds Python support for `partition.default-name`, using it when building partition directory paths for *null/empty/whitespace* partition values.
> 
> This threads the configured default through `FileStorePathFactory`, `DataFileMeta.set_file_path`, and split generators so scans resolve file paths consistently, and expands Java/Python (incl. Lance) E2E tests to write/read a row with a null partition value that lands in `__DEFAULT_PARTITION__` by default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6abf3bbfa6054a04b5b54d14be0ad80d438a2d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->