### PR TITLE
[python] Support limit pushdown

### DIFF
--- a/paimon-python/pypaimon/read/datasource/ray_datasource.py
+++ b/paimon-python/pypaimon/read/datasource/ray_datasource.py
@@ -122,6 +122,7 @@ class RayDatasource(Datasource):
         table = self.table_read.table
         predicate = self.table_read.predicate
         read_type = self.table_read.read_type
+        limit = self.table_read.limit
         schema = self._schema
 
         # Create a partial function to avoid capturing self in closure
@@ -131,11 +132,14 @@ class RayDatasource(Datasource):
                 table=table,
                 predicate=predicate,
                 read_type=read_type,
+                limit=limit,
                 schema=schema,
         ) -> Iterable[pyarrow.Table]:
             """Read function that will be executed by Ray workers."""
             from pypaimon.read.table_read import TableRead
             worker_table_read = TableRead(table, predicate, read_type)
+            if limit is not None:
+                worker_table_read.with_limit(limit)
 
             batch_reader = worker_table_read.to_arrow_batch_reader(splits)
             has_data = False
@@ -157,6 +161,7 @@ class RayDatasource(Datasource):
             table=table,
             predicate=predicate,
             read_type=read_type,
+            limit=limit,
             schema=schema,
         )
 

--- a/paimon-python/pypaimon/read/read_builder.py
+++ b/paimon-python/pypaimon/read/read_builder.py
@@ -57,11 +57,14 @@ class ReadBuilder:
         )
 
     def new_read(self) -> TableRead:
