### PR TITLE
reproduce row id bug

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
@@ -68,7 +68,10 @@ trait BaseScan extends Scan with SupportsReportStatistics with Logging {
   val coreOptions: CoreOptions = CoreOptions.fromMap(table.options())
 
   lazy val tableRowType: RowType = {
-    if (coreOptions.rowTrackingEnabled() && !table.rowType().containsField(SpecialFields.ROW_ID.name())) {
+    if (
+      coreOptions
+        .rowTrackingEnabled() && !table.rowType().containsField(SpecialFields.ROW_ID.name())
+    ) {
       SpecialFields.rowTypeWithRowTracking(table.rowType())
     } else {
       table.rowType()

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
@@ -68,7 +68,7 @@ trait BaseScan extends Scan with SupportsReportStatistics with Logging {
   val coreOptions: CoreOptions = CoreOptions.fromMap(table.options())
 
   lazy val tableRowType: RowType = {
-    if (coreOptions.rowTrackingEnabled()) {
+    if (coreOptions.rowTrackingEnabled() && !table.rowType().containsField(SpecialFields.ROW_ID.name())) {
       SpecialFields.rowTypeWithRowTracking(table.rowType())
     } else {
       table.rowType()

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -952,4 +952,30 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase {
       assert(!indexEntries.exists(entry => entry.partition().getString(0).toString.equals("p1")))
     }
   }
+
+  test("Data Evolution: self merge via row_tracking system table") {
+    withTable("target") {
+      sql(
+        "CREATE TABLE target (a INT, b INT, c STRING) TBLPROPERTIES ('row-tracking.enabled' = 'true', 'data-evolution.enabled' = 'true')")
+      sql("INSERT INTO target VALUES (1, 10, 'c1'), (2, 20, 'c2'), (3, 30, 'c3')")
+
+      // Add a new column and backfill via $row_tracking system table
+      sql("ALTER TABLE target ADD COLUMNS (status STRING)")
+
+      sql(s"""
+             |MERGE INTO target AS t
+             |USING `target$$row_tracking` AS s
+             |ON t._ROW_ID = s._ROW_ID
+             |WHEN MATCHED THEN UPDATE SET t.status = 'active'
+             |""".stripMargin)
+
+      checkAnswer(
+        sql("SELECT a, b, c, status FROM target ORDER BY a"),
+        Seq(
+          Row(1, 10, "c1", "active"),
+          Row(2, 20, "c2", "active"),
+          Row(3, 30, "c3", "active"))
+      )
+    }
+  }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -971,10 +971,7 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase {
 
       checkAnswer(
         sql("SELECT a, b, c, status FROM target ORDER BY a"),
-        Seq(
-          Row(1, 10, "c1", "active"),
-          Row(2, 20, "c2", "active"),
-          Row(3, 30, "c3", "active"))
+        Seq(Row(1, 10, "c1", "active"), Row(2, 20, "c2", "active"), Row(3, 30, "c3", "active"))
       )
     }
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -953,26 +953,4 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase {
     }
   }
 
-  test("Data Evolution: self merge via row_tracking system table") {
-    withTable("target") {
-      sql(
-        "CREATE TABLE target (a INT, b INT, c STRING) TBLPROPERTIES ('row-tracking.enabled' = 'true', 'data-evolution.enabled' = 'true')")
-      sql("INSERT INTO target VALUES (1, 10, 'c1'), (2, 20, 'c2'), (3, 30, 'c3')")
-
-      // Add a new column and backfill via $row_tracking system table
-      sql("ALTER TABLE target ADD COLUMNS (status STRING)")
-
-      sql(s"""
-             |MERGE INTO target AS t
-             |USING `target$$row_tracking` AS s
-             |ON t._ROW_ID = s._ROW_ID
-             |WHEN MATCHED THEN UPDATE SET t.status = 'active'
-             |""".stripMargin)
-
-      checkAnswer(
-        sql("SELECT a, b, c, status FROM target ORDER BY a"),
-        Seq(Row(1, 10, "c1", "active"), Row(2, 20, "c2", "active"), Row(3, 30, "c3", "active"))
-      )
-    }
-  }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -953,4 +953,15 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("query row_tracking system table should not throw duplicate _ROW_ID error") {
+    withTable("T") {
+      sql(
+        "CREATE TABLE T (a INT, b STRING) TBLPROPERTIES ('row-tracking.enabled' = 'true')")
+      sql("INSERT INTO T VALUES (1, 'a'), (2, 'b')")
+      checkAnswer(
+        sql("SELECT a, b FROM `T$row_tracking` ORDER BY a"),
+        Seq(Row(1, "a"), Row(2, "b"))
+      )
+    }
+  }
 }


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small guard in scan schema construction prevents adding row-tracking fields twice; behavior changes only for tables whose physical schema already includes `_ROW_ID` (not typical user tables).
> 
> **Overview**
> Fixes Spark scan schema construction for row-tracking by only appending row-tracking fields when the underlying `table.rowType()` does **not** already contain `SpecialFields.ROW_ID`, avoiding duplicate `_ROW_ID` column errors.
> 
> Adds a regression test that queries the `T$row_tracking` system table and verifies selecting `a, b` succeeds and returns expected rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07053f11e13d6565a7d20d4f7efb8af33ec4af03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->