### PR TITLE
optimize lance read

### DIFF
--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -56,9 +56,11 @@ class FormatLanceReader(RecordBatchReader):
 
     def read_arrow_batch(self) -> Optional[RecordBatch]:
         try:
+            # Handle both scanner reader and iterator
             if hasattr(self.reader, 'read_next_batch'):
                 return self.reader.read_next_batch()
             else:
+                # Iterator of batches
                 return next(self.reader)
         except StopIteration:
             return None

--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -35,11 +35,11 @@ class FormatLanceReader(RecordBatchReader):
 
         file_path_for_lance, storage_options = to_lance_specified(file_io, file_path)
 
-        columns = read_fields if read_fields else None
+        columns_for_lance = read_fields if read_fields else None
         self._lance_reader = lance.file.LanceFileReader(
             file_path_for_lance,
             storage_options=storage_options,
-            columns=columns)
+            columns=columns_for_lance)
         reader_results = self._lance_reader.read_all(batch_size=batch_size)
 
         if push_down_predicate is not None:

--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -13,12 +13,11 @@
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
-# limitations under the License.
+#  limitations under the License.
 ################################################################################
 
 from typing import List, Optional, Any
 
-import pyarrow as pa
 import pyarrow.dataset as ds
 from pyarrow import RecordBatch
 
@@ -28,70 +27,40 @@ from pypaimon.read.reader.lance_utils import to_lance_specified
 
 
 class FormatLanceReader(RecordBatchReader):
-    """Streaming Lance file reader with lazy initialization."""
+    """A Format Reader that reads record batches from a Lance file."""
 
     def __init__(self, file_io: FileIO, file_path: str, read_fields: List[str],
                  push_down_predicate: Any, batch_size: int = 1024):
-        self._file_io = file_io
-        self._file_path = file_path
-        self._read_fields = read_fields
-        self._push_down_predicate = push_down_predicate
-        self._batch_size = batch_size
-
-        self._reader = None
-        self._lance_file_reader = None
-        self._initialized = False
-
-    def _ensure_initialized(self):
-        if self._initialized:
-            return
-
         import lance
 
-        file_path_for_lance, storage_options = to_lance_specified(
-            self._file_io, self._file_path)
+        file_path_for_lance, storage_options = to_lance_specified(file_io, file_path)
 
-        columns = self._read_fields if self._read_fields else None
-        self._lance_file_reader = lance.file.LanceFileReader(
+        columns = read_fields if read_fields else None
+        self._lance_reader = lance.file.LanceFileReader(
             file_path_for_lance,
             storage_options=storage_options,
-            columns=columns,
-        )
+            columns=columns)
+        reader_results = self._lance_reader.read_all(batch_size=batch_size)
 
-        reader_results = self._lance_file_reader.read_all(
-            batch_size=self._batch_size)
-        self._reader = reader_results.to_batches()
-        self._initialized = True
+        if push_down_predicate is not None:
+            pa_table = reader_results.to_table()
+            in_memory_dataset = ds.InMemoryDataset(pa_table)
+            scanner = in_memory_dataset.scanner(filter=push_down_predicate, batch_size=batch_size)
+            self._reader = scanner.to_reader()
+        else:
+            self._reader = reader_results.to_batches()
 
     def read_arrow_batch(self) -> Optional[RecordBatch]:
-        if not self._initialized:
-            self._ensure_initialized()
-
-        while True:
-            try:
-                if hasattr(self._reader, 'read_next_batch'):
-                    batch = self._reader.read_next_batch()
-                else:
-                    batch = next(self._reader)
-            except StopIteration:
-                return None
-
-            if batch is None:
-                return None
-
-            if self._push_down_predicate is not None:
-                table = pa.Table.from_batches([batch])
-                filtered = ds.InMemoryDataset(table).scanner(
-                    filter=self._push_down_predicate).to_table()
-                if filtered.num_rows == 0:
-                    continue
-                return filtered.combine_chunks().to_batches()[0]
-
-            return batch
+        try:
+            if hasattr(self._reader, 'read_next_batch'):
+                return self._reader.read_next_batch()
+            else:
+                return next(self._reader)
+        except StopIteration:
+            return None
 
     def close(self):
-        if self._lance_file_reader is not None:
-            self._lance_file_reader.close()
-            self._lance_file_reader = None
+        if self._lance_reader is not None:
+            self._lance_reader.close()
+            self._lance_reader = None
         self._reader = None
-        self._initialized = False

--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -13,11 +13,12 @@
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
-#  limitations under the License.
+# limitations under the License.
 ################################################################################
 
 from typing import List, Optional, Any
 
+import pyarrow as pa
 import pyarrow.dataset as ds
 from pyarrow import RecordBatch
 
@@ -27,46 +28,70 @@ from pypaimon.read.reader.lance_utils import to_lance_specified
 
 
 class FormatLanceReader(RecordBatchReader):
-    """
-    A Format Reader that reads record batch from a Lance file using PyArrow,
-    and filters it based on the provided predicate and projection.
-    """
+    """Streaming Lance file reader with lazy initialization."""
 
     def __init__(self, file_io: FileIO, file_path: str, read_fields: List[str],
                  push_down_predicate: Any, batch_size: int = 1024):
