### PR TITLE
test: add case for descriptor blob read from external path

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
@@ -314,6 +314,75 @@ class BlobTestBase extends PaimonSparkTestBase {
     }
   }
 
+  /**
+   * Test reading blob descriptor that references an external file outside the catalog bucket.
+   *
+   * Uses blob-descriptor-field so descriptors are stored directly in parquet (no .blob copy).
+   * Writing the descriptor succeeds because path_to_descriptor just serializes the URI. Reading
+   * with blob-as-descriptor=false triggers ColumnarRow.getBlob() which resolves the descriptor and
+   * reads actual data from the external URI.
+   *
+   * Bug: ColumnarRow.getBlob() uses UriReader.fromFile(fileIO) with the table's FileIO
+   * (RESTTokenFileIO in DLF), whose STS token only covers the catalog bucket. External bucket URIs
+   * get 403 AccessDenied.
+   *
+   * To reproduce with real REST catalog:
+   *   1. Configure Spark catalog pointing to a DLF REST catalog
+   *   2. Set EXTERNAL_BLOB_URI to an OSS file in a DIFFERENT bucket than the catalog
+   *   3. Run this test — INSERT succeeds, SELECT with blob-as-descriptor=false fails with 403
+   */
+  test("Blob: descriptor read from external path outside warehouse") {
+    // To test against real OSS, set this to an OSS URI in a different bucket than catalog
+    // e.g. "oss://your-external-bucket/blob_test/test_blob_data"
+    // and make sure catalog options include fs.oss.accessKeyId/accessKeySecret for that bucket.
+    val externalUri = System.getProperty(
+      "paimon.test.external-blob-uri",
+      "file://" + Utils.createTempDir.getCanonicalPath + "/external_blob_data")
+
+    val blobData = "Hello Paimon Blob Test".getBytes("UTF-8")
+
+    // Write blob data to external path
+    val fileIO = new LocalFileIO
+    if (externalUri.startsWith("file://")) {
+      val outputStream = fileIO.newOutputStream(new Path(externalUri), true)
+      try outputStream.write(blobData)
+      finally outputStream.close()
+    }
+    // For OSS URIs, the file should already exist at the specified path
+
+    withTable("t") {
+      // blob-descriptor-field: store descriptor in parquet, no .blob file created
+      sql(
+        "CREATE TABLE t (id INT, name STRING, picture BINARY) TBLPROPERTIES (" +
+          "'row-tracking.enabled'='true', 'data-evolution.enabled'='true', " +
+          "'blob-field'='picture', 'blob-descriptor-field'='picture')")
+
+      // Write descriptor pointing to external file
+      val descriptor = new BlobDescriptor(externalUri, 0, blobData.length)
+      sql(s"INSERT INTO t VALUES (1, 'test', X'${bytesToHex(descriptor.serialize())}')")
+
+      // blob-as-descriptor=true: returns descriptor bytes (no external read, always works)
+      sql("ALTER TABLE t SET TBLPROPERTIES ('blob-as-descriptor'='true')")
+      val descBytes = sql("SELECT picture FROM t")
+        .collect()(0)
+        .get(0)
+        .asInstanceOf[Array[Byte]]
+      val readDescriptor = BlobDescriptor.deserialize(descBytes)
+      assert(readDescriptor.uri() == externalUri)
+
+      // blob-as-descriptor=false: reads actual data from external URI
+      // This fails with 403 on real REST catalog (DLF) when external URI is in a
+      // different bucket, because ColumnarRow.getBlob() uses table's FileIO directly.
+      sql("ALTER TABLE t SET TBLPROPERTIES ('blob-as-descriptor'='false')")
+      val result = sql("SELECT picture FROM t").collect()
+      assert(result.length == 1)
+      val readData = result(0).get(0).asInstanceOf[Array[Byte]]
+      assert(
+        util.Arrays.equals(blobData, readData),
+        "Blob data read from external path should match original data")
+    }
+  }
+
   private val HEX_ARRAY = "0123456789ABCDEF".toCharArray
 
   def bytesToHex(bytes: Array[Byte]): String = {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
@@ -25,9 +25,9 @@ import org.apache.paimon.fs.local.LocalFileIO
 import org.apache.paimon.options.Options
 import org.apache.paimon.spark.PaimonSparkTestBase
 import org.apache.paimon.utils.UriReaderFactory
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.paimon.Utils
 
 import java.util
 import java.util.Random
@@ -314,27 +314,7 @@ class BlobTestBase extends PaimonSparkTestBase {
     }
   }
 
