### PR TITLE
[core] Skip file index for changelog files

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileWriterFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileWriterFactory.java
@@ -149,6 +149,8 @@ public class KeyValueFileWriterFactory {
 
     private KeyValueDataFileWriter createDataFileWriter(
             Path path, WriteFormatKey key, FileSource fileSource, boolean isExternalPath) {
+        // Changelog is sequentially consumed, file index is unnecessary.
+        FileIndexOptions indexOptions = key.isChangelog ? new FileIndexOptions() : fileIndexOptions;
         return formatContext.thinModeEnabled
                 ? new KeyValueThinDataFileWriterImpl(
                         fileIO,
@@ -161,7 +163,7 @@ public class KeyValueFileWriterFactory {
                         key.level,
                         options,
                         fileSource,
-                        fileIndexOptions,
+                        indexOptions,
                         isExternalPath)
                 : new KeyValueDataFileWriterImpl(
                         fileIO,
@@ -174,7 +176,7 @@ public class KeyValueFileWriterFactory {
                         key.level,
                         options,
                         fileSource,
-                        fileIndexOptions,
+                        indexOptions,
                         isExternalPath);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
@@ -308,11 +308,16 @@ public class KeyValueFileReadWriteTest {
     }
 
     protected KeyValueFileWriterFactory createWriterFactory(String pathStr, String format) {
+        Options options = new Options();
+        options.set(CoreOptions.METADATA_STATS_MODE, "FULL");
+        return createWriterFactory(pathStr, format, options);
+    }
+
+    protected KeyValueFileWriterFactory createWriterFactory(
+            String pathStr, String format, Options options) {
         Path path = new Path(pathStr);
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         FileIO fileIO = FileIOFinder.find(path);
-        Options options = new Options();
-        options.set(CoreOptions.METADATA_STATS_MODE, "FULL");
 
         Function<String, FileStorePathFactory> pathFactoryMap =
                 format1 ->
@@ -452,6 +457,49 @@ public class KeyValueFileReadWriteTest {
         // expected.level == eachFile.level
         for (DataFileMeta meta : actual) {
             assertThat(meta.level()).isEqualTo(expected.level());
+        }
+    }
+
+    @Test
+    void testChangelogFile() throws Exception {
+        Options options = new Options();
+        options.set(CoreOptions.METADATA_STATS_MODE, "FULL");
+        options.setString("file-index.bloom-filter.columns", "comment");
+        options.setString("file-index.in-manifest-threshold", "1B");
+
+        KeyValueFileWriterFactory writerFactory =
+                createWriterFactory(tempDir.toString(), "avro", options);
+
+        DataFileTestDataGenerator.Data data = gen.next();
+        RollingFileWriter<KeyValue, DataFileMeta> dataWriter =
+                writerFactory.createRollingMergeTreeFileWriter(0, FileSource.APPEND);
+        dataWriter.write(CloseableIterator.fromList(data.content, kv -> {}));
+        dataWriter.close();
+        List<DataFileMeta> dataFileMetas = dataWriter.result();
+
+        assertThat(dataFileMetas).isNotEmpty();
+        assertThat(
+                        dataFileMetas.stream()
+                                .anyMatch(
+                                        meta ->
+                                                meta.extraFiles().stream()
+                                                        .anyMatch(
+                                                                f ->
+                                                                        f.endsWith(
+                                                                                DataFilePathFactory
+                                                                                        .INDEX_PATH_SUFFIX))))
+                .isTrue();
+
+        RollingFileWriter<KeyValue, DataFileMeta> changelogWriter =
+                writerFactory.createRollingChangelogFileWriter(0);
+        changelogWriter.write(CloseableIterator.fromList(data.content, kv -> {}));
+        changelogWriter.close();
+        List<DataFileMeta> changelogMetas = changelogWriter.result();
+
+        assertThat(changelogMetas).isNotEmpty();
+        for (DataFileMeta meta : changelogMetas) {
+            assertThat(meta.extraFiles())
+                    .noneMatch(f -> f.endsWith(DataFilePathFactory.INDEX_PATH_SUFFIX));
         }
     }
 


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limits file-index generation to non-changelog data files; behavior change is scoped but could affect any code path that expected indexes on changelog files.
> 
> **Overview**
> Changelog `KeyValue` files written via `KeyValueFileWriterFactory` now **skip file index generation** by passing an empty `FileIndexOptions` when `WriteFormatKey.isChangelog` is true.
> 
> Adds a regression test (`testChangelogFile`) to assert that normal data files still produce index extra files when file-index options are enabled, while changelog files do not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d47db98291c0fa8ad66f61a971896e7fa53ca6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->