-        """Initialize Lance reader."""
+        self._file_io = file_io
+        self._file_path = file_path
+        self._read_fields = read_fields
+        self._push_down_predicate = push_down_predicate
+        self._batch_size = batch_size
+
+        self._reader = None
+        self._lance_file_reader = None
+        self._initialized = False
+
+    def _ensure_initialized(self):
+        if self._initialized:
+            return
+
         import lance
 
-        file_path_for_lance, storage_options = to_lance_specified(file_io, file_path)
+        file_path_for_lance, storage_options = to_lance_specified(
+            self._file_io, self._file_path)
 
-        columns_for_lance = read_fields if read_fields else None
-        lance_reader = lance.file.LanceFileReader(
+        columns = self._read_fields if self._read_fields else None
+        self._lance_file_reader = lance.file.LanceFileReader(
             file_path_for_lance,
             storage_options=storage_options,
-            columns=columns_for_lance)
-        reader_results = lance_reader.read_all()
+            columns=columns,
+        )
 
-        # Convert to PyArrow table
-        pa_table = reader_results.to_table()
-
-        if push_down_predicate is not None:
-            in_memory_dataset = ds.InMemoryDataset(pa_table)
-            scanner = in_memory_dataset.scanner(filter=push_down_predicate, batch_size=batch_size)
-            self.reader = scanner.to_reader()
-        else:
-            self.reader = iter(pa_table.to_batches(max_chunksize=batch_size))
+        reader_results = self._lance_file_reader.read_all(
+            batch_size=self._batch_size)
+        self._reader = reader_results.to_batches()
+        self._initialized = True
 
     def read_arrow_batch(self) -> Optional[RecordBatch]:
-        try:
-            # Handle both scanner reader and iterator
-            if hasattr(self.reader, 'read_next_batch'):
-                return self.reader.read_next_batch()
-            else:
-                # Iterator of batches
-                return next(self.reader)
-        except StopIteration:
-            return None
+        if not self._initialized:
+            self._ensure_initialized()
+
+        while True:
+            try:
+                if hasattr(self._reader, 'read_next_batch'):
+                    batch = self._reader.read_next_batch()
+                else:
+                    batch = next(self._reader)
+            except StopIteration:
+                return None
+
+            if batch is None:
+                return None
+
+            if self._push_down_predicate is not None:
+                table = pa.Table.from_batches([batch])
+                filtered = ds.InMemoryDataset(table).scanner(
+                    filter=self._push_down_predicate).to_table()
+                if filtered.num_rows == 0:
+                    continue
+                return filtered.combine_chunks().to_batches()[0]
+
+            return batch
 
     def close(self):
-        if self.reader is not None:
-            self.reader = None
+        if self._lance_file_reader is not None:
+            self._lance_file_reader.close()
+            self._lance_file_reader = None
+        self._reader = None
+        self._initialized = False

--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -46,16 +46,16 @@ class FormatLanceReader(RecordBatchReader):
             pa_table = reader_results.to_table()
             in_memory_dataset = ds.InMemoryDataset(pa_table)
             scanner = in_memory_dataset.scanner(filter=push_down_predicate, batch_size=batch_size)
-            self._reader = scanner.to_reader()
+            self.reader = scanner.to_reader()
         else:
-            self._reader = reader_results.to_batches()
+            self.reader = reader_results.to_batches()
 
     def read_arrow_batch(self) -> Optional[RecordBatch]:
         try:
-            if hasattr(self._reader, 'read_next_batch'):
-                return self._reader.read_next_batch()
+            if hasattr(self.reader, 'read_next_batch'):
+                return self.reader.read_next_batch()
             else:
-                return next(self._reader)
+                return next(self.reader)
         except StopIteration:
             return None
 
@@ -63,4 +63,4 @@ class FormatLanceReader(RecordBatchReader):
         if self._lance_reader is not None:
             self._lance_reader.close()
             self._lance_reader = None
-        self._reader = None
+        self.reader = None

--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -27,10 +27,14 @@ from pypaimon.read.reader.lance_utils import to_lance_specified
 
 
 class FormatLanceReader(RecordBatchReader):
-    """A Format Reader that reads record batches from a Lance file."""
+    """
+    A Format Reader that reads record batch from a Lance file using PyArrow,
+    and filters it based on the provided predicate and projection.
+    """
 
     def __init__(self, file_io: FileIO, file_path: str, read_fields: List[str],
                  push_down_predicate: Any, batch_size: int = 1024):
+        """Initialize Lance reader."""
         import lance
 
         file_path_for_lance, storage_options = to_lance_specified(file_io, file_path)

--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -69,4 +69,5 @@ class FormatLanceReader(RecordBatchReader):
         if self._lance_reader is not None:
             self._lance_reader.close()
             self._lance_reader = None
-        self.reader = None
+        if self.reader is not None:
+            self.reader = None


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Lance file read path to stream batches and introduces explicit reader closing, which could affect batching behavior and resource lifecycle during reads.
> 
> **Overview**
> Optimizes `FormatLanceReader` to avoid eagerly materializing a full PyArrow table when no predicate is applied by reading Lance data in batches (`read_all(batch_size=...)` + `to_batches()`).
> 
> Adds lifecycle management by storing the underlying `LanceFileReader` on the instance and closing it in `close()` to prevent resource leaks; table conversion is now only done when predicate pushdown requires building an in-memory dataset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d9813136efeb81400fcff143d0a14fc009a89be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->