### PR TITLE
[python] Support MaxFrame distributed write for Paimon tables

### DIFF
--- a/paimon-python/pypaimon/write/maxframe_datasink.py
+++ b/paimon-python/pypaimon/write/maxframe_datasink.py
@@ -1,0 +1,163 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+"""
+Module to write a Paimon table from a MaxFrame DataFrame.
+
+Architecture
+------------
+MaxFrame is a lazy-evaluation distributed DataFrame engine backed by
+MaxCompute.  Its ``apply_chunk`` API distributes a user function across
+workers, where each worker receives a *chunk* of the DataFrame as a
+regular ``pandas.DataFrame``.
+
+The write is split into two phases so that data files can be written in
+parallel while metadata is committed atomically:
+
+Phase 1 – parallel on workers (via ``apply_chunk``)
+    Each worker converts its pandas chunk to PyArrow, writes data files
+    through PyPaimon, and calls ``prepare_commit()`` to obtain
+    ``CommitMessage`` objects.  The commit messages are serialized with
+    ``pickle`` and returned to the client inside a single-row DataFrame.
+
+Phase 2 – serial on client
+    The client deserializes all ``CommitMessage`` objects and calls
+    ``table_commit.commit()`` exactly once, producing a single atomic
+    Paimon snapshot.
+"""
+
+import logging
+import pickle
+import base64
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pypaimon.table.table import Table
+
+logger = logging.getLogger(__name__)
+
+
+def _serialize_commit_messages(messages):
+    """Pickle + base64-encode a list of CommitMessage objects."""
+    return base64.b64encode(pickle.dumps(messages)).decode("utf-8")
+
+
+def _deserialize_commit_messages(data_str):
+    """Decode a base64 string back into a list of CommitMessage objects."""
+    return pickle.loads(base64.b64decode(data_str))
+
+
+def maxframe_write(table: "Table", dataframe, overwrite: bool = False):
+    """
+    Distributed write of a MaxFrame DataFrame into a Paimon table.
+
+    Parameters
+    ----------
+    table : Table
+        The target Paimon table object.
+    dataframe : maxframe.dataframe.DataFrame
+        A MaxFrame distributed DataFrame.
+    overwrite : bool
+        If True, overwrite the existing data in the table.
+    """
+    try:
+        import maxframe.dataframe  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "MaxFrame is required for write_maxframe(). "
+            "Install it with: pip install pypaimon[maxframe]"
+        )
+
+    import pandas as pd
+
+    # --- Phase 1: parallel data-file writing via apply_chunk ---------------
+
+    # The table object is picklable (verified by Ray datasink pattern).
+    # We capture it in the closure so each worker can create its own writer.
+    _table = table
+    _overwrite = overwrite
+
+    def _write_chunk_to_paimon(pdf):
+        """Executed on each MaxFrame worker with a pandas chunk."""
+        import pyarrow as pa
+        from pypaimon.schema.data_types import PyarrowFieldParser
+
+        if pdf.empty:
+            return pd.DataFrame({"_paimon_commit_msg": [""]})
+
+        # Create a fresh writer per chunk (same pattern as Ray datasink)
+        write_builder = _table.new_batch_write_builder()
+        if _overwrite:
+            write_builder = write_builder.overwrite()
+        table_write = write_builder.new_write()
+        try:
+            pa_schema = PyarrowFieldParser.from_paimon_schema(
+                _table.table_schema.fields
+            )
+            record_batch = pa.RecordBatch.from_pandas(pdf, schema=pa_schema)
+            table_write.write_arrow_batch(record_batch)
+            commit_messages = table_write.prepare_commit()
+        finally:
+            table_write.close()
+
+        serialized = _serialize_commit_messages(commit_messages)
+        return pd.DataFrame({"_paimon_commit_msg": [serialized]})
+
+    logger.info("MaxFrame write phase 1: distributing data-file writes")
+
+    commit_result_df = dataframe.mf.apply_chunk(
+        _write_chunk_to_paimon,
+        output_type="dataframe",
+        dtypes={"_paimon_commit_msg": "object"},
+        skip_infer=True,
+    ).execute()
+
+    # --- Phase 2: serial commit on client ----------------------------------
+
+    all_commit_messages = []
+    for msg_str in commit_result_df["_paimon_commit_msg"]:
+        if not msg_str:
+            continue
+        messages = _deserialize_commit_messages(msg_str)
+        non_empty = [m for m in messages if not m.is_empty()]
+        all_commit_messages.extend(non_empty)
+
+    if not all_commit_messages:
+        logger.info("No data to commit (all chunks were empty)")
+        return
+
+    logger.info(
+        "MaxFrame write phase 2: committing %d commit messages",
+        len(all_commit_messages),
+    )
+
+    write_builder = table.new_batch_write_builder()
+    if overwrite:
+        write_builder = write_builder.overwrite()
+    table_commit = write_builder.new_commit()
+    try:
+        table_commit.commit(all_commit_messages)
+        logger.info("Successfully committed MaxFrame write")
+    except Exception:
+        logger.error("Failed to commit MaxFrame write", exc_info=True)
+        try:
+            table_commit.abort(all_commit_messages)
+        except Exception:
+            logger.warning("Failed to abort commit messages", exc_info=True)
+        raise
+    finally:
+        table_commit.close()

