### PR TITLE
Mock server fix

### DIFF
--- a/paimon-python/pypaimon/tests/rest/rest_base_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_base_test.py
@@ -339,6 +339,29 @@ class RESTBaseTest(unittest.TestCase):
         )
         self.assertEqual(len(result.elements), 3)
 
+    def test_alter_database(self):
+        """Test alter_database sets and removes properties."""
+        from pypaimon.catalog.rest.property_change import PropertyChange
+        db_name = "alter_db_test"
+        self.rest_catalog.create_database(db_name, True)
+
+        # set property
+        self.rest_catalog.alter_database(
+            db_name,
+            [PropertyChange.set_property("key1", "value1"),
+             PropertyChange.set_property("key2", "value2")])
+        db = self.rest_catalog.get_database(db_name)
+        self.assertEqual(db.options.get("key1"), "value1")
+        self.assertEqual(db.options.get("key2"), "value2")
+
+        # remove property
+        self.rest_catalog.alter_database(
+            db_name,
+            [PropertyChange.remove_property("key1")])
+        db = self.rest_catalog.get_database(db_name)
+        self.assertNotIn("key1", db.options)
+        self.assertEqual(db.options.get("key2"), "value2")
+
     def test_list_partitions_paged_empty(self):
         """Test list_partitions_paged returns empty when no partitions."""
         identifier = Identifier.from_string('default.test_reader_iterator')

--- a/paimon-python/pypaimon/tests/rest/rest_server.py
+++ b/paimon-python/pypaimon/tests/rest/rest_server.py
@@ -29,7 +29,8 @@ from urllib.parse import urlparse
 if TYPE_CHECKING:
     from pypaimon.catalog.rest.rest_token import RESTToken
 
-from pypaimon.api.api_request import (AlterTableRequest, CreateDatabaseRequest,
+from pypaimon.api.api_request import (AlterDatabaseRequest, AlterTableRequest,
+                                      CreateDatabaseRequest,
                                       CreateTableRequest, RenameTableRequest)
 from pypaimon.api.api_response import (ConfigResponse, GetDatabaseResponse,
                                        GetTableResponse, ListDatabasesResponse,
@@ -526,6 +527,18 @@ class RESTCatalogServer:
         if method == "GET":
             response = database
             return self._mock_response(response, 200)
+
+        elif method == "POST":
+            request_body = JSON.from_json(data, AlterDatabaseRequest)
+            removals = request_body.removals or []
+            updates = request_body.updates or {}
+            options = dict(database.options) if database.options else {}
+            options.update(updates)
+            for key in removals:
+                options.pop(key, None)
+            self.database_store[database_name] = self.mock_database(
+                database_name, options)
+            return self._mock_response("", 200)
 
         elif method == "DELETE":
             del self.database_store[database_name]

--- a/paimon-python/pypaimon/tests/rest/rest_server.py
+++ b/paimon-python/pypaimon/tests/rest/rest_server.py
@@ -295,6 +295,10 @@ class RESTCatalogServer:
             def _authenticate(self, token: str, path: str, params: Dict[str, str],
                               method: str, data: str) -> bool:
                 """Authenticate request by verifying Authorization header."""
+                if server_instance.auth_provider is None:
+                    return True
+                if path.startswith("/ram/security-credential"):
+                    return True
                 if not token:
                     return False
                 rest_auth_parameter = RESTAuthParameter(

--- a/paimon-python/pypaimon/tests/rest/rest_server.py
+++ b/paimon-python/pypaimon/tests/rest/rest_server.py
@@ -45,6 +45,7 @@ from pypaimon.catalog.catalog_exception import (DatabaseNoPermissionException,
                                                 TableAlreadyExistException)
 from pypaimon.catalog.rest.table_metadata import TableMetadata
 from pypaimon.common.identifier import Identifier
+from pypaimon.api.typedef import RESTAuthParameter
 from pypaimon.common.json_util import JSON
 from pypaimon import Schema
 from pypaimon.schema.schema_change import Actions, SchemaChange
@@ -258,11 +259,11 @@ class RESTCatalogServer:
                     content_length = int(self.headers.get('Content-Length', 0))
                     data = self.rfile.read(content_length).decode('utf-8') if content_length > 0 else ""
 
-                    # Get headers
+                    # Get headers (case-insensitive from HTTPMessage)
+                    auth_token = self.headers.get(AUTHORIZATION_HEADER_KEY)
                     headers = dict(self.headers)
 
                     # Handle authentication
-                    auth_token = headers.get(AUTHORIZATION_HEADER_KEY.lower())
                     if not self._authenticate(auth_token, resource_path, parameters, method, data):
                         self._send_response(401, "Unauthorized")
                         return
@@ -292,9 +293,21 @@ class RESTCatalogServer:
 
             def _authenticate(self, token: str, path: str, params: Dict[str, str],
                               method: str, data: str) -> bool:
-                """Authenticate request"""
-                # Simplified authentication - always return True for mock
-                return True
+                """Authenticate request by verifying Authorization header."""
+                if not token:
+                    return False
+                rest_auth_parameter = RESTAuthParameter(
+                    method=method,
+                    path=path,
+                    data=data or "",
+                    parameters=params or {},
+                )
+                from pypaimon.api.auth.base import RESTAuthFunction
+                auth_fn = RESTAuthFunction({}, server_instance.auth_provider)
+                expected_headers = auth_fn(rest_auth_parameter)
+                expected_token = expected_headers.get(
+                    AUTHORIZATION_HEADER_KEY, "")
+                return token == expected_token
 
             def _send_response(self, status_code: int, body: str):
                 """Send HTTP response"""


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the REST test mock server and its tests; main risk is breaking existing REST unit tests due to stricter Authorization checking and new request handling paths.
> 
> **Overview**
> Improves the REST test mock server to behave more like the real REST catalog by **validating the `Authorization` header** (instead of always allowing requests) and by reading the header case-insensitively.
> 
> Adds mock handling for **`POST` database operations** via `AlterDatabaseRequest` to update/remove database properties, and introduces a new `test_alter_database` verifying `RESTCatalog.alter_database` correctly sets and removes options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f32b873d74f41ea08a428b2307e38d4fc5bc8f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->