### PR TITLE
Data evolution read fix

### DIFF
--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -613,8 +613,13 @@ class DataEvolutionSplitRead(SplitRead):
             elif first_file.write_cols:
                 field_ids = self._get_field_ids_from_write_cols(first_file.write_cols)
             else:
-                # For regular files, get all field IDs from the schema
-                field_ids = [field.id for field in self.table.fields]
+                # For regular files without write_cols, derive field IDs from
+                # the file's schema version, not the current table schema.
+                # The file only contains columns from when it was written.
+                file_schema = self.table.schema_manager.get_schema(first_file.schema_id)
+                field_ids = [field.id for field in file_schema.fields]
+                field_ids.append(SpecialFields.ROW_ID.id)
+                field_ids.append(SpecialFields.SEQUENCE_NUMBER.id)
 
             read_fields = []
             for j, read_field_id in enumerate(read_field_index):

--- a/paimon-python/pypaimon/tests/data_evolution_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_test.py
@@ -1357,18 +1357,7 @@ class DataEvolutionTest(unittest.TestCase):
         self.assertTrue(rebuilt.schema.field('_ROW_ID').nullable)
         self.assertTrue(rebuilt.schema.field('_SEQUENCE_NUMBER').nullable)
 
-    def test_read_after_schema_evolution_without_write_cols(self):
-        """Reproduce: reading a data-evolution table fails with IndexError when
-        a data file has no write_cols metadata (written with all columns of the
-        old schema before schema evolution) and sorts first in the union reader,
-        causing it to wrongly claim fields from new columns it doesn't have.
-
-        This simulates the real-world scenario where:
-        1. Data is written with the original schema (write_cols=None)
-        2. Schema evolution adds new columns
-        3. New column data is written as separate files with the same first_row_id
-        4. The original file sorts first (higher max_seq) and _create_union_reader
-           assumes it contains ALL current table fields, leading to IndexError."""
+    def test_read_full_schema_on_write_before_evolution(self):
         from pypaimon.schema.schema_change import SchemaChange
         from pypaimon.schema.data_types import AtomicType
 
@@ -1425,20 +1414,11 @@ class DataEvolutionTest(unittest.TestCase):
         table_commit.close()
 
         # Step 5: Read all columns
-        # The two files have the same first_row_id=0, so they are merged.
-        # In _split_by_row_id they go into the same group, sorted by -max_seq.
-        # Normally the f2 file (higher max_seq) sorts first, so the bug
-        # doesn't trigger. But in real scenarios (e.g. blob files, or files
-        # written by Java Paimon), the old file can be Bunch 0.
-        # We force this by boosting the old file's max_sequence_number.
         read_builder = table.new_read_builder()
         table_scan = read_builder.new_scan()
         table_read = read_builder.new_read()
         splits = table_scan.plan().splits()
 
-        # Manipulate: set higher max_seq on the no-write_cols file so it
-        # sorts first — reproducing the real scenario where the original
-        # data file is processed as Bunch 0 in _split_field_bunches.
         for split in splits:
             for f in split.files:
                 if f.write_cols is None:

--- a/paimon-python/pypaimon/tests/data_evolution_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_test.py
@@ -1356,3 +1356,104 @@ class DataEvolutionTest(unittest.TestCase):
         rebuilt = pa.RecordBatch.from_arrays(arrays, names=batch.schema.names)
         self.assertTrue(rebuilt.schema.field('_ROW_ID').nullable)
         self.assertTrue(rebuilt.schema.field('_SEQUENCE_NUMBER').nullable)