--- a/paimon-python/pypaimon/write/maxframe_datasink.py
+++ b/paimon-python/pypaimon/write/maxframe_datasink.py
@@ -93,11 +93,12 @@ def maxframe_write(table: "Table", dataframe, overwrite: bool = False):
 
     def _write_chunk_to_paimon(pdf):
         """Executed on each MaxFrame worker with a pandas chunk."""
+        import os
         import pyarrow as pa
         from pypaimon.schema.data_types import PyarrowFieldParser
 
         if pdf.empty:
-            return pd.DataFrame({"_paimon_commit_msg": [""]})
+            return pd.DataFrame({"_paimon_commit_msg": [""], "_paimon_worker_info": ["empty"]})
 
         # Create a fresh writer per chunk (same pattern as Ray datasink)
         write_builder = _table.new_batch_write_builder()
@@ -115,18 +116,36 @@ def maxframe_write(table: "Table", dataframe, overwrite: bool = False):
             table_write.close()
 
         serialized = _serialize_commit_messages(commit_messages)
-        return pd.DataFrame({"_paimon_commit_msg": [serialized]})
+        worker_info = (
+            f"pid={os.getpid()}, "
+            f"rows={len(pdf)}, "
+            f"files={sum(len(m.new_files) for m in commit_messages)}"
+        )
+        return pd.DataFrame({
+            "_paimon_commit_msg": [serialized],
+            "_paimon_worker_info": [worker_info],
+        })
 
     logger.info("MaxFrame write phase 1: distributing data-file writes")
 
     commit_result_df = dataframe.mf.apply_chunk(
         _write_chunk_to_paimon,
         output_type="dataframe",
-        dtypes={"_paimon_commit_msg": "object"},
+        dtypes={"_paimon_commit_msg": "object", "_paimon_worker_info": "object"},
         skip_infer=True,
     ).execute()
 
     # --- Phase 2: serial commit on client ----------------------------------
+
+    # Log distributed execution summary
+    worker_infos = commit_result_df.get("_paimon_worker_info", [])
+    num_workers = sum(1 for w in worker_infos if w and w != "empty")
+    logger.info(
+        "MaxFrame write phase 1 completed: %d workers participated", num_workers
+    )
+    for i, info in enumerate(worker_infos):
+        if info and info != "empty":
+            logger.info("  chunk %d: %s", i, info)
 
     all_commit_messages = []
     for msg_str in commit_result_df["_paimon_commit_msg"]:

--- a/paimon-python/pypaimon/write/maxframe_datasink.py
+++ b/paimon-python/pypaimon/write/maxframe_datasink.py
@@ -15,30 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-"""
-Module to write a Paimon table from a MaxFrame DataFrame.
-
-Architecture
-------------
-MaxFrame is a lazy-evaluation distributed DataFrame engine backed by
-MaxCompute.  Its ``apply_chunk`` API distributes a user function across
-workers, where each worker receives a *chunk* of the DataFrame as a
-regular ``pandas.DataFrame``.
-
-The write is split into two phases so that data files can be written in
-parallel while metadata is committed atomically:
-
-Phase 1 – parallel on workers (via ``apply_chunk``)
-    Each worker converts its pandas chunk to PyArrow, writes data files
-    through PyPaimon, and calls ``prepare_commit()`` to obtain
-    ``CommitMessage`` objects.  The commit messages are serialized with
-    ``pickle`` and returned to the client inside a single-row DataFrame.
-
-Phase 2 – serial on client
-    The client deserializes all ``CommitMessage`` objects and calls
-    ``table_commit.commit()`` exactly once, producing a single atomic
-    Paimon snapshot.
-"""
 
 import logging
 import pickle
@@ -52,28 +28,14 @@ logger = logging.getLogger(__name__)
 
 
 def _serialize_commit_messages(messages):
-    """Pickle + base64-encode a list of CommitMessage objects."""
     return base64.b64encode(pickle.dumps(messages)).decode("utf-8")
 
 
 def _deserialize_commit_messages(data_str):
-    """Decode a base64 string back into a list of CommitMessage objects."""
     return pickle.loads(base64.b64decode(data_str))
 
 
 def maxframe_write(table: "Table", dataframe, overwrite: bool = False):
-    """
-    Distributed write of a MaxFrame DataFrame into a Paimon table.
-
-    Parameters
-    ----------
-    table : Table
-        The target Paimon table object.
-    dataframe : maxframe.dataframe.DataFrame
-        A MaxFrame distributed DataFrame.
-    overwrite : bool
-        If True, overwrite the existing data in the table.
-    """
     try:
         import maxframe.dataframe  # noqa: F401
     except ImportError:
@@ -84,15 +46,10 @@ def maxframe_write(table: "Table", dataframe, overwrite: bool = False):
 
     import pandas as pd
 
-    # --- Phase 1: parallel data-file writing via apply_chunk ---------------
-
-    # The table object is picklable (verified by Ray datasink pattern).
-    # We capture it in the closure so each worker can create its own writer.
     _table = table
     _overwrite = overwrite
 
     def _write_chunk_to_paimon(pdf):
-        """Executed on each MaxFrame worker with a pandas chunk."""
         import os
         import pyarrow as pa
         from pypaimon.schema.data_types import PyarrowFieldParser
@@ -100,7 +57,6 @@ def maxframe_write(table: "Table", dataframe, overwrite: bool = False):
         if pdf.empty:
             return pd.DataFrame({"_paimon_commit_msg": [""], "_paimon_worker_info": ["empty"]})
 
-        # Create a fresh writer per chunk (same pattern as Ray datasink)
         write_builder = _table.new_batch_write_builder()
         if _overwrite:
             write_builder = write_builder.overwrite()
@@ -135,9 +91,6 @@ def maxframe_write(table: "Table", dataframe, overwrite: bool = False):
         skip_infer=True,
     ).execute()
 
-    # --- Phase 2: serial commit on client ----------------------------------
-
-    # Log distributed execution summary
     worker_infos = commit_result_df.get("_paimon_worker_info", [])
     num_workers = sum(1 for w in worker_infos if w and w != "empty")
     logger.info(

--- a/paimon-python/pypaimon/write/table_write.py
+++ b/paimon-python/pypaimon/write/table_write.py
@@ -98,6 +98,28 @@ class TableWrite:
             ray_remote_args=ray_remote_args,
         )
 
+    def write_maxframe(
+        self,
+        dataframe: "maxframe.dataframe.DataFrame",
+        overwrite: bool = False,
+        concurrency: Optional[int] = None,
+    ) -> None:
+        """
+        Write a MaxFrame DataFrame to Paimon table.
+
+        The write is distributed: each MaxFrame worker writes data files in
+        parallel using ``apply_chunk``, and a single atomic commit is performed
+        on the client after all workers finish.
+
+        Args:
+            dataframe: MaxFrame DataFrame to write.  This is a distributed,
+                lazily-evaluated DataFrame from the ``maxframe`` package.
+            overwrite: Whether to overwrite existing data.  Defaults to False.
+            concurrency: Reserved for future use.
+        """
+        from pypaimon.write.maxframe_datasink import maxframe_write
+        maxframe_write(self.table, dataframe, overwrite=overwrite)
+
     def close(self):
         self.file_store_write.close()
 

--- a/paimon-python/pypaimon/write/table_write.py
+++ b/paimon-python/pypaimon/write/table_write.py
@@ -104,19 +104,6 @@ class TableWrite:
         overwrite: bool = False,
         concurrency: Optional[int] = None,
     ) -> None:
-        """
-        Write a MaxFrame DataFrame to Paimon table.
-
-        The write is distributed: each MaxFrame worker writes data files in
-        parallel using ``apply_chunk``, and a single atomic commit is performed
-        on the client after all workers finish.
-
-        Args:
-            dataframe: MaxFrame DataFrame to write.  This is a distributed,
-                lazily-evaluated DataFrame from the ``maxframe`` package.
-            overwrite: Whether to overwrite existing data.  Defaults to False.
-            concurrency: Reserved for future use.
-        """
         from pypaimon.write.maxframe_datasink import maxframe_write
         maxframe_write(self.table, dataframe, overwrite=overwrite)
 

--- a/paimon-python/setup.py
+++ b/paimon-python/setup.py
@@ -70,6 +70,9 @@ setup(
             'pylance>=0.20,<1; python_version>="3.9"',
             'pylance>=0.10,<1; python_version>="3.8" and python_version<"3.9"'
         ],
+        'maxframe': [
+            'maxframe>=1.0.0; python_version>="3.9"',
+        ],
     },
     description="Apache Paimon Python API",
     long_description=long_description,


### PR DESCRIPTION
Add write_maxframe() method to TableWrite, following the same pattern as write_ray(). The implementation uses MaxFrame's apply_chunk API to write data files in parallel across workers, then collects CommitMessages and performs a single atomic commit on the client.

### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new distributed write path that serializes commit messages across workers and performs a client-side atomic commit; failures in serialization/commit aggregation could lead to partial or failed writes.
> 
> **Overview**
> Adds MaxFrame-based distributed writes for Python Paimon tables via `TableWrite.write_maxframe()`.
> 
> Introduces `maxframe_write()` which uses MaxFrame `apply_chunk` to write data files in parallel, serializes per-chunk `CommitMessage`s (pickle+base64) back to the driver, then performs a single commit with abort-on-failure handling and progress logging.
> 
> Adds a new optional dependency extra `pypaimon[maxframe]` (MaxFrame >= 1.0.0, Python >= 3.9).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09e149ea44d04925e1a29caa0e22394186e4fc9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->