-  /**
-   * Test reading blob descriptor that references an external file outside the catalog bucket.
-   *
-   * Uses blob-descriptor-field so descriptors are stored directly in parquet (no .blob copy).
-   * Writing the descriptor succeeds because path_to_descriptor just serializes the URI. Reading
-   * with blob-as-descriptor=false triggers ColumnarRow.getBlob() which resolves the descriptor and
-   * reads actual data from the external URI.
-   *
-   * Bug: ColumnarRow.getBlob() uses UriReader.fromFile(fileIO) with the table's FileIO
-   * (RESTTokenFileIO in DLF), whose STS token only covers the catalog bucket. External bucket URIs
-   * get 403 AccessDenied.
-   *
-   * To reproduce with real REST catalog:
-   *   1. Configure Spark catalog pointing to a DLF REST catalog
-   *   2. Set EXTERNAL_BLOB_URI to an OSS file in a DIFFERENT bucket than the catalog
-   *   3. Run this test — INSERT succeeds, SELECT with blob-as-descriptor=false fails with 403
-   */
   test("Blob: descriptor read from external path outside warehouse") {
-    // To test against real OSS, set this to an OSS URI in a different bucket than catalog
-    // e.g. "oss://your-external-bucket/blob_test/test_blob_data"
-    // and make sure catalog options include fs.oss.accessKeyId/accessKeySecret for that bucket.
     val externalUri = System.getProperty(
       "paimon.test.external-blob-uri",
       "file://" + Utils.createTempDir.getCanonicalPath + "/external_blob_data")
@@ -351,7 +331,6 @@ class BlobTestBase extends PaimonSparkTestBase {
     // For OSS URIs, the file should already exist at the specified path
 
     withTable("t") {
-      // blob-descriptor-field: store descriptor in parquet, no .blob file created
       sql(
         "CREATE TABLE t (id INT, name STRING, picture BINARY) TBLPROPERTIES (" +
           "'row-tracking.enabled'='true', 'data-evolution.enabled'='true', " +
@@ -371,8 +350,6 @@ class BlobTestBase extends PaimonSparkTestBase {
       assert(readDescriptor.uri() == externalUri)
 
       // blob-as-descriptor=false: reads actual data from external URI
-      // This fails with 403 on real REST catalog (DLF) when external URI is in a
-      // different bucket, because ColumnarRow.getBlob() uses table's FileIO directly.
       sql("ALTER TABLE t SET TBLPROPERTIES ('blob-as-descriptor'='false')")
       val result = sql("SELECT picture FROM t").collect()
       assert(result.length == 1)

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RestBlobTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RestBlobTestBase.scala
@@ -20,10 +20,10 @@ package org.apache.paimon.spark.sql
 
 import org.apache.paimon.catalog.CatalogContext
 import org.apache.paimon.data.{Blob, BlobDescriptor}
-import org.apache.paimon.fs.{FileIO, Path}
+import org.apache.paimon.fs.Path
 import org.apache.paimon.fs.local.LocalFileIO
 import org.apache.paimon.options.Options
-import org.apache.paimon.spark.PaimonSparkTestBase
+import org.apache.paimon.spark.{PaimonSparkTestBase, PaimonSparkTestWithRestCatalogBase}
 import org.apache.paimon.utils.UriReaderFactory
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
@@ -32,7 +32,7 @@ import org.apache.spark.sql.paimon.Utils
 import java.util
 import java.util.Random
 
-class BlobTestBase extends PaimonSparkTestBase {
+class RestBlobTestBase extends PaimonSparkTestWithRestCatalogBase {
 
   private val RANDOM = new Random
 
@@ -314,6 +314,52 @@ class BlobTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("Blob: descriptor read from external path outside warehouse") {
+    val externalUri = System.getProperty(
+      "paimon.test.external-blob-uri",
+      "file://" + Utils.createTempDir.getCanonicalPath + "/external_blob_data")
+
+    val blobData = "Hello Paimon Blob Test".getBytes("UTF-8")
+
+    // Write blob data to external path
+    val fileIO = new LocalFileIO
+    if (externalUri.startsWith("file://")) {
+      val outputStream = fileIO.newOutputStream(new Path(externalUri), true)
+      try outputStream.write(blobData)
+      finally outputStream.close()
+    }
+    // For OSS URIs, the file should already exist at the specified path
+
+    withTable("t") {
+      sql(
+        "CREATE TABLE t (id INT, name STRING, picture BINARY) TBLPROPERTIES (" +
+          "'row-tracking.enabled'='true', 'data-evolution.enabled'='true', " +
+          "'blob-field'='picture', 'blob-descriptor-field'='picture')")
+
+      // Write descriptor pointing to external file
+      val descriptor = new BlobDescriptor(externalUri, 0, blobData.length)
+      sql(s"INSERT INTO t VALUES (1, 'test', X'${bytesToHex(descriptor.serialize())}')")
+
+      // blob-as-descriptor=true: returns descriptor bytes (no external read, always works)
+      sql("ALTER TABLE t SET TBLPROPERTIES ('blob-as-descriptor'='true')")
+      val descBytes = sql("SELECT picture FROM t")
+        .collect()(0)
+        .get(0)
+        .asInstanceOf[Array[Byte]]
+      val readDescriptor = BlobDescriptor.deserialize(descBytes)
+      assert(readDescriptor.uri() == externalUri)
+
+      // blob-as-descriptor=false: reads actual data from external URI
+      sql("ALTER TABLE t SET TBLPROPERTIES ('blob-as-descriptor'='false')")
+      val result = sql("SELECT picture FROM t").collect()
+      assert(result.length == 1)
+      val readData = result(0).get(0).asInstanceOf[Array[Byte]]
+      assert(
+        util.Arrays.equals(blobData, readData),
+        "Blob data read from external path should match original data")
+    }
+  }
+
   private val HEX_ARRAY = "0123456789ABCDEF".toCharArray
 
   def bytesToHex(bytes: Array[Byte]): String = {
@@ -327,7 +373,7 @@ class BlobTestBase extends PaimonSparkTestBase {
   }
 }
 
-class BlobTestWithV2Write extends BlobTestBase {
+class RestBlobTestWithV2Write extends RestBlobTestBase {
   override def sparkConf: SparkConf = {
     super.sparkConf.set("spark.paimon.write.use-v2-write", "true")
   }


### PR DESCRIPTION
Reproduces the issue where ColumnarRow.getBlob() uses UriReader.fromFile(fileIO) with the table's FileIO directly, instead of using UriReaderFactory. On DLF REST catalog, the table's RESTTokenFileIO only has permission for the catalog bucket, so reading from an external bucket URI fails with 403 AccessDenied.

To reproduce with real REST catalog + OSS:
  -Dpaimon.test.external-blob-uri=oss://external-bucket/path/file

### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes adding REST-catalog coverage for blob descriptor handling and external URI reads; low risk to production code but may affect CI stability due to reliance on external URI configuration.
> 
> **Overview**
> Adds a new `RestBlobTestBase` suite (and `RestBlobTestWithV2Write`) that runs the existing blob test scenarios against the REST catalog, including a new regression case that verifies **descriptor-based BLOBs can be read from an external URI outside the warehouse** (configurable via `paimon.test.external-blob-uri`).
> 
> Updates `BlobTestBase` imports to align with the new test utilities used for external-path handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47b03493d5a4da49a1485c451685c5cc1cb18dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->