### PR TITLE
[core] Optimize error message when creating PK table with row-trackin…

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -648,13 +648,13 @@ public class SchemaValidation {
         boolean rowTrackingEnabled = options.rowTrackingEnabled();
         if (rowTrackingEnabled) {
             checkArgument(
-                    options.bucket() == -1,
-                    "Cannot define %s for row tracking table, it only support bucket = -1",
-                    CoreOptions.BUCKET.key());
-            checkArgument(
                     schema.primaryKeys().isEmpty(),
                     "Cannot define %s for row tracking table.",
                     PRIMARY_KEY.key());
+            checkArgument(
+                    options.bucket() == -1,
+                    "Cannot define %s for row tracking table, it only support bucket = -1",
+                    CoreOptions.BUCKET.key());
         }
 
         if (options.dataEvolutionEnabled()) {

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -314,4 +314,31 @@ class SchemaValidationTest {
                 .hasMessage(
                         "Data evolution config must enabled for table with vector-store file format.");
     }
+
+    @Test
+    void testRowTrackingWithPkTable() {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(BUCKET.key(), String.valueOf(-2));
+
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "f0", DataTypes.INT()),
+                        new DataField(1, "f1", DataTypes.INT()),
+                        new DataField(2, "f2", DataTypes.STRING()));
+        List<String> primaryKeys = singletonList("f1");
+
+        assertThatThrownBy(
+                        () ->
+                                validateTableSchema(
+                                        new TableSchema(
+                                                1,
+                                                fields,
+                                                10,
+                                                emptyList(),
+                                                primaryKeys,
+                                                options,
+                                                "")))
+                .hasMessageContaining("primary-key");
+    }
 }


### PR DESCRIPTION
…g enabled

### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only reorders validation checks to improve error messaging and adds a targeted unit test; no behavioral change beyond which invalid option is reported first.
> 
> **Overview**
> Improves schema validation error reporting for `row-tracking.enabled` tables by **checking for disallowed `primary-key` before validating `bucket`** so users see the more relevant failure first.
> 
> Adds a regression test (`testRowTrackingWithPkTable`) to ensure creating a row-tracking table with a primary key surfaces a *primary-key-related* error even if other options (e.g., `bucket`) are also invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a69be27054627e0ebfa8a08378aa28b01f4c694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->