+
+    def test_read_after_schema_evolution_without_write_cols(self):
+        """Reproduce: reading a data-evolution table fails with IndexError when
+        a data file has no write_cols metadata (written with all columns of the
+        old schema before schema evolution) and sorts first in the union reader,
+        causing it to wrongly claim fields from new columns it doesn't have.
+
+        This simulates the real-world scenario where:
+        1. Data is written with the original schema (write_cols=None)
+        2. Schema evolution adds new columns
+        3. New column data is written as separate files with the same first_row_id
+        4. The original file sorts first (higher max_seq) and _create_union_reader
+           assumes it contains ALL current table fields, leading to IndexError."""
+        from pypaimon.schema.schema_change import SchemaChange
+        from pypaimon.schema.data_types import AtomicType
+
+        # Step 1: Create table with [f0, f1]
+        initial_schema = pa.schema([
+            ('f0', pa.int32()),
+            ('f1', pa.string()),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            initial_schema,
+            options={'row-tracking.enabled': 'true', 'data-evolution.enabled': 'true'},
+        )
+        table_name = 'default.test_no_write_cols_schema_evo'
+        self.catalog.create_table(table_name, schema, False)
+        table = self.catalog.get_table(table_name)
+
+        # Step 2: Write data with ALL columns of old schema → write_cols = None
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        table_write.write_arrow(pa.Table.from_pydict(
+            {'f0': [1, 2], 'f1': ['a', 'b']},
+            schema=initial_schema,
+        ))
+        cmts = table_write.prepare_commit()
+        for c in cmts:
+            for nf in c.new_files:
+                self.assertIsNone(nf.write_cols)
+        table_commit.commit(cmts)
+        table_write.close()
+        table_commit.close()
+
+        # Step 3: Schema evolution - add column f2
+        self.catalog.alter_table(
+            table_name,
+            [SchemaChange.add_column('f2', AtomicType('STRING'))],
+        )
+        table = self.catalog.get_table(table_name)
+
+        # Step 4: Write f2 only for same rows (first_row_id = 0)
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write().with_write_type(['f2'])
+        table_commit = write_builder.new_commit()
+        table_write.write_arrow(pa.Table.from_pydict(
+            {'f2': ['x', 'y']},
+            schema=pa.schema([('f2', pa.string())]),
+        ))
+        cmts_f2 = table_write.prepare_commit()
+        for c in cmts_f2:
+            for nf in c.new_files:
+                nf.first_row_id = 0
+        table_commit.commit(cmts_f2)
+        table_write.close()
+        table_commit.close()
+
+        # Step 5: Read all columns
+        # The two files have the same first_row_id=0, so they are merged.
+        # In _split_by_row_id they go into the same group, sorted by -max_seq.
+        # Normally the f2 file (higher max_seq) sorts first, so the bug
+        # doesn't trigger. But in real scenarios (e.g. blob files, or files
+        # written by Java Paimon), the old file can be Bunch 0.
+        # We force this by boosting the old file's max_sequence_number.
+        read_builder = table.new_read_builder()
+        table_scan = read_builder.new_scan()
+        table_read = read_builder.new_read()
+        splits = table_scan.plan().splits()
+
+        # Manipulate: set higher max_seq on the no-write_cols file so it
+        # sorts first — reproducing the real scenario where the original
+        # data file is processed as Bunch 0 in _split_field_bunches.
+        for split in splits:
+            for f in split.files:
+                if f.write_cols is None:
+                    f.max_sequence_number = 999999
+
+        actual = table_read.to_arrow(splits)
+
+        expect = pa.Table.from_pydict({
+            'f0': [1, 2],
+            'f1': ['a', 'b'],
+            'f2': ['x', 'y'],
+        }, schema=pa.schema([
+            ('f0', pa.int32()),
+            ('f1', pa.string()),
+            ('f2', pa.string()),
+        ]))
+        self.assertEqual(actual.num_rows, 2)
+        self.assertEqual(actual, expect)


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes data-evolution read/merge field resolution to use each file’s recorded schema instead of the current table schema, which can affect which columns are read and merged. Risk is mainly around correctness/regressions in schema-evolution scenarios and row-tracking metadata inclusion.
> 
> **Overview**
> Fixes data-evolution reads for older data files that have `write_cols=None` by deriving readable field IDs from the file’s `schema_id` (plus `_ROW_ID`/`_SEQUENCE_NUMBER`) rather than the current table schema.
> 
> Adds a regression test that writes a full pre-evolution schema (no `write_cols`), evolves the table by adding a column, writes the new column separately, and verifies reads return all columns correctly across the mixed file set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac91b941d9c98553a1c2944b697a4c7878787c89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->