### PR TITLE
[python] Add test to reproduce first_row_id duplicate bug in _write_g…

### DIFF
--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -1092,7 +1092,8 @@ class TableUpdateTest(unittest.TestCase):
             [SetOption('target-file-size', '10kb')])
         table = self.catalog.get_table(f'default.{table_name}')
 
-        updator = table.new_batch_write_builder().new_update()
+        wb = table.new_batch_write_builder()
+        updator = wb.new_update()
         updator.with_update_type(['name'])
         update_data = pa.table({
             '_ROW_ID': pa.array(
@@ -1114,7 +1115,7 @@ class TableUpdateTest(unittest.TestCase):
         self.assertEqual(all_files[0].first_row_id, 0)
         self.assertEqual(all_files[0].row_count, N)
 
-        tc = table.new_batch_write_builder().new_commit()
+        tc = wb.new_commit()
         tc.commit(msgs)
         tc.close()
 

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -1054,6 +1054,9 @@ class TableUpdateTest(unittest.TestCase):
 
 
     def test_update_large_file_split_assigns_incremental_row_ids(self):
+        """When _write_group produces multiple files (data exceeds
+        target-file-size), each file must get an incrementing
+        first_row_id instead of all sharing the same value."""
         import uuid
         import random
         import string
@@ -1071,6 +1074,7 @@ class TableUpdateTest(unittest.TestCase):
             f'default.{table_name}', schema, False)
         table = self.catalog.get_table(f'default.{table_name}')
 
+        # Write 5000 rows into one large file
         N = 5000
         data = pa.table({
             'id': list(range(N)),
@@ -1087,12 +1091,14 @@ class TableUpdateTest(unittest.TestCase):
         tw.close()
         tc.close()
 
+        # Shrink target-file-size to force file split on update
         from pypaimon.schema.schema_change import SetOption
         self.catalog.alter_table(
             f'default.{table_name}',
             [SetOption('target-file-size', '10kb')])
         table = self.catalog.get_table(f'default.{table_name}')
 
+        # Update all rows -> _write_group splits into many files
         updator = table.new_batch_write_builder().new_update()
         updator.with_update_type(['name'])
         update_data = pa.table({
@@ -1105,9 +1111,27 @@ class TableUpdateTest(unittest.TestCase):
         })
         msgs = updator.update_by_arrow_with_row_id(update_data)
 
-        tc = table.new_batch_write_builder().new_commit()
-        tc.commit(msgs)
-        tc.close()
+        all_files = []
+        for msg in msgs:
+            all_files.extend(msg.new_files)
+
+        # Must produce multiple files for the test to be meaningful
+        self.assertGreater(
+            len(all_files), 1,
+            "Update should produce multiple files")
+
+        # Each file must have a unique first_row_id
+        first_ids = [f.first_row_id for f in all_files]
+        self.assertEqual(
+            len(first_ids), len(set(first_ids)),
+            "All files must have unique first_row_id")
+
+        # first_row_ids should increment by row_count
+        expected_id = 0
+        for f in sorted(
+                all_files, key=lambda x: x.first_row_id):
+            self.assertEqual(f.first_row_id, expected_id)
+            expected_id += f.row_count
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -1053,5 +1053,69 @@ class TableUpdateTest(unittest.TestCase):
         self.assertEqual(45, ages[4], "Row 4 should remain unchanged")
 
 
+    def test_update_large_file_split_assigns_incremental_row_ids(self):
+        """When _write_group produces multiple files (data exceeds
+        target-file-size), each file must get an incremented
+        first_row_id instead of all sharing the same value."""
+        import uuid
+        import random
+        import string
+
+        table_name = f'test_row_id_split_{uuid.uuid4().hex[:8]}'
+        schema = Schema.from_pyarrow_schema(
+            pa.schema([('id', pa.int64()), ('name', pa.string())]),
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'write-only': 'true',
+            }
+        )
+        self.catalog.create_table(
+            f'default.{table_name}', schema, False)
+        table = self.catalog.get_table(f'default.{table_name}')
+
+        # Write 5000 rows into one large file
+        N = 5000
+        data = pa.table({
+            'id': list(range(N)),
+            'name': [
+                ''.join(random.choices(
+                    string.ascii_letters, k=200))
+                for _ in range(N)],
+        })
+        wb = table.new_batch_write_builder()
+        tw = wb.new_write()
+        tc = wb.new_commit()
+        tw.write_arrow(data)
+        tc.commit(tw.prepare_commit())
+        tw.close()
+        tc.close()
+
+        # Shrink target-file-size to force split on update
+        from pypaimon.schema.schema_change import SetOption
+        self.catalog.alter_table(
+            f'default.{table_name}',
+            [SetOption('target-file-size', '10kb')])
+        table = self.catalog.get_table(f'default.{table_name}')
+
+        # Update all rows
+        updator = table.new_batch_write_builder().new_update()
+        updator.with_update_type(['name'])
+        update_data = pa.table({
+            '_ROW_ID': pa.array(
+                list(range(N)), type=pa.int64()),
+            'name': [
+                ''.join(random.choices(
+                    string.ascii_letters, k=200))
+                for _ in range(N)],
+        })
+        msgs = updator.update_by_arrow_with_row_id(update_data)
+
+        # Commit should succeed without conflict
+        tc = table.new_batch_write_builder().new_commit()
+        tc.commit(msgs)
+        tc.close()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -1109,11 +1109,18 @@ class TableUpdateTest(unittest.TestCase):
         for msg in msgs:
             all_files.extend(msg.new_files)
 
-        self.assertEqual(
-            len(all_files), 1,
-            "Update should produce exactly one file per group")
-        self.assertEqual(all_files[0].first_row_id, 0)
-        self.assertEqual(all_files[0].row_count, N)
+        self.assertGreater(len(all_files), 1,
+                           "Update should produce multiple files")
+
+        first_ids = [f.first_row_id for f in all_files]
+        self.assertEqual(len(first_ids), len(set(first_ids)),
+                         "All files must have unique first_row_id")
+
+        expected_id = 0
+        for f in sorted(all_files, key=lambda x: x.first_row_id):
+            self.assertEqual(f.first_row_id, expected_id)
+            expected_id += f.row_count
+        self.assertEqual(expected_id, N)
 
         tc = wb.new_commit()
         tc.commit(msgs)

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -1109,18 +1109,11 @@ class TableUpdateTest(unittest.TestCase):
         for msg in msgs:
             all_files.extend(msg.new_files)
 
-        self.assertGreater(len(all_files), 1,
-                           "Update should produce multiple files")
-
-        first_ids = [f.first_row_id for f in all_files]
-        self.assertEqual(len(first_ids), len(set(first_ids)),
-                         "All files must have unique first_row_id")
-
-        expected_id = 0
-        for f in sorted(all_files, key=lambda x: x.first_row_id):
-            self.assertEqual(f.first_row_id, expected_id)
-            expected_id += f.row_count
-        self.assertEqual(expected_id, N)
+        self.assertEqual(
+            len(all_files), 1,
+            "Update should produce exactly one file per group")
+        self.assertEqual(all_files[0].first_row_id, 0)
+        self.assertEqual(all_files[0].row_count, N)
 
         tc = wb.new_commit()
         tc.commit(msgs)

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -1054,9 +1054,6 @@ class TableUpdateTest(unittest.TestCase):
 
 
     def test_update_with_large_file(self):
-        """When _write_group produces multiple files (data exceeds
-        target-file-size), each file must get an incrementing
-        first_row_id instead of all sharing the same value."""
         import uuid
         import random
         import string
@@ -1074,7 +1071,6 @@ class TableUpdateTest(unittest.TestCase):
             f'default.{table_name}', schema, False)
         table = self.catalog.get_table(f'default.{table_name}')
 
-        # Write 5000 rows into one large file
         N = 5000
         data = pa.table({
             'id': list(range(N)),
@@ -1091,14 +1087,12 @@ class TableUpdateTest(unittest.TestCase):
         tw.close()
         tc.close()
 
-        # Shrink target-file-size to force file split on update
         from pypaimon.schema.schema_change import SetOption
         self.catalog.alter_table(
             f'default.{table_name}',
             [SetOption('target-file-size', '10kb')])
         table = self.catalog.get_table(f'default.{table_name}')
 
-        # Update all rows -> _write_group splits into many files
         updator = table.new_batch_write_builder().new_update()
         updator.with_update_type(['name'])
         update_data = pa.table({
@@ -1115,15 +1109,12 @@ class TableUpdateTest(unittest.TestCase):
         for msg in msgs:
             all_files.extend(msg.new_files)
 
-        # _write_group should not roll files — one output file
-        # per first_row_id group, matching the original file range
         self.assertEqual(
             len(all_files), 1,
             "Update should produce exactly one file per group")
         self.assertEqual(all_files[0].first_row_id, 0)
         self.assertEqual(all_files[0].row_count, N)
 
-        # Commit should succeed without conflict
         tc = table.new_batch_write_builder().new_commit()
         tc.commit(msgs)
         tc.close()

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -1054,9 +1054,6 @@ class TableUpdateTest(unittest.TestCase):
 
 
     def test_update_large_file_split_assigns_incremental_row_ids(self):
-        """When _write_group produces multiple files (data exceeds
-        target-file-size), each file must get an incremented
-        first_row_id instead of all sharing the same value."""
         import uuid
         import random
         import string
@@ -1074,7 +1071,6 @@ class TableUpdateTest(unittest.TestCase):
             f'default.{table_name}', schema, False)
         table = self.catalog.get_table(f'default.{table_name}')
 
-        # Write 5000 rows into one large file
         N = 5000
         data = pa.table({
             'id': list(range(N)),
@@ -1091,14 +1087,12 @@ class TableUpdateTest(unittest.TestCase):
         tw.close()
         tc.close()
 
-        # Shrink target-file-size to force split on update
         from pypaimon.schema.schema_change import SetOption
         self.catalog.alter_table(
             f'default.{table_name}',
             [SetOption('target-file-size', '10kb')])
         table = self.catalog.get_table(f'default.{table_name}')
 
-        # Update all rows
         updator = table.new_batch_write_builder().new_update()
         updator.with_update_type(['name'])
         update_data = pa.table({
@@ -1111,7 +1105,6 @@ class TableUpdateTest(unittest.TestCase):
         })
         msgs = updator.update_by_arrow_with_row_id(update_data)
 
-        # Commit should succeed without conflict
         tc = table.new_batch_write_builder().new_commit()
         tc.commit(msgs)
         tc.close()

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -1052,7 +1052,6 @@ class TableUpdateTest(unittest.TestCase):
         self.assertEqual(40, ages[3], "Row 3 should remain unchanged")
         self.assertEqual(45, ages[4], "Row 4 should remain unchanged")
 
-
     def test_update_with_large_file(self):
         import uuid
         import random

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -1053,7 +1053,7 @@ class TableUpdateTest(unittest.TestCase):
         self.assertEqual(45, ages[4], "Row 4 should remain unchanged")
 
 
-    def test_update_large_file_split_assigns_incremental_row_ids(self):
+    def test_update_with_large_file(self):
         """When _write_group produces multiple files (data exceeds
         target-file-size), each file must get an incrementing
         first_row_id instead of all sharing the same value."""
@@ -1115,23 +1115,18 @@ class TableUpdateTest(unittest.TestCase):
         for msg in msgs:
             all_files.extend(msg.new_files)
 
-        # Must produce multiple files for the test to be meaningful
-        self.assertGreater(
-            len(all_files), 1,
-            "Update should produce multiple files")
-
-        # Each file must have a unique first_row_id
-        first_ids = [f.first_row_id for f in all_files]
+        # _write_group should not roll files — one output file
+        # per first_row_id group, matching the original file range
         self.assertEqual(
-            len(first_ids), len(set(first_ids)),
-            "All files must have unique first_row_id")
+            len(all_files), 1,
+            "Update should produce exactly one file per group")
+        self.assertEqual(all_files[0].first_row_id, 0)
+        self.assertEqual(all_files[0].row_count, N)
 
-        # first_row_ids should increment by row_count
-        expected_id = 0
-        for f in sorted(
-                all_files, key=lambda x: x.first_row_id):
-            self.assertEqual(f.first_row_id, expected_id)
-            expected_id += f.row_count
+        # Commit should succeed without conflict
+        tc = table.new_batch_write_builder().new_commit()
+        tc.commit(msgs)
+        tc.close()
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -85,7 +85,10 @@ class ConflictDetection:
             return RuntimeError(
                 "File deletion conflicts detected! Give up committing. " + str(e))
 
-        conflict = self.check_row_id_range_conflicts(commit_kind, merged_entries)
+        if commit_kind == "COMPACT":
+            conflict = self.check_row_id_range_conflicts(commit_kind, merged_entries)
+        else:
+            conflict = self.check_row_id_range_conflicts(commit_kind, delta_entries)
         if conflict is not None:
             return conflict
 

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -85,10 +85,7 @@ class ConflictDetection:
             return RuntimeError(
                 "File deletion conflicts detected! Give up committing. " + str(e))
 
-        if commit_kind == "COMPACT":
-            conflict = self.check_row_id_range_conflicts(commit_kind, merged_entries)
-        else:
-            conflict = self.check_row_id_range_conflicts(commit_kind, delta_entries)
+        conflict = self.check_row_id_range_conflicts(commit_kind, merged_entries)
         if conflict is not None:
             return conflict
 

--- a/paimon-python/pypaimon/write/file_store_write.py
+++ b/paimon-python/pypaimon/write/file_store_write.py
@@ -46,6 +46,11 @@ class FileStoreWrite:
                              (f"{self.options.data_file_prefix()}-u-{commit_user}"
                               f"-s-{random.randint(0, 2 ** 31 - 2)}-w-"))
 
+    def disable_rolling(self):
+        """Disable file rolling by setting target_file_size to max."""
+        self.options.set(
+            CoreOptions.TARGET_FILE_SIZE, str(2 ** 63 - 1))
+
     def write(self, partition: Tuple, bucket: int, data: pa.RecordBatch):
         key = (partition, bucket)
         if key not in self.data_writers:

--- a/paimon-python/pypaimon/write/file_store_write.py
+++ b/paimon-python/pypaimon/write/file_store_write.py
@@ -46,11 +46,6 @@ class FileStoreWrite:
                              (f"{self.options.data_file_prefix()}-u-{commit_user}"
                               f"-s-{random.randint(0, 2 ** 31 - 2)}-w-"))
 
-    def disable_rolling(self):
-        """Disable file rolling by setting target_file_size to max."""
-        self.options.set(
-            CoreOptions.TARGET_FILE_SIZE, str(2 ** 63 - 1))
-
     def write(self, partition: Tuple, bucket: int, data: pa.RecordBatch):
         key = (partition, bucket)
         if key not in self.data_writers:

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -294,7 +294,6 @@ class TableUpdateByRowId:
 
         # Create a file store write for this partition
         # Disable rolling to ensure one output file per first_row_id group,
-        # matching the original file's row ID range exactly.
         file_store_write = FileStoreWrite(self.table, self.commit_user)
         file_store_write.disable_rolling()
 

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -292,24 +292,31 @@ class TableUpdateByRowId:
         # Merge update data with original data
         merged_data = self._merge_update_with_original(original_data, data, column_names, first_row_id)
 
+        # Create a file store write for this partition
+        # Disable rolling to ensure one output file per first_row_id group,
         file_store_write = FileStoreWrite(self.table, self.commit_user)
+        file_store_write.disable_rolling()
+
+        # Set write columns to only update specific columns
         write_cols = column_names
         file_store_write.write_cols = write_cols
 
+        # Convert partition to tuple for hashing
         partition_tuple = tuple(partition.values)
 
+        # Write merged data - convert Table to RecordBatch
         for batch in merged_data.to_batches():
             file_store_write.write(partition_tuple, 0, batch)
 
+        # Prepare commit and assign first_row_id
         commit_messages = file_store_write.prepare_commit(BATCH_COMMIT_IDENTIFIER)
 
-        current_row_id = first_row_id
+        # Assign first_row_id to the new files
         for msg in commit_messages:
             msg.check_from_snapshot = self.snapshot_id
             for file in msg.new_files:
-                file.first_row_id = current_row_id
+                file.first_row_id = first_row_id
                 file.write_cols = write_cols
-                current_row_id += file.row_count
 
         self.commit_messages.extend(commit_messages)
 

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -309,13 +309,14 @@ class TableUpdateByRowId:
         # Prepare commit and assign first_row_id
         commit_messages = file_store_write.prepare_commit(BATCH_COMMIT_IDENTIFIER)
 
-        # Assign first_row_id to the new files
+        # Assign first_row_id to the new files, incrementing by row_count
+        current_row_id = first_row_id
         for msg in commit_messages:
             msg.check_from_snapshot = self.snapshot_id
             for file in msg.new_files:
-                # Assign the same first_row_id as the original file
-                file.first_row_id = first_row_id
+                file.first_row_id = current_row_id
                 file.write_cols = write_cols
+                current_row_id += file.row_count
 
         self.commit_messages.extend(commit_messages)
 

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -293,7 +293,10 @@ class TableUpdateByRowId:
         merged_data = self._merge_update_with_original(original_data, data, column_names, first_row_id)
 
         # Create a file store write for this partition
+        # Disable rolling to ensure one output file per first_row_id group,
+        # matching the original file's row ID range exactly.
         file_store_write = FileStoreWrite(self.table, self.commit_user)
+        file_store_write.disable_rolling()
 
         # Set write columns to only update specific columns
         write_cols = column_names
@@ -309,14 +312,12 @@ class TableUpdateByRowId:
         # Prepare commit and assign first_row_id
         commit_messages = file_store_write.prepare_commit(BATCH_COMMIT_IDENTIFIER)
 
-        # Assign first_row_id to the new files, incrementing by row_count
-        current_row_id = first_row_id
+        # Assign first_row_id to the new files
         for msg in commit_messages:
             msg.check_from_snapshot = self.snapshot_id
             for file in msg.new_files:
-                file.first_row_id = current_row_id
+                file.first_row_id = first_row_id
                 file.write_cols = write_cols
-                current_row_id += file.row_count
 
         self.commit_messages.extend(commit_messages)
 

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -292,31 +292,24 @@ class TableUpdateByRowId:
         # Merge update data with original data
         merged_data = self._merge_update_with_original(original_data, data, column_names, first_row_id)
 
-        # Create a file store write for this partition
-        # Disable rolling to ensure one output file per first_row_id group,
         file_store_write = FileStoreWrite(self.table, self.commit_user)
-        file_store_write.disable_rolling()
-
-        # Set write columns to only update specific columns
         write_cols = column_names
         file_store_write.write_cols = write_cols
 
-        # Convert partition to tuple for hashing
         partition_tuple = tuple(partition.values)
 
-        # Write merged data - convert Table to RecordBatch
         for batch in merged_data.to_batches():
             file_store_write.write(partition_tuple, 0, batch)
 
-        # Prepare commit and assign first_row_id
         commit_messages = file_store_write.prepare_commit(BATCH_COMMIT_IDENTIFIER)
 
-        # Assign first_row_id to the new files
+        current_row_id = first_row_id
         for msg in commit_messages:
             msg.check_from_snapshot = self.snapshot_id
             for file in msg.new_files:
-                file.first_row_id = first_row_id
+                file.first_row_id = current_row_id
                 file.write_cols = write_cols
+                current_row_id += file.row_count
 
         self.commit_messages.extend(commit_messages)
 


### PR DESCRIPTION
…roup

When _write_group writes data that exceeds target-file-size, the output is split into multiple files. All files are assigned the same first_row_id, causing row ID range overlap and conflict detection failure on commit.

### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the write path for row-id based updates by overriding file sizing/rolling behavior, which could affect performance and file layout for large updates. Scoped to data-evolution update writes, with a new regression test covering the previously failing split case.
> 
> **Overview**
> Fixes a data-evolution update bug where `_write_group` could roll/split output into multiple files that all shared the same `first_row_id`, leading to overlapping row-id ranges.
> 
> `TableUpdateByRowId._write_group` now disables file rolling by forcing an effectively unlimited `target-file-size` via a new `FileStoreWrite.disable_rolling()` helper, and a new `test_update_with_large_file` regression test asserts large updates still produce exactly one file with the correct `first_row_id`/`row_count` even when the table `target-file-size` is set very small.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24b16259ec7892c2665cf6939c5d95148ca3f957. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->