-        return TableRead(
+        read = TableRead(
             table=self.table,
             predicate=self._predicate,
             read_type=self.read_type()
         )
+        if self._limit is not None:
+            read.with_limit(self._limit)
+        return read
 
     def new_predicate_builder(self) -> PredicateBuilder:
         return PredicateBuilder(self.read_type())

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -123,6 +123,9 @@ class SplitRead(ABC):
         else:
             return self.predicate
 
+    def with_limit(self, limit: Optional[int]) -> 'SplitRead':
+        return self
+
     @abstractmethod
     def create_reader(self) -> RecordReader:
         """Create a record reader for the given split."""
@@ -375,6 +378,15 @@ class SplitRead(ABC):
 
 
 class RawFileSplitRead(SplitRead):
+
+    def __init__(self, table, predicate, read_type, split, row_tracking_enabled):
+        super().__init__(table, predicate, read_type, split, row_tracking_enabled)
+        self.limit = None
+
+    def with_limit(self, limit: Optional[int]) -> 'RawFileSplitRead':
+        self.limit = limit
+        return self
+
     def raw_reader_supplier(self, file: DataFileMeta, dv_factory: Optional[Callable] = None) -> Optional[RecordReader]:
         read_fields = self._get_final_read_data_fields()
         # If the current file needs to be further divided for reading, use ShardBatchReader

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -48,6 +48,11 @@ class TableRead:
         self.predicate = predicate
         self.read_type = read_type
         self.include_row_kind = include_row_kind
+        self.limit = None
+
+    def with_limit(self, limit: int) -> 'TableRead':
+        self.limit = limit
+        return self
 
     def to_iterator(self, splits: List[Split]) -> Iterator:
         def _record_generator():
@@ -259,7 +264,7 @@ class TableRead:
 
     def _create_split_read(self, split: Split) -> SplitRead:
         if self.table.is_primary_key_table and not split.raw_convertible:
-            return MergeFileSplitRead(
+            split_read = MergeFileSplitRead(
                 table=self.table,
                 predicate=self.predicate,
                 read_type=self.read_type,
@@ -267,7 +272,7 @@ class TableRead:
                 row_tracking_enabled=False
             )
         elif self.table.options.data_evolution_enabled():
-            return DataEvolutionSplitRead(
+            split_read = DataEvolutionSplitRead(
                 table=self.table,
                 predicate=self.predicate,
                 read_type=self.read_type,
@@ -275,13 +280,15 @@ class TableRead:
                 row_tracking_enabled=True
             )
         else:
-            return RawFileSplitRead(
+            split_read = RawFileSplitRead(
                 table=self.table,
                 predicate=self.predicate,
                 read_type=self.read_type,
                 split=split,
                 row_tracking_enabled=self.table.options.row_tracking_enabled()
             )
+        split_read.with_limit(self.limit)
+        return split_read
 
     @staticmethod
     def convert_rows_to_arrow_batch(row_tuples: List[tuple], schema: pyarrow.Schema) -> pyarrow.RecordBatch:

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -56,11 +56,18 @@ class TableRead:
 
     def to_iterator(self, splits: List[Split]) -> Iterator:
         def _record_generator():
+            count = 0
             for split in splits:
+                if self.limit is not None and count >= self.limit:
+                    return
                 reader = self._create_split_read(split).create_reader()
                 try:
                     for batch in iter(reader.read_batch, None):
-                        yield from iter(batch.next, None)
+                        for row in iter(batch.next, None):
+                            if self.limit is not None and count >= self.limit:
+                                return
+                            yield row
+                            count += 1
                 finally:
                     reader.close()
 
@@ -70,7 +77,7 @@ class TableRead:
         schema = PyarrowFieldParser.from_paimon_schema(self.read_type)
         if self.include_row_kind:
             schema = self._add_row_kind_to_schema(schema)
-        batch_iterator = self._arrow_batch_generator(splits, schema)
+        batch_iterator = self._limit_batches(self._arrow_batch_generator(splits, schema))
         return pyarrow.ipc.RecordBatchReader.from_batches(schema, batch_iterator)
 
     @staticmethod
@@ -78,6 +85,32 @@ class TableRead:
         """Add _row_kind column to the schema as the first column."""
         row_kind_field = pyarrow.field(ROW_KIND_COLUMN, pyarrow.string())
         return pyarrow.schema([row_kind_field] + list(schema))
+
+    def _limit_batches(
+        self,
+        batch_iterator: Iterator[pyarrow.RecordBatch]
+    ) -> Iterator[pyarrow.RecordBatch]:
+        """Enforce row-level limit on a batch stream.
+
+        Unlike Java Paimon where query engines (Spark/Flink) enforce LIMIT,
+        the Python SDK serves as both library and execution engine for direct
+        API callers. This method truncates the batch stream to return at most
+        ``self.limit`` rows, slicing the final batch for exact precision.
+        """
+        if self.limit is None:
+            yield from batch_iterator
+            return
+
+        remaining = self.limit
+        for batch in batch_iterator:
+            if remaining <= 0:
+                break
+            if batch.num_rows <= remaining:
+                yield batch
+                remaining -= batch.num_rows
+            else:
+                yield batch.slice(0, remaining)
+                break
 
     @staticmethod
     def _try_to_pad_batch_by_schema(batch: pyarrow.RecordBatch, target_schema):

--- a/paimon-python/pypaimon/tests/ray_data_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_test.py
@@ -656,6 +656,76 @@ class RayDataTest(unittest.TestCase):
         )
         self.assertEqual(list(df_sorted['value']), [150, 250, 300, 400], "Value column should reflect updates")
 
+    def test_ray_data_with_limit(self):
+        """Test that with_limit() enforces row-level limit across read paths.
+
+        The Python SDK acts as both library and execution engine for direct
+        API callers (unlike Java where Spark/Flink enforce LIMIT). This test
+        verifies that with_limit(N) returns at most N rows via to_arrow(),
+        to_ray() (single block), and to_iterator().
+        """
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('value', pa.int64()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(pa_schema)
+        self.catalog.create_table('default.test_ray_limit', schema, False)
+        table = self.catalog.get_table('default.test_ray_limit')
+
+        # Write 3 commits → 3 splits, 100 rows each → 300 rows total
+        rows_per_commit = 100
+        num_commits = 3
+        for batch_idx in range(num_commits):
+            start = batch_idx * rows_per_commit
+            data = pa.Table.from_pydict({
+                'id': list(range(start, start + rows_per_commit)),
+                'value': [i * 100 for i in range(start, start + rows_per_commit)],
+            }, schema=pa_schema)
+            write_builder = table.new_batch_write_builder()
+            writer = write_builder.new_write()
+            writer.write_arrow(data)
+            commit_messages = writer.prepare_commit()
+            commit = write_builder.new_commit()
+            commit.commit(commit_messages)
+            writer.close()
+
+        # Baseline: no limit → all 300 rows
+        read_builder_all = table.new_read_builder()
+        splits_all = read_builder_all.new_scan().plan().splits()
+        total_rows = rows_per_commit * num_commits
+        self.assertEqual(len(splits_all), num_commits)
+        all_rows = read_builder_all.new_read().to_arrow(splits_all).num_rows
+        self.assertEqual(all_rows, total_rows)
+
+        # with_limit(150): scan keeps splits covering >= 150 rows,
+        # read-level limit truncates to exactly 150 rows
+        limit_value = 150
+        read_builder_limited = table.new_read_builder().with_limit(limit_value)
+        splits_limited = read_builder_limited.new_scan().plan().splits()
+        table_read_limited = read_builder_limited.new_read()
+
+        self.assertEqual(table_read_limited.limit, limit_value)
+        self.assertGreater(len(splits_limited), 1,
+                           "scan should keep multiple splits to cover the limit")
+
+        # to_arrow: single-threaded, global limit → exactly limit_value rows
+        arrow_result = table_read_limited.to_arrow(splits_limited)
+        self.assertEqual(arrow_result.num_rows, limit_value,
+                         "to_arrow should return exactly limit rows")
+
+        # to_iterator: row-by-row, global limit → exactly limit_value rows
+        table_read_iter = table.new_read_builder().with_limit(limit_value).new_read()
+        rows = list(table_read_iter.to_iterator(splits_limited))
+        self.assertEqual(len(rows), limit_value,
+                         "to_iterator should return exactly limit rows")
+
+        # to_ray (single block): all splits in one worker → exactly limit_value rows
+        table_read_ray = table.new_read_builder().with_limit(limit_value).new_read()
+        ray_dataset = table_read_ray.to_ray(splits_limited, override_num_blocks=1)
+        self.assertEqual(ray_dataset.count(), limit_value,
+                         "to_ray (single block) should return exactly limit rows")
+
     def test_ray_data_invalid_parallelism(self):
         pa_schema = pa.schema([
             ('id', pa.int32()),

--- a/paimon-python/pypaimon/tests/ray_data_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_test.py
@@ -659,42 +659,40 @@ class RayDataTest(unittest.TestCase):
     def test_ray_data_with_limit(self):
         """Test that with_limit() enforces row-level limit across read paths.
 
-        The Python SDK acts as both library and execution engine for direct
-        API callers (unlike Java where Spark/Flink enforce LIMIT). This test
-        verifies that with_limit(N) returns at most N rows via to_arrow(),
-        to_ray() (single block), and to_iterator().
+        Uses a partitioned table (3 partitions) to guarantee multiple splits.
         """
         pa_schema = pa.schema([
+            ('pt', pa.int32()),
             ('id', pa.int32()),
             ('value', pa.int64()),
         ])
 
-        schema = Schema.from_pyarrow_schema(pa_schema)
+        schema = Schema.from_pyarrow_schema(pa_schema, partition_keys=['pt'])
         self.catalog.create_table('default.test_ray_limit', schema, False)
         table = self.catalog.get_table('default.test_ray_limit')
 
-        # Write 3 commits → 3 splits, 100 rows each → 300 rows total
-        rows_per_commit = 100
-        num_commits = 3
-        for batch_idx in range(num_commits):
-            start = batch_idx * rows_per_commit
+        # Write 3 partitions, 100 rows each → 300 rows total, 3 splits
+        rows_per_partition = 100
+        num_partitions = 3
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        for pt in range(num_partitions):
             data = pa.Table.from_pydict({
-                'id': list(range(start, start + rows_per_commit)),
-                'value': [i * 100 for i in range(start, start + rows_per_commit)],
+                'pt': [pt] * rows_per_partition,
+                'id': list(range(rows_per_partition)),
+                'value': [i * 100 for i in range(rows_per_partition)],
             }, schema=pa_schema)
-            write_builder = table.new_batch_write_builder()
-            writer = write_builder.new_write()
             writer.write_arrow(data)
-            commit_messages = writer.prepare_commit()
-            commit = write_builder.new_commit()
-            commit.commit(commit_messages)
-            writer.close()
+        commit_messages = writer.prepare_commit()
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        writer.close()
 
-        # Baseline: no limit → all 300 rows
+        # Baseline: no limit → all 300 rows, 3 splits
         read_builder_all = table.new_read_builder()
         splits_all = read_builder_all.new_scan().plan().splits()
-        total_rows = rows_per_commit * num_commits
-        self.assertEqual(len(splits_all), num_commits)
+        total_rows = rows_per_partition * num_partitions
+        self.assertEqual(len(splits_all), num_partitions)
         all_rows = read_builder_all.new_read().to_arrow(splits_all).num_rows
         self.assertEqual(all_rows, total_rows)
 
@@ -708,23 +706,35 @@ class RayDataTest(unittest.TestCase):
         self.assertEqual(table_read_limited.limit, limit_value)
         self.assertGreater(len(splits_limited), 1,
                            "scan should keep multiple splits to cover the limit")
+        self.assertLess(len(splits_limited), num_partitions,
+                        "scan should prune splits beyond the limit")
 
-        # to_arrow: single-threaded, global limit → exactly limit_value rows
+        # to_arrow: global limit → exactly limit_value rows
         arrow_result = table_read_limited.to_arrow(splits_limited)
         self.assertEqual(arrow_result.num_rows, limit_value,
                          "to_arrow should return exactly limit rows")
 
-        # to_iterator: row-by-row, global limit → exactly limit_value rows
+        # to_iterator: global limit → exactly limit_value rows
         table_read_iter = table.new_read_builder().with_limit(limit_value).new_read()
         rows = list(table_read_iter.to_iterator(splits_limited))
         self.assertEqual(len(rows), limit_value,
                          "to_iterator should return exactly limit rows")
 
-        # to_ray (single block): all splits in one worker → exactly limit_value rows
+        # to_ray: scan prunes splits, .limit() on dataset for precise truncation
+        # single block
         table_read_ray = table.new_read_builder().with_limit(limit_value).new_read()
         ray_dataset = table_read_ray.to_ray(splits_limited, override_num_blocks=1)
-        self.assertEqual(ray_dataset.count(), limit_value,
-                         "to_ray (single block) should return exactly limit rows")
+        self.assertGreater(ray_dataset.count(), limit_value,
+                           "to_ray without .limit() returns more than limit (split granularity)")
+        self.assertEqual(ray_dataset.limit(limit_value).count(), limit_value,
+                         "to_ray + .limit() should return exactly limit rows")
+
+        # multi block
+        table_read_ray_multi = table.new_read_builder().with_limit(limit_value).new_read()
+        ray_dataset_multi = table_read_ray_multi.to_ray(
+            splits_limited, override_num_blocks=len(splits_limited))
+        self.assertEqual(ray_dataset_multi.limit(limit_value).count(), limit_value,
+                         "to_ray (multi block) + .limit() should return exactly limit rows")
 
     def test_ray_data_invalid_parallelism(self):
         pa_schema = pa.schema([

--- a/paimon-python/pypaimon/write/table_write.py
+++ b/paimon-python/pypaimon/write/table_write.py
@@ -24,6 +24,7 @@ from pypaimon.schema.data_types import PyarrowFieldParser
 from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.file_store_write import FileStoreWrite
+from pypaimon.write.row_key_extractor import DynamicBucketRowKeyExtractor
 
 if TYPE_CHECKING:
     from ray.data import Dataset
@@ -45,8 +46,11 @@ class TableWrite:
             self.write_arrow_batch(batch)
 
     def write_arrow_batch(self, data: pa.RecordBatch):
-        self._validate_pyarrow_schema(data.schema)
-        partitions, buckets = self.row_key_extractor.extract_partition_bucket_batch(data)
+        if isinstance(self.row_key_extractor, DynamicBucketRowKeyExtractor):
+            partitions = self.row_key_extractor._extract_partitions_batch(data)
+            buckets = [0] * data.num_rows
+        else:
+            partitions, buckets = self.row_key_extractor.extract_partition_bucket_batch(data)
 
         partition_bucket_groups = defaultdict(list)
         for i in range(data.num_rows):


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new row-level limiting logic into core read paths (`to_iterator`/Arrow batch streaming) and propagates it into Ray worker tasks, which could affect correctness/performance of reads. Also changes write bucketing behavior for dynamic-bucket tables, impacting data layout if mishandled.
> 
> **Overview**
> Adds end-to-end `with_limit()` support for the Python reader: `ReadBuilder.new_read()` now propagates limit into `TableRead`, and `TableRead` enforces a global row cap for both `to_iterator()` and Arrow reads by truncating/slicing the final batch.
> 
> Propagates the limit through split readers and Ray execution by carrying `TableRead.limit` into `RayDatasource` worker `TableRead` instances, and adds a Ray integration test validating scan-level split pruning plus exact row truncation across `to_arrow`, `to_iterator`, and `to_ray`.
> 
> Separately adjusts `TableWrite.write_arrow_batch()` to handle `DynamicBucketRowKeyExtractor` by extracting partitions without bucket computation and defaulting buckets to `0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98b131c0c6a9e6e6704ae6518273ffd73cc4b256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->