### PR TITLE
[python] Fix rolling stack overflow by replacing recursion with itera…

### DIFF
--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -459,15 +459,15 @@ class TableWriteTest(unittest.TestCase):
             max_seq_number=0, options=options,
         )
 
-        num_chunks = 1500
-        tables = []
-        for i in range(num_chunks):
-            batch = pa.RecordBatch.from_pydict({'name': pa.array([row_value], type=pa.string())})
-            tables.append(pa.Table.from_batches([batch]))
-        writer.pending_data = pa.concat_tables(tables)
+        num_rows = 1500
+        big_batch = pa.RecordBatch.from_pydict(
+            {'name': pa.array([row_value] * num_rows, type=pa.string())}
+        )
+        writer.write(big_batch)
 
-        writer._check_and_roll_if_needed()
-
+        pending_rows = writer.pending_data.num_rows if writer.pending_data is not None else 0
+        committed_rows = sum(f.row_count for f in writer.committed_files)
+        self.assertEqual(committed_rows + pending_rows, num_rows)
         self.assertGreater(len(writer.committed_files), 0)
         if writer.pending_data is not None:
             self.assertLessEqual(writer.pending_data.nbytes, target)

--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -28,6 +28,8 @@ import pyarrow as pa
 from parameterized import parameterized
 
 from pypaimon.common.json_util import JSON
+from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.write.writer.append_only_data_writer import AppendOnlyDataWriter
 
 
 class TableWriteTest(unittest.TestCase):
@@ -436,3 +438,36 @@ class TableWriteTest(unittest.TestCase):
         splits = read_builder.new_scan().plan().splits()
         actual = table_read.to_arrow(splits)
         self.assertEqual(expected, actual)
+
+    def test_rolling(self):
+        pa_schema = pa.schema([('name', pa.string())])
+        schema = Schema.from_pyarrow_schema(pa_schema, partition_keys=[])
+        self.catalog.create_table('default.test_rolling_recursion', schema, True)
+        table = self.catalog.get_table('default.test_rolling_recursion')
+
+        row_value = 'x' * 100
+        sample = pa.Table.from_batches([
+            pa.RecordBatch.from_pydict({'name': pa.array([row_value], type=pa.string())})
+        ])
+        # Set target just above single chunk nbytes so best_split=1 every time
+        target = sample.nbytes + 1
+
+        options = CoreOptions.copy(table.options)
+        options.set(CoreOptions.TARGET_FILE_SIZE, str(target))
+        writer = AppendOnlyDataWriter(
+            table=table, partition=(), bucket=0,
+            max_seq_number=0, options=options,
+        )
+
+        num_chunks = 1500
+        tables = []
+        for i in range(num_chunks):
+            batch = pa.RecordBatch.from_pydict({'name': pa.array([row_value], type=pa.string())})
+            tables.append(pa.Table.from_batches([batch]))
+        writer.pending_data = pa.concat_tables(tables)
+
+        writer._check_and_roll_if_needed()
+
+        self.assertGreater(len(writer.committed_files), 0)
+        if writer.pending_data is not None:
+            self.assertLessEqual(writer.pending_data.nbytes, target)

--- a/paimon-python/pypaimon/write/writer/data_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_writer.py
@@ -142,19 +142,17 @@ class DataWriter(ABC):
         """Merge existing data with new data. Must be implemented by subclasses."""
 
     def _check_and_roll_if_needed(self):
-        if self.pending_data is None:
-            return
-
-        current_size = self.pending_data.nbytes
-        if current_size > self.target_file_size:
+        while self.pending_data is not None:
+            current_size = self.pending_data.nbytes
+            if current_size <= self.target_file_size:
+                break
             split_row = self._find_optimal_split_point(self.pending_data, self.target_file_size)
-            if split_row > 0:
-                data_to_write = self.pending_data.slice(0, split_row)
-                remaining_data = self.pending_data.slice(split_row)
-
-                self._write_data_to_file(data_to_write)
-                self.pending_data = remaining_data
-                self._check_and_roll_if_needed()
+            if split_row <= 0:
+                break
+            data_to_write = self.pending_data.slice(0, split_row)
+            remaining_data = self.pending_data.slice(split_row)
+            self._write_data_to_file(data_to_write)
+            self.pending_data = remaining_data
 
     def _write_data_to_file(self, data: pa.Table):
         if data.num_rows == 0:


### PR DESCRIPTION
…tion

### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core write-path rolling/splitting logic; while behavior is intended to be equivalent, it could affect file boundaries or rolling termination in edge cases. Added test coverage reduces risk but performance/size calculations may still differ with real datasets.
> 
> **Overview**
> Fixes potential stack overflows during data-file rolling by rewriting `DataWriter._check_and_roll_if_needed` to iteratively split and flush `pending_data` in a loop instead of recursing per split.
> 
> Adds a regression test (`test_rolling`) that forces many small splits by setting `CoreOptions.TARGET_FILE_SIZE` just above a single-row batch size, asserting rows are fully accounted for, at least one file is committed, and any remaining pending data stays within the target size.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57a2a9349e60dc01a494fc196dc83be356d45ce9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->