### PR TITLE
[python] Fix blob read OOM by wrapping lazy stream in BlobRef

### DIFF
--- a/paimon-python/pypaimon/table/row/blob.py
+++ b/paimon-python/pypaimon/table/row/blob.py
@@ -213,8 +213,9 @@ class OffsetInputStream(io.RawIOBase):
             if self._length != -1:
                 target = self._offset + self._length + pos
             else:
-                result = self._wrapped.seek(pos, io.SEEK_END)
-                return max(result - self._offset, 0)
+                target = self._wrapped.seek(pos, io.SEEK_END)
+                target = max(target, self._offset)
+                return self._wrapped.seek(target) - self._offset
             target = max(target, self._offset)
         else:
             raise ValueError(f"Invalid whence: {whence}")

--- a/paimon-python/pypaimon/table/row/blob.py
+++ b/paimon-python/pypaimon/table/row/blob.py
@@ -213,9 +213,8 @@ class OffsetInputStream(io.RawIOBase):
             if self._length != -1:
                 target = self._offset + self._length + pos
             else:
-                target = self._wrapped.seek(pos, io.SEEK_END)
-                target = max(target, self._offset)
-                return self._wrapped.seek(target) - self._offset
+                end = self._wrapped.seek(0, io.SEEK_END)
+                target = max(end + pos, self._offset)
             target = max(target, self._offset)
         else:
             raise ValueError(f"Invalid whence: {whence}")

--- a/paimon-python/pypaimon/table/row/blob.py
+++ b/paimon-python/pypaimon/table/row/blob.py
@@ -19,7 +19,7 @@
 import io
 import struct
 from abc import ABC, abstractmethod
-from typing import Optional, Union
+from typing import BinaryIO, Optional, Union
 from urllib.parse import urlparse
 
 from pypaimon.common.uri_reader import UriReader, FileUriReader
@@ -163,6 +163,61 @@ class BlobDescriptor:
         return self.__str__()
 
 
+class OffsetInputStream(io.RawIOBase):
+
+    def __init__(self, wrapped, offset: int, length: int):
+        self._wrapped = wrapped
+        self._offset = offset
+        self._length = length
+        if offset != 0:
+            wrapped.seek(offset)
+
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return True
+
+    def readinto(self, b):
+        if self._length != -1:
+            remaining = self._length - self.tell()
+            if remaining <= 0:
+                return 0
+            if len(b) > remaining:
+                b = memoryview(b)[:remaining]
+        n = self._wrapped.readinto(b)
+        return n if n is not None else 0
+
+    def read(self, size=-1):
+        if self._length != -1:
+            remaining = self._length - self.tell()
+            if remaining <= 0:
+                return b''
+            if size == -1 or size > remaining:
+                size = remaining
+        return self._wrapped.read(size)
+
+    def seek(self, pos, whence=io.SEEK_SET):
+        if whence == io.SEEK_SET:
+            return self._wrapped.seek(self._offset + pos) - self._offset
+        elif whence == io.SEEK_CUR:
+            return self._wrapped.seek(pos, io.SEEK_CUR) - self._offset
+        elif whence == io.SEEK_END:
+            if self._length != -1:
+                return self._wrapped.seek(self._offset + self._length + pos) - self._offset
+            else:
+                return self._wrapped.seek(pos, io.SEEK_END) - self._offset
+        raise ValueError(f"Invalid whence: {whence}")
+
+    def tell(self) -> int:
+        return self._wrapped.tell() - self._offset
+
+    def close(self):
+        if not self.closed:
+            self._wrapped.close()
+            super().close()
+
+
 class Blob(ABC):
 
     @abstractmethod
@@ -174,7 +229,7 @@ class Blob(ABC):
         pass
 
     @abstractmethod
-    def new_input_stream(self) -> io.BytesIO:
+    def new_input_stream(self) -> BinaryIO:
         pass
 
     @staticmethod
