### PR TITLE
Limit pushdown fix

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -141,10 +141,6 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
         return this;
     }
 
-    protected boolean hasPartitionFilter() {
-        return manifestsReader.partitionFilter() != null;
-    }
-
     @Override
     public FileStoreScan onlyReadRealBuckets() {
         manifestsReader.onlyReadRealBuckets();

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -141,6 +141,10 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
         return this;
     }
 
+    protected boolean hasPartitionFilter() {
+        return manifestsReader.partitionFilter() != null;
+    }
+
     @Override
     public FileStoreScan onlyReadRealBuckets() {
         manifestsReader.onlyReadRealBuckets();

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
@@ -99,7 +99,11 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
     public Iterator<ManifestEntry> readManifestEntries(
             List<ManifestFileMeta> manifestFiles, boolean useSequential) {
         Iterator<ManifestEntry> result = super.readManifestEntries(manifestFiles, useSequential);
-        if (limit == null || limit <= 0 || deletionVectorsEnabled || dataEvolutionEnabled) {
+        if (limit == null
+                || limit <= 0
+                || deletionVectorsEnabled
+                || dataEvolutionEnabled
+                || inputFilter != null) {
             return result;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
@@ -22,7 +22,6 @@ import org.apache.paimon.AppendOnlyFileStore;
 import org.apache.paimon.fileindex.FileIndexPredicate;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFile;
-import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
@@ -34,9 +33,6 @@ import org.apache.paimon.utils.SnapshotManager;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -93,32 +89,6 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
     public FileStoreScan withCompleteFilter(Predicate predicate) {
         this.bucketSelectConverter.convert(predicate).ifPresent(this::withTotalAwareBucketFilter);
         return this;
-    }
-
-    @Override
-    public Iterator<ManifestEntry> readManifestEntries(
-            List<ManifestFileMeta> manifestFiles, boolean useSequential) {
-        Iterator<ManifestEntry> result = super.readManifestEntries(manifestFiles, useSequential);
-        if (limit == null
-                || limit <= 0
-                || deletionVectorsEnabled
-                || dataEvolutionEnabled
-                || inputFilter != null
-                || hasPartitionFilter()) {
-            return result;
-        }
-
-        List<ManifestEntry> filtered = new ArrayList<>();
-        long accumulatedRowCount = 0;
-        while (result.hasNext()) {
-            ManifestEntry next = result.next();
-            filtered.add(next);
-            accumulatedRowCount += next.file().rowCount();
-            if (accumulatedRowCount >= limit) {
-                break;
-            }
-        }
-        return filtered.iterator();
     }
 
     /** Note: Keep this thread-safe. */

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
@@ -103,7 +103,8 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
                 || limit <= 0
                 || deletionVectorsEnabled
                 || dataEvolutionEnabled
-                || inputFilter != null) {
+                || inputFilter != null
+                || hasPartitionFilter()) {
             return result;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
@@ -22,6 +22,7 @@ import org.apache.paimon.AppendOnlyFileStore;
 import org.apache.paimon.fileindex.FileIndexPredicate;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFile;
+import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
@@ -33,6 +34,9 @@ import org.apache.paimon.utils.SnapshotManager;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -89,6 +93,32 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
     public FileStoreScan withCompleteFilter(Predicate predicate) {
         this.bucketSelectConverter.convert(predicate).ifPresent(this::withTotalAwareBucketFilter);
         return this;
+    }
+
+    @Override
+    public Iterator<ManifestEntry> readManifestEntries(
+            List<ManifestFileMeta> manifestFiles, boolean useSequential) {
+        Iterator<ManifestEntry> result = super.readManifestEntries(manifestFiles, useSequential);
+        if (limit == null
+                || limit <= 0
+                || deletionVectorsEnabled
+                || dataEvolutionEnabled
+                || inputFilter != null
+                || manifestsReader().partitionFilter() != null) {
+            return result;
+        }
+
+        List<ManifestEntry> filtered = new ArrayList<>();
+        long accumulatedRowCount = 0;
+        while (result.hasNext()) {
+            ManifestEntry next = result.next();
+            filtered.add(next);
+            accumulatedRowCount += next.file().rowCount();
+            if (accumulatedRowCount >= limit) {
+                break;
+            }
+        }
+        return filtered.iterator();
     }
 
     /** Note: Keep this thread-safe. */

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
@@ -104,6 +104,8 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
                 || deletionVectorsEnabled
                 || dataEvolutionEnabled
                 || inputFilter != null
+                // Partition filter runs after this method, so early truncation here
+                // may discard files belonging to the target partition.
                 || manifestsReader().partitionFilter() != null) {
             return result;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
@@ -103,10 +103,7 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
                 || limit <= 0
                 || deletionVectorsEnabled
                 || dataEvolutionEnabled
-                || inputFilter != null
-                // Partition filter runs after this method, so early truncation here
-                // may discard files belonging to the target partition.
-                || manifestsReader().partitionFilter() != null) {
+                || inputFilter != null) {
             return result;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
@@ -228,7 +228,8 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
         return mergeEngine != PARTIAL_UPDATE
                 && mergeEngine != AGGREGATE
                 && !deletionVectorsEnabled
-                && valueFilter == null;
+                && valueFilter == null
+                && keyFilter == null;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
@@ -225,7 +225,10 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
             return false;
         }
 
-        return mergeEngine != PARTIAL_UPDATE && mergeEngine != AGGREGATE && !deletionVectorsEnabled;
+        return mergeEngine != PARTIAL_UPDATE
+                && mergeEngine != AGGREGATE
+                && !deletionVectorsEnabled
+                && valueFilter == null;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -21,7 +21,6 @@ package org.apache.paimon.table.source;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.predicate.Predicate;
-import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.predicate.SortValue;
 import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.schema.SchemaManager;
@@ -36,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -52,7 +50,6 @@ public class DataTableBatchScan extends AbstractDataTableScan {
     private boolean hasNext;
 
     private Integer pushDownLimit;
-    private boolean hasNonPartitionFilter;
     private TopN topN;
 
     private final SchemaManager schemaManager;
@@ -81,9 +78,6 @@ public class DataTableBatchScan extends AbstractDataTableScan {
 
     @Override
     public InnerTableScan withFilter(Predicate predicate) {
-        this.hasNonPartitionFilter |=
-                !new HashSet<>(schema.partitionKeys())
-                        .containsAll(PredicateVisitor.collectFieldNames(predicate));
         super.withFilter(predicate);
         return this;
     }
@@ -132,7 +126,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
     }
 
     private Optional<StartingScanner.Result> applyPushDownLimit() {
-        if (pushDownLimit == null || hasNonPartitionFilter) {
+        if (pushDownLimit == null || snapshotReader.hasNonPartitionFilter()) {
             return Optional.empty();
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -50,6 +50,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
     private boolean hasNext;
 
     private Integer pushDownLimit;
+    private Predicate filter;
     private TopN topN;
 
     private final SchemaManager schemaManager;
@@ -78,6 +79,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
 
     @Override
     public InnerTableScan withFilter(Predicate predicate) {
+        this.filter = predicate;
         super.withFilter(predicate);
         return this;
     }
@@ -126,7 +128,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
     }
 
     private Optional<StartingScanner.Result> applyPushDownLimit() {
-        if (pushDownLimit == null) {
+        if (pushDownLimit == null || filter != null) {
             return Optional.empty();
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -81,7 +81,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
 
     @Override
     public InnerTableScan withFilter(Predicate predicate) {
-        this.hasNonPartitionFilter =
+        this.hasNonPartitionFilter |=
                 !new HashSet<>(schema.partitionKeys())
                         .containsAll(PredicateVisitor.collectFieldNames(predicate));
         super.withFilter(predicate);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -21,6 +21,7 @@ package org.apache.paimon.table.source;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.predicate.SortValue;
 import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.schema.SchemaManager;
@@ -35,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -50,7 +52,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
     private boolean hasNext;
 
     private Integer pushDownLimit;
-    private Predicate filter;
+    private boolean hasNonPartitionFilter;
     private TopN topN;
 
     private final SchemaManager schemaManager;
@@ -79,7 +81,9 @@ public class DataTableBatchScan extends AbstractDataTableScan {
 
     @Override
     public InnerTableScan withFilter(Predicate predicate) {
-        this.filter = predicate;
+        this.hasNonPartitionFilter =
+                !new HashSet<>(schema.partitionKeys())
+                        .containsAll(PredicateVisitor.collectFieldNames(predicate));
         super.withFilter(predicate);
         return this;
     }
@@ -128,7 +132,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
     }
 
     private Optional<StartingScanner.Result> applyPushDownLimit() {
-        if (pushDownLimit == null || filter != null) {
+        if (pushDownLimit == null || hasNonPartitionFilter) {
             return Optional.empty();
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
@@ -121,6 +121,9 @@ public interface SnapshotReader {
 
     SnapshotReader withLimit(int limit);
 
+    /** Whether the pushed filter still contains non-partition predicates. */
+    boolean hasNonPartitionFilter();
+
     /** Get splits plan from snapshot. */
     Plan read();
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -102,6 +102,7 @@ public class SnapshotReaderImpl implements SnapshotReader {
     @Nullable private final DVMetaCache dvMetaCache;
 
     private ScanMode scanMode = ScanMode.ALL;
+    private boolean hasNonPartitionFilter;
     private RecordComparator lazyPartitionComparator;
     private CacheMetrics dvMetaCacheMetrics;
 
@@ -239,6 +240,7 @@ public class SnapshotReaderImpl implements SnapshotReader {
             scan.withPartitionFilter(pair.getLeft().get());
         }
         if (!pair.getRight().isEmpty()) {
+            this.hasNonPartitionFilter = true;
             nonPartitionFilterConsumer.accept(scan, PredicateBuilder.and(pair.getRight()));
         }
         scan.withCompleteFilter(predicate);
@@ -336,6 +338,11 @@ public class SnapshotReaderImpl implements SnapshotReader {
     public SnapshotReader withLimit(int limit) {
         scan.withLimit(limit);
         return this;
+    }
+
+    @Override
+    public boolean hasNonPartitionFilter() {
+        return hasNonPartitionFilter;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -478,6 +478,11 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         }
 
         @Override
+        public boolean hasNonPartitionFilter() {
+            return wrapped.hasNonPartitionFilter();
+        }
+
+        @Override
         public Plan read() {
             return wrapped.read();
         }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
@@ -331,20 +331,24 @@ public class KeyValueFileStoreScanTest {
 
     @Test
     public void testLimitPushdownWithKeyFilter() throws Exception {
-        // Write data with different shop IDs
         List<KeyValue> data = generateData(200);
         Snapshot snapshot = writeData(data);
 
-        // With keyFilter, limit pushdown should still work (keyFilter doesn't affect limit
-        // pushdown)
+        KeyValueFileStoreScan scanAll = store.newScan();
+        scanAll.withSnapshot(snapshot.id());
+        int totalFiles = scanAll.plan().files().size();
+        assertThat(totalFiles).isGreaterThan(0);
+
+        // keyFilter + limit: early-stop by rowCount() is unsafe, should be disabled
         KeyValueFileStoreScan scan = store.newScan();
         scan.withSnapshot(snapshot.id());
         scan.withKeyFilter(
                 new PredicateBuilder(RowType.of(new IntType(false)))
                         .equal(0, data.get(0).key().getInt(0)));
         scan.withLimit(5);
-        List<ManifestEntry> files = scan.plan().files();
-        assertThat(files.size()).isGreaterThan(0);
+
+        assertThat(scan.limitPushdownEnabled()).isFalse();
+        assertThat(scan.plan().files().size()).isEqualTo(totalFiles);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
@@ -569,6 +569,48 @@ public class KeyValueFileStoreScanTest {
         return store.toKvMap(actualKvs);
     }
 
+    @Test
+    void testLimitPushdownWithFilter() throws Exception {
+        int numFiles = 10;
+        int rowsPerFile = 100;
+
+        Snapshot snapshot = null;
+        for (int bucket = 0; bucket < numFiles; bucket++) {
+            List<KeyValue> data = new ArrayList<>();
+            for (int i = 0; i < rowsPerFile; i++) {
+                data.add(gen.nextInsert("", 0, (long) i, null, null));
+            }
+            snapshot = writeData(data, bucket);
+        }
+
+        KeyValueFileStoreScan scanAll = store.newScan();
+        scanAll.withSnapshot(snapshot.id());
+        List<ManifestEntry> allFiles = scanAll.plan().files();
+        assertThat(allFiles.size()).isEqualTo(numFiles);
+
+        KeyValueFileStoreScan scanFilterOnly = store.newScan();
+        scanFilterOnly.withSnapshot(snapshot.id());
+        scanFilterOnly.withValueFilter(
+                new PredicateBuilder(TestKeyValueGenerator.DEFAULT_ROW_TYPE).equal(4, 50L));
+        List<ManifestEntry> filteredFiles = scanFilterOnly.plan().files();
+        assertThat(filteredFiles.size()).isEqualTo(numFiles); // no file eliminated by stats
+
+        KeyValueFileStoreScan scanWithLimit = store.newScan();
+        scanWithLimit.withSnapshot(snapshot.id());
+        scanWithLimit.withValueFilter(
+                new PredicateBuilder(TestKeyValueGenerator.DEFAULT_ROW_TYPE).equal(4, 50L));
+        scanWithLimit.withLimit(5);
+
+        assertThat(scanWithLimit.limitPushdownEnabled()).isFalse();
+
+        List<ManifestEntry> limitedFiles = scanWithLimit.plan().files();
+
+        assertThat(limitedFiles.size())
+                .as(
+                        "When filter is present, limit pushdown should be disabled, returning all files")
+                .isEqualTo(numFiles);
+    }
+
     private List<KeyValue> generateData(int numRecords) {
         List<KeyValue> data = new ArrayList<>();
         for (int i = 0; i < numRecords; i++) {

--- a/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
@@ -28,6 +28,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
+import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
@@ -334,21 +335,25 @@ public class KeyValueFileStoreScanTest {
         List<KeyValue> data = generateData(200);
         Snapshot snapshot = writeData(data);
 
-        KeyValueFileStoreScan scanAll = store.newScan();
-        scanAll.withSnapshot(snapshot.id());
-        int totalFiles = scanAll.plan().files().size();
-        assertThat(totalFiles).isGreaterThan(0);
+        Predicate keyPredicate =
+                new PredicateBuilder(RowType.of(new IntType(false)))
+                        .equal(0, data.get(0).key().getInt(0));
+
+        // baseline: keyFilter without limit
+        KeyValueFileStoreScan scanFilterOnly = store.newScan();
+        scanFilterOnly.withSnapshot(snapshot.id());
+        scanFilterOnly.withKeyFilter(keyPredicate);
+        int filteredFiles = scanFilterOnly.plan().files().size();
+        assertThat(filteredFiles).isGreaterThan(0);
 
         // keyFilter + limit: early-stop by rowCount() is unsafe, should be disabled
         KeyValueFileStoreScan scan = store.newScan();
         scan.withSnapshot(snapshot.id());
-        scan.withKeyFilter(
-                new PredicateBuilder(RowType.of(new IntType(false)))
-                        .equal(0, data.get(0).key().getInt(0)));
+        scan.withKeyFilter(keyPredicate);
         scan.withLimit(5);
 
         assertThat(scan.limitPushdownEnabled()).isFalse();
-        assertThat(scan.plan().files().size()).isEqualTo(totalFiles);
+        assertThat(scan.plan().files().size()).isEqualTo(filteredFiles);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/TableScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/TableScanTest.java
@@ -167,6 +167,34 @@ public class TableScanTest extends ScannerTestBase {
     }
 
     @Test
+    void testLimitPushdownWithPartitionFilter() throws Exception {
+        createAppendOnlyTable();
+
+        StreamTableWrite write = table.newWrite(commitUser);
+        StreamTableCommit commit = table.newCommit(commitUser);
+
+        for (int i = 0; i < 10; i++) {
+            write.write(rowData(i, i, (long) i * 100));
+            commit.commit(i, write.prepareCommit(true, i));
+        }
+
+        Predicate partitionFilter =
+                new PredicateBuilder(table.schema().logicalRowType()).lessOrEqual(0, 4);
+
+        TableScan.Plan planNoLimit = table.newScan().withFilter(partitionFilter).plan();
+        assertThat(planNoLimit.splits().size()).isEqualTo(5);
+
+        TableScan.Plan plan = table.newScan().withFilter(partitionFilter).withLimit(2).plan();
+
+        assertThat(plan.splits().size())
+                .as("Partition filter + limit: limit pushdown should not be disabled")
+                .isEqualTo(2);
+
+        write.close();
+        commit.close();
+    }
+
+    @Test
     public void testLimitPushdownWhenDataLessThanLimit() throws Exception {
         createAppendOnlyTable();
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/TableScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/TableScanTest.java
@@ -114,7 +114,48 @@ public class TableScanTest extends ScannerTestBase {
     }
 
     @Test
-    void testLimitPushdownWithFilter() throws Exception {
+    public void testLimitPushdownWithFilter() throws Exception {
+        createAppendOnlyTable();
+
+        StreamTableWrite write = table.newWrite(commitUser);
+        StreamTableCommit commit = table.newCommit(commitUser);
+
+        // Write 50 files, each with 1 row. Rows 0-24 have 'a' = 10, rows 25-49 have 'a' = 20.
+        for (int i = 0; i < 25; i++) {
+            write.write(rowData(i, 10, (long) i * 100));
+            commit.commit(i, write.prepareCommit(true, i));
+        }
+        for (int i = 25; i < 50; i++) {
+            write.write(rowData(i, 20, (long) i * 100));
+            commit.commit(i, write.prepareCommit(true, i));
+        }
+
+        // Without limit, should read all 50 files
+        TableScan.Plan planWithoutLimit = table.newScan().plan();
+        int totalSplits = planWithoutLimit.splits().size();
+        assertThat(totalSplits).isEqualTo(50);
+
+        // With filter (a = 20) and limit (10)
+        // filterByStats has already been applied in baseIterator, so only files 25-49 will be
+        // returned
+        // To get 10 rows, it should read 10 files (from index 25 to 34)
+        Predicate filter =
+                new PredicateBuilder(table.schema().logicalRowType())
+                        .equal(1, 20); // Filter on 'a' = 20
+        TableScan.Plan planWithFilterAndLimit =
+                table.newScan().withFilter(filter).withLimit(10).plan();
+        int splitsWithFilterAndLimit = planWithFilterAndLimit.splits().size();
+
+        // With non-partition filter, limit pushdown should be disabled to avoid
+        // returning insufficient rows. All 25 matching files should be returned.
+        assertThat(splitsWithFilterAndLimit).isEqualTo(25);
+
+        write.close();
+        commit.close();
+    }
+
+    @Test
+    void testLimitPushdownWithNonPartitionFilter() throws Exception {
         createAppendOnlyTable();
 
         StreamTableWrite write = table.newWrite(commitUser);

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/TableScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/TableScanTest.java
@@ -114,42 +114,53 @@ public class TableScanTest extends ScannerTestBase {
     }
 
     @Test
-    public void testLimitPushdownWithFilter() throws Exception {
+    void testLimitPushdownWithFilter() throws Exception {
         createAppendOnlyTable();
 
         StreamTableWrite write = table.newWrite(commitUser);
         StreamTableCommit commit = table.newCommit(commitUser);
 
-        // Write 50 files, each with 1 row. Rows 0-24 have 'a' = 10, rows 25-49 have 'a' = 20.
-        for (int i = 0; i < 25; i++) {
-            write.write(rowData(i, 10, (long) i * 100));
-            commit.commit(i, write.prepareCommit(true, i));
-        }
-        for (int i = 25; i < 50; i++) {
-            write.write(rowData(i, 20, (long) i * 100));
-            commit.commit(i, write.prepareCommit(true, i));
+        int filesCount = 10;
+        int rowsPerFile = 100;
+        int filterValue = 50;
+
+        for (int fileIdx = 0; fileIdx < filesCount; fileIdx++) {
+            for (int i = 0; i < rowsPerFile; i++) {
+                write.write(rowData(fileIdx, i, (long) (fileIdx * rowsPerFile + i)));
+            }
+            commit.commit(fileIdx, write.prepareCommit(true, fileIdx));
         }
 
-        // Without limit, should read all 50 files
-        TableScan.Plan planWithoutLimit = table.newScan().plan();
-        int totalSplits = planWithoutLimit.splits().size();
-        assertThat(totalSplits).isEqualTo(50);
+        TableScan.Plan planAll = table.newScan().plan();
+        assertThat(planAll.splits().size()).isEqualTo(filesCount);
 
-        // With filter (a = 20) and limit (10)
-        // filterByStats has already been applied in baseIterator, so only files 25-49 will be
-        // returned
-        // To get 10 rows, it should read 10 files (from index 25 to 34)
         Predicate filter =
-                new PredicateBuilder(table.schema().logicalRowType())
-                        .equal(1, 20); // Filter on 'a' = 20
-        TableScan.Plan planWithFilterAndLimit =
-                table.newScan().withFilter(filter).withLimit(10).plan();
-        int splitsWithFilterAndLimit = planWithFilterAndLimit.splits().size();
+                new PredicateBuilder(table.schema().logicalRowType()).equal(1, filterValue);
+        TableScan.Plan planFilterOnly = table.newScan().withFilter(filter).plan();
+        assertThat(planFilterOnly.splits().size()).isEqualTo(filesCount);
 
-        // Should read exactly 10 files (from index 25 to 34) to get 10 rows
-        assertThat(splitsWithFilterAndLimit).isLessThanOrEqualTo(10);
-        assertThat(splitsWithFilterAndLimit).isGreaterThan(0);
-        assertThat(splitsWithFilterAndLimit).isLessThan(totalSplits);
+        List<String> allRows = getResult(table.newRead(), planFilterOnly.splits());
+        long totalMatchingRows =
+                allRows.stream().filter(r -> r.contains("|" + filterValue + "|")).count();
+        assertThat(totalMatchingRows).isEqualTo(filesCount);
+
+        int limit = 5;
+        TableScan.Plan planWithFilterAndLimit =
+                table.newScan().withFilter(filter).withLimit(limit).plan();
+
+        List<String> limitedAllRows = getResult(table.newRead(), planWithFilterAndLimit.splits());
+        long limitedMatchingRows =
+                limitedAllRows.stream().filter(r -> r.contains("|" + filterValue + "|")).count();
+
+        assertThat(limitedMatchingRows)
+                .as(
+                        "Filter+limit bug: scan returned %d splits, but only %d rows match "
+                                + "filter (expected >= %d). Total matching = %d",
+                        planWithFilterAndLimit.splits().size(),
+                        limitedMatchingRows,
+                        limit,
+                        totalMatchingRows)
+                .isGreaterThanOrEqualTo(limit);
 
         write.close();
         commit.close();


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query planning/scan optimization behavior by disabling limit-based early stopping when filters are applied, which can increase scan work and could affect performance/regressions in split planning.
> 
> **Overview**
> Fixes an incorrect *limit pushdown* optimization that could stop scanning too early when filters are present, leading to fewer matching rows than the requested limit.
> 
> `AppendOnlyFileStoreScan` and `KeyValueFileStoreScan` now disable limit-by-`rowCount()` early-stop whenever any data/key/value filter is applied, and `DataTableBatchScan` skips split-level limit pushdown when `SnapshotReader` reports remaining non-partition predicates (tracked via new `SnapshotReader.hasNonPartitionFilter()` and implemented in `SnapshotReaderImpl`/`AuditLogTable`). Tests are updated/added to assert limit pushdown is disabled for non-partition filters while still working for partition-only filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616344670a0c669738c4046d0a2d1dab05a85dba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->