### PR TITLE
[deploy] Fix JDK 17 deploy script to use renamed Spark4 module artifa…

### DIFF
--- a/tools/releasing/deploy_staging_jars_for_jdk17.sh
+++ b/tools/releasing/deploy_staging_jars_for_jdk17.sh
@@ -47,6 +47,6 @@ ${MVN} clean install -ntp -Pdocs-and-source,spark4 -DskipTests -pl paimon-spark/
 
 echo "Deploying spark4 module to repository.apache.org"
 ${MVN} deploy -ntp -Papache-release,docs-and-source,spark4 -DskipTests -DretryFailedDeploymentCount=10 \
- -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark4-common,org.apache.paimon:paimon-spark-4.0 $CUSTOM_OPTIONS
+ -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark4-common_2.13,org.apache.paimon:paimon-spark-4.0_2.13 $CUSTOM_OPTIONS
 
 cd ${CURR_DIR}


### PR DESCRIPTION
…ctIds

### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Maven `-pl` artifact coordinates in a release helper script, affecting staging deployment selection but not runtime code.
> 
> **Overview**
> Updates the JDK 17 staging deploy script to deploy the renamed Spark 4 Scala 2.13 artifacts by switching the Maven `-pl` list to `paimon-spark4-common_2.13` and `paimon-spark-4.0_2.13` (instead of the non-suffixed coordinates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd28ca4c751556e5f7cc8c9e44a6e6d3b233797. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->