@@ -236,7 +291,7 @@ class BlobData(Blob):
     def to_descriptor(self) -> 'BlobDescriptor':
         raise RuntimeError("Blob data can not convert to descriptor.")
 
-    def new_input_stream(self) -> io.BytesIO:
+    def new_input_stream(self) -> BinaryIO:
         return io.BytesIO(self._data)
 
     def __eq__(self, other) -> bool:
@@ -264,18 +319,12 @@ class BlobRef(Blob):
     def to_descriptor(self) -> BlobDescriptor:
         return self._descriptor
 
-    def new_input_stream(self) -> io.BytesIO:
+    def new_input_stream(self) -> BinaryIO:
         uri = self._descriptor.uri
         offset = self._descriptor.offset
         length = self._descriptor.length
-        with self._uri_reader.new_input_stream(uri) as input_stream:
-            if offset > 0:
-                input_stream.seek(offset)
-            if length == -1:
-                data = input_stream.read()
-            else:
-                data = input_stream.read(length)
-            return io.BytesIO(data)
+        stream = self._uri_reader.new_input_stream(uri)
+        return OffsetInputStream(stream, offset, length)
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, BlobRef):

--- a/paimon-python/pypaimon/table/row/blob.py
+++ b/paimon-python/pypaimon/table/row/blob.py
@@ -201,15 +201,22 @@ class OffsetInputStream(io.RawIOBase):
 
     def seek(self, pos, whence=io.SEEK_SET):
         if whence == io.SEEK_SET:
-            return self._wrapped.seek(self._offset + pos) - self._offset
+            if pos < 0:
+                raise ValueError(f"Negative seek position: {pos}")
+            target = self._offset + pos
         elif whence == io.SEEK_CUR:
-            return self._wrapped.seek(pos, io.SEEK_CUR) - self._offset
+            target = self._wrapped.tell() + pos
+            target = max(target, self._offset)
         elif whence == io.SEEK_END:
             if self._length != -1:
-                return self._wrapped.seek(self._offset + self._length + pos) - self._offset
+                target = self._offset + self._length + pos
             else:
-                return self._wrapped.seek(pos, io.SEEK_END) - self._offset
-        raise ValueError(f"Invalid whence: {whence}")
+                result = self._wrapped.seek(pos, io.SEEK_END)
+                return max(result - self._offset, 0)
+            target = max(target, self._offset)
+        else:
+            raise ValueError(f"Invalid whence: {whence}")
+        return self._wrapped.seek(target) - self._offset
 
     def tell(self) -> int:
         return self._wrapped.tell() - self._offset

--- a/paimon-python/pypaimon/table/row/blob.py
+++ b/paimon-python/pypaimon/table/row/blob.py
@@ -189,6 +189,8 @@ class OffsetInputStream(io.RawIOBase):
         return n if n is not None else 0
 
     def read(self, size=-1):
+        if size is None:
+            size = -1
         if self._length != -1:
             remaining = self._length - self.tell()
             if remaining <= 0:
@@ -333,7 +335,11 @@ class BlobRef(Blob):
         offset = self._descriptor.offset
         length = self._descriptor.length
         stream = self._uri_reader.new_input_stream(uri)
-        return OffsetInputStream(stream, offset, length)
+        try:
+            return OffsetInputStream(stream, offset, length)
+        except Exception:
+            stream.close()
+            raise
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, BlobRef):

--- a/paimon-python/pypaimon/table/row/blob.py
+++ b/paimon-python/pypaimon/table/row/blob.py
@@ -193,9 +193,9 @@ class OffsetInputStream(io.RawIOBase):
             remaining = self._length - self.tell()
             if remaining <= 0:
                 return b''
-            if size == -1 or size > remaining:
+            if size < 0 or size > remaining:
                 size = remaining
-        if size == -1:
+        if size < 0:
             return self._wrapped.read()
         return self._wrapped.read(size)
 

