### PR TITLE
add test_rolling_single_chunk

### DIFF
--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -470,3 +470,31 @@ class TableWriteTest(unittest.TestCase):
         self.assertGreater(len(writer.committed_files), 0)
         if writer.pending_data is not None:
             self.assertLessEqual(writer.pending_data.nbytes, target)
+
+    def test_rolling_single_chunk(self):
+        pa_schema = pa.schema([('name', pa.string())])
+        schema = Schema.from_pyarrow_schema(pa_schema, partition_keys=[])
+        self.catalog.create_table('default.test_rolling_nbytes', schema, True)
+        table = self.catalog.get_table('default.test_rolling_nbytes')
+
+        # target = 10KB, but a 500-row batch is ~52KB (single chunk)
+        target = 10 * 1024
+        options = CoreOptions.copy(table.options)
+        options.set(CoreOptions.TARGET_FILE_SIZE, str(target))
+        writer = AppendOnlyDataWriter(
+            table=table, partition=(), bucket=0,
+            max_seq_number=0, options=options,
+        )
+
+        num_rows = 500
+        row_value = 'x' * 100
+        batch = pa.RecordBatch.from_pydict(
+            {'name': pa.array([row_value] * num_rows, type=pa.string())})
+        writer.write(batch)
+
+        pending_rows = writer.pending_data.num_rows if writer.pending_data is not None else 0
+        committed_rows = sum(f.row_count for f in writer.committed_files)
+        self.assertEqual(committed_rows + pending_rows, num_rows)
+        self.assertGreater(len(writer.committed_files), 1)
+        if writer.pending_data is not None:
+            self.assertLessEqual(writer.pending_data.nbytes, target)

--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -439,7 +439,6 @@ class TableWriteTest(unittest.TestCase):
         actual = table_read.to_arrow(splits)
         self.assertEqual(expected, actual)
 
-<<<<<<< HEAD
     def test_rolling(self):
         pa_schema = pa.schema([('name', pa.string())])
         schema = Schema.from_pyarrow_schema(pa_schema, partition_keys=[])
@@ -452,18 +451,6 @@ class TableWriteTest(unittest.TestCase):
         ])
         # Set target just above single chunk nbytes so best_split=1 every time
         target = sample.nbytes + 1
-
-=======
-    def test_rolling_single_chunk(self):
-        pa_schema = pa.schema([('name', pa.string())])
-        schema = Schema.from_pyarrow_schema(pa_schema, partition_keys=[])
-        self.catalog.create_table(
-            'default.test_rolling_nbytes', schema, True)
-        table = self.catalog.get_table('default.test_rolling_nbytes')
-
-        # target = 10KB, but a 500-row batch is ~52KB (single chunk)
-        target = 10 * 1024
->>>>>>> 8ec79ac6b (add test_rolling_single_chunk)
         options = CoreOptions.copy(table.options)
         options.set(CoreOptions.TARGET_FILE_SIZE, str(target))
         writer = AppendOnlyDataWriter(
@@ -471,7 +458,6 @@ class TableWriteTest(unittest.TestCase):
             max_seq_number=0, options=options,
         )
 
-<<<<<<< HEAD
         num_rows = 1500
         big_batch = pa.RecordBatch.from_pydict(
             {'name': pa.array([row_value] * num_rows, type=pa.string())}
@@ -484,14 +470,3 @@ class TableWriteTest(unittest.TestCase):
         self.assertGreater(len(writer.committed_files), 0)
         if writer.pending_data is not None:
             self.assertLessEqual(writer.pending_data.nbytes, target)
-=======
-        row_value = 'x' * 100
-        batch = pa.RecordBatch.from_pydict(
-            {'name': pa.array([row_value] * 500, type=pa.string())})
-        writer.write(batch)
-
-        # Rolling should split 52KB into multiple ~10KB files
-        self.assertGreater(len(writer.committed_files), 0)
-        if writer.pending_data is not None:
-            self.assertLess(writer.pending_data.num_rows, 500)
->>>>>>> 8ec79ac6b (add test_rolling_single_chunk)

--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -439,6 +439,7 @@ class TableWriteTest(unittest.TestCase):
         actual = table_read.to_arrow(splits)
         self.assertEqual(expected, actual)
 
+<<<<<<< HEAD
     def test_rolling(self):
         pa_schema = pa.schema([('name', pa.string())])
         schema = Schema.from_pyarrow_schema(pa_schema, partition_keys=[])
@@ -452,6 +453,17 @@ class TableWriteTest(unittest.TestCase):
         # Set target just above single chunk nbytes so best_split=1 every time
         target = sample.nbytes + 1
 
+=======
+    def test_rolling_single_chunk(self):
+        pa_schema = pa.schema([('name', pa.string())])
+        schema = Schema.from_pyarrow_schema(pa_schema, partition_keys=[])
+        self.catalog.create_table(
+            'default.test_rolling_nbytes', schema, True)
+        table = self.catalog.get_table('default.test_rolling_nbytes')
+
+        # target = 10KB, but a 500-row batch is ~52KB (single chunk)
+        target = 10 * 1024
+>>>>>>> 8ec79ac6b (add test_rolling_single_chunk)
         options = CoreOptions.copy(table.options)
         options.set(CoreOptions.TARGET_FILE_SIZE, str(target))
         writer = AppendOnlyDataWriter(
@@ -459,6 +471,7 @@ class TableWriteTest(unittest.TestCase):
             max_seq_number=0, options=options,
         )
 
+<<<<<<< HEAD
         num_rows = 1500
         big_batch = pa.RecordBatch.from_pydict(
             {'name': pa.array([row_value] * num_rows, type=pa.string())}
@@ -471,3 +484,14 @@ class TableWriteTest(unittest.TestCase):
         self.assertGreater(len(writer.committed_files), 0)
         if writer.pending_data is not None:
             self.assertLessEqual(writer.pending_data.nbytes, target)
+=======
+        row_value = 'x' * 100
+        batch = pa.RecordBatch.from_pydict(
+            {'name': pa.array([row_value] * 500, type=pa.string())})
+        writer.write(batch)
+
+        # Rolling should split 52KB into multiple ~10KB files
+        self.assertGreater(len(writer.committed_files), 0)
+        if writer.pending_data is not None:
+            self.assertLess(writer.pending_data.num_rows, 500)
+>>>>>>> 8ec79ac6b (add test_rolling_single_chunk)


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds a new unit test; no production code paths are modified. Potential risk is limited to test flakiness due to size assumptions.
> 
> **Overview**
> Adds `test_rolling_single_chunk` to validate `AppendOnlyDataWriter` file-rolling behavior when a *single-chunk* `RecordBatch` exceeds `CoreOptions.TARGET_FILE_SIZE`.
> 
> The test asserts all rows are accounted for, that multiple files are committed (i.e., rolling occurs), and any remaining `pending_data` stays under the configured target size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1246d7eb30619cf2d1350146a6f2f92eed62dcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->