### PR TITLE
  [python] Fix data evolution merge read with disordered projection

### DIFF
--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -597,6 +597,7 @@ class DataEvolutionSplitRead(SplitRead):
         # Initialize offsets
         row_offsets = [-1] * len(all_read_fields)
         field_offsets = [-1] * len(all_read_fields)
+        schema_pos = {f.id: p for p, f in enumerate(self.table.fields)}
 
         for i, bunch in enumerate(fields_files):
             first_file = bunch.files()[0]
@@ -623,7 +624,6 @@ class DataEvolutionSplitRead(SplitRead):
             if not read_fields:
                 file_record_readers[i] = None
             else:
-                schema_pos = {f.id: p for p, f in enumerate(self.table.fields)}
                 read_fields.sort(key=lambda f: schema_pos.get(f.id, float('inf')))
                 id_to_pos = {f.id: p for p, f in enumerate(read_fields)}
                 for j in range(len(read_field_index)):

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -617,13 +617,19 @@ class DataEvolutionSplitRead(SplitRead):
                     if read_field_id == field_id:
                         if row_offsets[j] == -1:
                             row_offsets[j] = i
-                            field_offsets[j] = len(read_fields)
                             read_fields.append(all_read_fields[j])
                         break
 
             if not read_fields:
                 file_record_readers[i] = None
             else:
+                schema_pos = {f.id: p for p, f in enumerate(self.table.fields)}
+                read_fields.sort(key=lambda f: schema_pos.get(f.id, float('inf')))
+                id_to_pos = {f.id: p for p, f in enumerate(read_fields)}
+                for j in range(len(read_field_index)):
+                    if row_offsets[j] == i:
+                        field_offsets[j] = id_to_pos[read_field_index[j]]
+
                 read_field_names = self._remove_partition_fields(read_fields)
                 table_fields = self.read_fields
                 self.read_fields = read_fields  # create reader based on read_fields

--- a/paimon-python/pypaimon/tests/data_evolution_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_test.py
@@ -558,6 +558,14 @@ class DataEvolutionTest(unittest.TestCase):
         }, schema=simple_pa_schema)
         self.assertEqual(actual, expect)
 
+        read_builder2 = table.new_read_builder()
+        read_builder2.with_projection(['f2', 'f0', 'f1'])
+        actual2 = read_builder2.new_read().to_arrow(
+            read_builder2.new_scan().plan().splits())
+        self.assertEqual(actual2.column('f0').to_pylist(), [2] * num_rows)
+        self.assertEqual(actual2.column('f1').to_pylist(), ['x'] * num_rows)
+        self.assertEqual(actual2.column('f2').to_pylist(), ['y'] * num_rows)
+
     def test_only_some_columns(self):
         simple_pa_schema = pa.schema([
             ('f0', pa.int32()),


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts field ordering and offset calculation in the data-evolution merge reader, which affects how columns are mapped during reads across evolved schemas. Risk is moderate because it changes core read/merge logic but is covered by an added regression test.
> 
> **Overview**
> Fixes data-evolution merge reads when a projection requests columns in a different order than the table schema.
> 
> `DataEvolutionSplitRead._create_union_reader` now sorts per-bunch `read_fields` into table-schema order and recomputes `field_offsets` based on the sorted positions, ensuring `DataEvolutionMergeReader` maps output columns correctly. A regression test is added to validate correct results for a disordered projection (`['f2', 'f0', 'f1']`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f70d21b9f0ee87a7f8fd86f4904a8841837de820. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->