--- a/paimon-python/pypaimon/table/row/blob.py
+++ b/paimon-python/pypaimon/table/row/blob.py
@@ -195,6 +195,8 @@ class OffsetInputStream(io.RawIOBase):
                 return b''
             if size == -1 or size > remaining:
                 size = remaining
+        if size == -1:
+            return self._wrapped.read()
         return self._wrapped.read(size)
 
     def seek(self, pos, whence=io.SEEK_SET):

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -1236,6 +1236,32 @@ class OffsetInputStreamTest(unittest.TestCase):
         self.assertEqual(stream.tell(), 10)
         stream.close()
 
+    def test_seek_set_negative_raises(self):
+        from pypaimon.table.row.blob import OffsetInputStream
+        stream = OffsetInputStream(io.BytesIO(self.test_data), 5, 10)
+        with self.assertRaises(ValueError):
+            stream.seek(-1, io.SEEK_SET)
+        stream.close()
+
+    def test_seek_cur_underflow_clamps_to_zero(self):
+        from pypaimon.table.row.blob import OffsetInputStream
+        stream = OffsetInputStream(io.BytesIO(self.test_data), 5, 10)
+        stream.seek(2)
+        stream.seek(-5, io.SEEK_CUR)
+        self.assertEqual(stream.tell(), 0)
+        data = stream.read(1)
+        self.assertEqual(data[0], self.test_data[5])
+        stream.close()
+
+    def test_seek_end_underflow_clamps_to_zero(self):
+        from pypaimon.table.row.blob import OffsetInputStream
+        stream = OffsetInputStream(io.BytesIO(self.test_data), 5, 10)
+        stream.seek(-20, io.SEEK_END)
+        self.assertEqual(stream.tell(), 0)
+        data = stream.read(1)
+        self.assertEqual(data[0], self.test_data[5])
+        stream.close()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import io
 import os
 import shutil
 import struct
@@ -1156,6 +1157,84 @@ class BlobEndToEndTest(unittest.TestCase):
         # With blob_as_descriptor=False, we should get the actual blob content
         self.assertEqual(read_content_bytes, test_content)
         reader_content.close()
+
+
+class OffsetInputStreamTest(unittest.TestCase):
+
+    def setUp(self):
+        self.test_data = bytes(range(20))
+        self.wrapped = io.BytesIO(self.test_data)
+
+    def test_constructor(self):
+        from pypaimon.table.row.blob import OffsetInputStream
+        stream = OffsetInputStream(io.BytesIO(self.test_data), 5, 10)
+        self.assertEqual(stream.tell(), 0)
+        stream.close()
+
+    def test_get_pos_and_seek(self):
+        from pypaimon.table.row.blob import OffsetInputStream
+        stream = OffsetInputStream(io.BytesIO(self.test_data), 5, 10)
+        stream.seek(3)
+        self.assertEqual(stream.tell(), 3)
+        stream.seek(10)
+        self.assertEqual(stream.tell(), 10)
+        stream.seek(0)
+        self.assertEqual(stream.tell(), 0)
+        stream.close()
+
+    def test_read_single_byte(self):
+        from pypaimon.table.row.blob import OffsetInputStream
+        stream = OffsetInputStream(io.BytesIO(self.test_data), 5, 10)
+        data = stream.read(1)
+        self.assertEqual(data[0], self.test_data[5])
+        self.assertEqual(stream.tell(), 1)
+        stream.seek(9)
+        data = stream.read(1)
+        self.assertEqual(data[0], self.test_data[14])
+        self.assertEqual(stream.tell(), 10)
+        stream.close()
+
+    def test_read_single_byte_at_end(self):
+        from pypaimon.table.row.blob import OffsetInputStream
+        stream = OffsetInputStream(io.BytesIO(self.test_data), 5, 10)
+        stream.seek(10)
+        data = stream.read(1)
+        self.assertEqual(data, b'')
+        stream.close()
+
+    def test_read_byte_array(self):
+        from pypaimon.table.row.blob import OffsetInputStream
+        stream = OffsetInputStream(io.BytesIO(self.test_data), 5, 10)
+        data = stream.read(5)
+        self.assertEqual(data, self.test_data[5:10])
+        self.assertEqual(stream.tell(), 5)
+        stream.close()
+
+    def test_read_byte_array_hitting_end(self):
+        from pypaimon.table.row.blob import OffsetInputStream
+        stream = OffsetInputStream(io.BytesIO(self.test_data), 5, 10)
+        stream.seek(7)
+        data = stream.read(5)
+        self.assertEqual(len(data), 3)
+        self.assertEqual(data, self.test_data[12:15])
+        self.assertEqual(stream.tell(), 10)
+        stream.close()
+
+    def test_read_byte_array_at_end(self):
+        from pypaimon.table.row.blob import OffsetInputStream
+        stream = OffsetInputStream(io.BytesIO(self.test_data), 5, 10)
+        stream.seek(10)
+        data = stream.read(5)
+        self.assertEqual(data, b'')
+        stream.close()
+
+    def test_read_with_unlimited_length(self):
+        from pypaimon.table.row.blob import OffsetInputStream
+        stream = OffsetInputStream(io.BytesIO(self.test_data), 5, -1)
+        data = stream.read(10)
+        self.assertEqual(data, self.test_data[5:15])
+        self.assertEqual(stream.tell(), 10)
+        stream.close()
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -1262,6 +1262,15 @@ class OffsetInputStreamTest(unittest.TestCase):
         self.assertEqual(data[0], self.test_data[5])
         stream.close()
 
+    def test_seek_end_underflow_unlimited_length(self):
+        from pypaimon.table.row.blob import OffsetInputStream
+        stream = OffsetInputStream(io.BytesIO(self.test_data), 5, -1)
+        stream.seek(-30, io.SEEK_END)
+        self.assertEqual(stream.tell(), 0)
+        data = stream.read(2)
+        self.assertEqual(data, self.test_data[5:7])
+        stream.close()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -1271,6 +1271,32 @@ class OffsetInputStreamTest(unittest.TestCase):
         self.assertEqual(data, self.test_data[5:7])
         stream.close()
 
+    def test_seek_end_with_real_file(self):
+        from pypaimon.table.row.blob import OffsetInputStream
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(self.test_data)
+            tmp_path = tmp.name
+        try:
+            f = open(tmp_path, 'rb')
+            stream = OffsetInputStream(f, 5, 10)
+            stream.seek(0, io.SEEK_END)
+            self.assertEqual(stream.tell(), 10)
+            stream.seek(-3, io.SEEK_END)
+            self.assertEqual(stream.tell(), 7)
+            data = stream.read(3)
+            self.assertEqual(data, self.test_data[12:15])
+            stream.close()
+
+            f = open(tmp_path, 'rb')
+            stream = OffsetInputStream(f, 5, -1)
+            stream.seek(-30, io.SEEK_END)
+            self.assertEqual(stream.tell(), 0)
+            data = stream.read(2)
+            self.assertEqual(data, self.test_data[5:7])
+            stream.close()
+        finally:
+            os.remove(tmp_path)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes blob I/O to return a wrapped streaming view instead of materializing bytes, which can affect callers that assume `BytesIO` semantics and introduces new seek/read boundary logic that must be correct to avoid partial reads.
> 
> **Overview**
> Prevents potential OOM when reading `BlobRef` by **stopping eager materialization** of the referenced data into an in-memory `BytesIO`; `BlobRef.new_input_stream()` now returns a lazy stream wrapped by a new `OffsetInputStream` that enforces `offset`/`length` boundaries.
> 
> Updates the `Blob`/`BlobData` stream-return type to `BinaryIO` and adds a focused `OffsetInputStreamTest` suite covering reads and seek behavior (including end/underflow and unlimited-length cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28e29e6c37b2ac37f209a340061d3bd2bef21aba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->