### PR TITLE
Lance support rowtracking

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
@@ -66,23 +66,31 @@ public class ArrowBatchReader {
         this.caseSensitive = caseSensitive;
     }
 
+    /** A {@link ColumnVector} that always returns null for any position. */
+    private static final ColumnVector NULL_COLUMN_VECTOR = i -> true;
+
     public Iterable<InternalRow> readBatch(VectorSchemaRoot vsr) {
         int[] mapping = new int[projectedRowType.getFieldCount()];
         Schema arrowSchema = vsr.getSchema();
         List<DataField> dataFields = projectedRowType.getFields();
         for (int i = 0; i < dataFields.size(); ++i) {
+            String fieldName = dataFields.get(i).name();
             try {
-                String fieldName = dataFields.get(i).name();
                 Field field = arrowSchema.findField(toLowerCaseIfNeed(fieldName, caseSensitive));
-                int idx = arrowSchema.getFields().indexOf(field);
-                mapping[i] = idx;
+                mapping[i] = arrowSchema.getFields().indexOf(field);
             } catch (IllegalArgumentException e) {
-                throw new RuntimeException(e);
+                // Field does not exist in the Arrow schema (e.g., virtual system fields
+                // like _ROW_ID, _SEQUENCE_NUMBER). Mark as missing; will use null vector.
+                mapping[i] = -1;
             }
         }
 
         for (int i = 0; i < batch.columns.length; i++) {
-            batch.columns[i] = convertors[i].convertVector(vsr.getVector(mapping[i]));
+            if (mapping[i] >= 0) {
+                batch.columns[i] = convertors[i].convertVector(vsr.getVector(mapping[i]));
+            } else {
+                batch.columns[i] = NULL_COLUMN_VECTOR;
+            }
         }
 
         int rowCount = vsr.getRowCount();

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
@@ -30,8 +30,10 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import static org.apache.paimon.utils.StringUtils.toLowerCaseIfNeed;
 
@@ -72,15 +74,16 @@ public class ArrowBatchReader {
     public Iterable<InternalRow> readBatch(VectorSchemaRoot vsr) {
         int[] mapping = new int[projectedRowType.getFieldCount()];
         Schema arrowSchema = vsr.getSchema();
+        Set<String> arrowFieldNames = new HashSet<>();
+        for (Field f : arrowSchema.getFields()) {
+            arrowFieldNames.add(f.getName());
+        }
         List<DataField> dataFields = projectedRowType.getFields();
         for (int i = 0; i < dataFields.size(); ++i) {
-            String fieldName = dataFields.get(i).name();
-            try {
-                Field field = arrowSchema.findField(toLowerCaseIfNeed(fieldName, caseSensitive));
-                mapping[i] = arrowSchema.getFields().indexOf(field);
-            } catch (IllegalArgumentException e) {
-                // Field does not exist in the Arrow schema (e.g., virtual system fields
-                // like _ROW_ID, _SEQUENCE_NUMBER). Mark as missing; will use null vector.
+            String fieldName = toLowerCaseIfNeed(dataFields.get(i).name(), caseSensitive);
+            if (arrowFieldNames.contains(fieldName)) {
+                mapping[i] = arrowSchema.getFields().indexOf(arrowSchema.findField(fieldName));
+            } else {
                 mapping[i] = -1;
             }
         }

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
@@ -76,7 +76,7 @@ public class ArrowBatchReader {
         Schema arrowSchema = vsr.getSchema();
         Set<String> arrowFieldNames = new HashSet<>();
         for (Field f : arrowSchema.getFields()) {
-            arrowFieldNames.add(f.getName());
+            arrowFieldNames.add(toLowerCaseIfNeed(f.getName(), caseSensitive));
         }
         List<DataField> dataFields = projectedRowType.getFields();
         for (int i = 0; i < dataFields.size(); ++i) {

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
@@ -30,10 +30,10 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import static org.apache.paimon.utils.StringUtils.toLowerCaseIfNeed;
 
@@ -74,18 +74,15 @@ public class ArrowBatchReader {
     public Iterable<InternalRow> readBatch(VectorSchemaRoot vsr) {
         int[] mapping = new int[projectedRowType.getFieldCount()];
         Schema arrowSchema = vsr.getSchema();
-        Set<String> arrowFieldNames = new HashSet<>();
-        for (Field f : arrowSchema.getFields()) {
-            arrowFieldNames.add(toLowerCaseIfNeed(f.getName(), caseSensitive));
+        Map<String, Integer> arrowFieldIndex = new HashMap<>();
+        List<Field> arrowFields = arrowSchema.getFields();
+        for (int j = 0; j < arrowFields.size(); j++) {
+            arrowFieldIndex.put(toLowerCaseIfNeed(arrowFields.get(j).getName(), caseSensitive), j);
         }
         List<DataField> dataFields = projectedRowType.getFields();
         for (int i = 0; i < dataFields.size(); ++i) {
             String fieldName = toLowerCaseIfNeed(dataFields.get(i).name(), caseSensitive);
-            if (arrowFieldNames.contains(fieldName)) {
-                mapping[i] = arrowSchema.getFields().indexOf(arrowSchema.findField(fieldName));
-            } else {
-                mapping[i] = -1;
-            }
+            mapping[i] = arrowFieldIndex.getOrDefault(fieldName, -1);
         }
 
         for (int i = 0; i < batch.columns.length; i++) {

--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -33,6 +33,7 @@ import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder;
+import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
@@ -51,6 +52,7 @@ import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.sink.InnerTableCommit;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
@@ -986,6 +988,90 @@ public class JavaPyE2ETest {
         Identifier id = identifier("compact_conflict_test");
         doDataEvolutionCompact((FileStoreTable) catalog.getTable(id));
         LOG.info("compact_conflict_test: compact done, 5 files merged into 1 (1000 rows)");
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
+    public void testDataEvolutionWrite() throws Exception {
+        for (String format : Arrays.asList("parquet", "orc", "avro")) {
+            Identifier identifier = identifier("data_evolution_test_" + format);
+            catalog.dropTable(identifier, true);
+            Schema schema =
+                    Schema.newBuilder()
+                            .column("f0", DataTypes.INT())
+                            .column("f1", DataTypes.STRING())
+                            .column("f2", DataTypes.STRING())
+                            .option(ROW_TRACKING_ENABLED.key(), "true")
+                            .option(DATA_EVOLUTION_ENABLED.key(), "true")
+                            .option(CoreOptions.FILE_FORMAT.key(), format)
+                            .build();
+            catalog.createTable(identifier, schema, false);
+
+            RowType writeType0 = schema.rowType().project(Arrays.asList("f0", "f1"));
+            RowType writeType1 = schema.rowType().project(Collections.singletonList("f2"));
+
+            FileStoreTable table = (FileStoreTable) catalog.getTable(identifier);
+            BatchWriteBuilder builder = table.newBatchWriteBuilder();
+
+            // Write (f0, f1) columns
+            try (BatchTableWrite write = builder.newWrite().withWriteType(writeType0)) {
+                for (int i = 0; i < 5; i++) {
+                    write.write(GenericRow.of(i, BinaryString.fromString("a" + i)));
+                }
+                builder.newCommit().commit(write.prepareCommit());
+            }
+
+            // Write (f2) column with setFirstRowId
+            table = (FileStoreTable) catalog.getTable(identifier);
+            long rowId = table.snapshotManager().latestSnapshot().nextRowId() - 5;
+            builder = table.newBatchWriteBuilder();
+            try (BatchTableWrite write = builder.newWrite().withWriteType(writeType1)) {
+                for (int i = 0; i < 5; i++) {
+                    write.write(GenericRow.of(BinaryString.fromString("b" + i)));
+                }
+                List<CommitMessage> messages = write.prepareCommit();
+                setFirstRowId(messages, rowId);
+                builder.newCommit().commit(messages);
+            }
+
+            LOG.info("data_evolution_test_{}: written 5 rows with partial columns", format);
+        }
+    }
+
+    /** Read data evolution tables written by Python. */
+    @Test
+    @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
+    public void testReadDataEvolutionTable() throws Exception {
+        for (String format : Arrays.asList("parquet", "orc", "avro")) {
+            Identifier identifier = identifier("data_evolution_test_py_" + format);
+            FileStoreTable table = (FileStoreTable) catalog.getTable(identifier);
+            ReadBuilder readBuilder = table.newReadBuilder();
+            List<Split> splits = new ArrayList<>(readBuilder.newScan().plan().splits());
+            TableRead read = readBuilder.newRead();
+            List<String> res =
+                    getResult(
+                            read,
+                            splits,
+                            row -> DataFormatTestUtil.toStringNoRowKind(row, table.rowType()));
+            assertThat(res).hasSize(5);
+            LOG.info("data_evolution_test_py_{}: read {} rows", format, res.size());
+        }
+    }
+
+    private void setFirstRowId(List<CommitMessage> messages, long firstRowId) {
+        messages.forEach(
+                c -> {
+                    CommitMessageImpl impl = (CommitMessageImpl) c;
+                    List<DataFileMeta> newFiles =
+                            new ArrayList<>(impl.newFilesIncrement().newFiles());
+                    impl.newFilesIncrement().newFiles().clear();
+                    impl.newFilesIncrement()
+                            .newFiles()
+                            .addAll(
+                                    newFiles.stream()
+                                            .map(f -> f.assignFirstRowId(firstRowId))
+                                            .collect(Collectors.toList()));
+                });
     }
 
     private void doDataEvolutionCompact(FileStoreTable table) throws Exception {

--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceReaderFactory.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceReaderFactory.java
@@ -22,6 +22,7 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FormatReaderFactory;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.reader.EmptyFileRecordReader;
 import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Pair;
@@ -52,6 +53,9 @@ public class LanceReaderFactory implements FormatReaderFactory {
         RoaringBitmap32 roaringBitmap32 = context.selection();
         if (roaringBitmap32 != null) {
             selectionRangesArray = toRangeArray(roaringBitmap32);
+            if (selectionRangesArray.isEmpty()) {
+                return new EmptyFileRecordReader<>();
+            }
         }
 
         Pair<Path, Map<String, String>> lanceSpecified =

--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceRecordsReader.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceRecordsReader.java
@@ -39,13 +39,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-/** File reade for lance. */
+/** File reader for lance. */
 public class LanceRecordsReader implements FileRecordReader<InternalRow> {
 
     private final ArrowBatchReader arrowBatchReader;
     private final Path filePath;
     private final LanceReader reader;
     private final PositionGenerator positionGenerator;
+
+    // Hold the current VectorSchemaRoot to keep Arrow memory alive until the next batch
+    // is loaded or the reader is closed. This avoids SIGSEGV when rows collected from
+    // the batch are accessed after releaseBatch() is called.
+    @Nullable private VectorSchemaRoot currentVsr;
 
     public LanceRecordsReader(
             Path path,
@@ -77,7 +82,9 @@ public class LanceRecordsReader implements FileRecordReader<InternalRow> {
     @Override
     public FileRecordIterator<InternalRow> readBatch() throws IOException {
         try {
+            closePreviousBatch();
             VectorSchemaRoot vsr = reader.readBatch();
+            this.currentVsr = vsr;
             Iterator<InternalRow> rows = arrowBatchReader.readBatch(vsr).iterator();
             return new FileRecordIterator<InternalRow>() {
                 @Override
@@ -103,7 +110,9 @@ public class LanceRecordsReader implements FileRecordReader<InternalRow> {
 
                 @Override
                 public void releaseBatch() {
-                    vsr.close();
+                    // Do not close vsr here. Arrow memory is kept alive until the next
+                    // batch is loaded or the reader is closed, so that ColumnarRow
+                    // references remain valid after releaseBatch().
                 }
             };
         } catch (EOFException e) {
@@ -111,8 +120,16 @@ public class LanceRecordsReader implements FileRecordReader<InternalRow> {
         }
     }
 
+    private void closePreviousBatch() {
+        if (currentVsr != null) {
+            currentVsr.close();
+            currentVsr = null;
+        }
+    }
+
     @Override
     public void close() throws IOException {
+        closePreviousBatch();
         this.reader.close();
     }
 

--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceRecordsReader.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceRecordsReader.java
@@ -82,8 +82,10 @@ public class LanceRecordsReader implements FileRecordReader<InternalRow> {
     @Override
     public FileRecordIterator<InternalRow> readBatch() throws IOException {
         try {
-            closePreviousBatch();
             VectorSchemaRoot vsr = reader.readBatch();
+            // Hold reference to prevent GC of off-heap Arrow memory (SIGSEGV fix).
+            // Do NOT close the previous VSR here — ArrowReader reuses the same
+            // VectorSchemaRoot across batches, closing it would release shared buffers.
             this.currentVsr = vsr;
             Iterator<InternalRow> rows = arrowBatchReader.readBatch(vsr).iterator();
             return new FileRecordIterator<InternalRow>() {
@@ -120,16 +122,9 @@ public class LanceRecordsReader implements FileRecordReader<InternalRow> {
         }
     }
 
-    private void closePreviousBatch() {
-        if (currentVsr != null) {
-            currentVsr.close();
-            currentVsr = null;
-        }
-    }
-
     @Override
     public void close() throws IOException {
-        closePreviousBatch();
+        this.currentVsr = null;
         this.reader.close();
     }
 

--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceRecordsReader.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceRecordsReader.java
@@ -143,10 +143,11 @@ public class LanceRecordsReader implements FileRecordReader<InternalRow> {
     private static class RangePositionGenerator implements PositionGenerator {
         private final List<Range> ranges;
         private int currentRangeIndex = 0;
-        private int currentPosition = -1;
+        private int currentPosition;
 
         public RangePositionGenerator(List<Range> ranges) {
             this.ranges = ranges;
+            this.currentPosition = ranges.get(0).getStart() - 1;
         }
 
         @Override

--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/jni/LanceReader.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/jni/LanceReader.java
@@ -25,6 +25,7 @@ import com.lancedb.lance.util.Range;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.pojo.Field;
 
 import javax.annotation.Nullable;
 
@@ -32,6 +33,8 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Wrapper for Native Lance Reader. */
 public class LanceReader {
@@ -49,7 +52,18 @@ public class LanceReader {
         this.rootAllocator = new RootAllocator();
         try {
             this.reader = LanceFileReader.open(path, storageOptions, rootAllocator);
-            this.arrowReader = reader.readAll(projectedRowType.getFieldNames(), ranges, batchSize);
+            // Filter to only read columns that exist in the file schema.
+            // Virtual columns like _ROW_ID and _SEQUENCE_NUMBER are added by the framework
+            // but do not physically exist in the file.
+            Set<String> fileFieldNames =
+                    reader.schema().getFields().stream()
+                            .map(Field::getName)
+                            .collect(Collectors.toSet());
+            List<String> existingFields =
+                    projectedRowType.getFieldNames().stream()
+                            .filter(fileFieldNames::contains)
+                            .collect(Collectors.toList());
+            this.arrowReader = reader.readAll(existingFields, ranges, batchSize);
         } catch (IOException e) {
             throw new RuntimeException("Failed to open Lance file: " + path, e);
         }

--- a/paimon-lance/src/test/java/org/apache/paimon/JavaPyLanceE2ETest.java
+++ b/paimon-lance/src/test/java/org/apache/paimon/JavaPyLanceE2ETest.java
@@ -29,15 +29,22 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.lance.jni.LanceReader;
 import org.apache.paimon.format.lance.jni.LanceWriter;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.sink.InnerTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
+import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.TraceableFileIO;
 
 import org.apache.arrow.memory.RootAllocator;
@@ -58,10 +65,12 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.table.SimpleTableTestBase.getResult;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -315,6 +324,84 @@ public class JavaPyLanceE2ETest {
         } catch (Throwable t) {
             throw t;
         }
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
+    public void testDataEvolutionWriteLance() throws Exception {
+        Identifier identifier = identifier("data_evolution_test_lance");
+        catalog.dropTable(identifier, true);
+        Schema schema =
+                Schema.newBuilder()
+                        .column("f0", DataTypes.INT())
+                        .column("f1", DataTypes.STRING())
+                        .column("f2", DataTypes.STRING())
+                        .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                        .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                        .option(CoreOptions.FILE_FORMAT.key(), "lance")
+                        .build();
+        catalog.createTable(identifier, schema, false);
+
+        RowType writeType0 = schema.rowType().project(Arrays.asList("f0", "f1"));
+        RowType writeType1 = schema.rowType().project(Collections.singletonList("f2"));
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier);
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+
+        // Write (f0, f1) columns
+        try (BatchTableWrite write = builder.newWrite().withWriteType(writeType0)) {
+            for (int i = 0; i < 5; i++) {
+                write.write(GenericRow.of(i, BinaryString.fromString("a" + i)));
+            }
+            builder.newCommit().commit(write.prepareCommit());
+        }
+
+        // Write (f2) column with setFirstRowId
+        table = (FileStoreTable) catalog.getTable(identifier);
+        long rowId = table.snapshotManager().latestSnapshot().nextRowId() - 5;
+        builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = builder.newWrite().withWriteType(writeType1)) {
+            for (int i = 0; i < 5; i++) {
+                write.write(GenericRow.of(BinaryString.fromString("b" + i)));
+            }
+            List<CommitMessage> messages = write.prepareCommit();
+            setFirstRowId(messages, rowId);
+            builder.newCommit().commit(messages);
+        }
+    }
+
+    /** Read data evolution table with Lance format written by Python. */
+    @Test
+    @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
+    @DisabledIfSystemProperty(named = "python.version", matches = "3.6")
+    public void testReadDataEvolutionTableLance() throws Exception {
+        Identifier identifier = identifier("data_evolution_test_py_lance");
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier);
+        ReadBuilder readBuilder = table.newReadBuilder();
+        List<Split> splits = new ArrayList<>(readBuilder.newScan().plan().splits());
+        TableRead read = readBuilder.newRead();
+        List<String> res =
+                getResult(
+                        read,
+                        splits,
+                        row -> DataFormatTestUtil.toStringNoRowKind(row, table.rowType()));
+        assertThat(res).hasSize(5);
+    }
+
+    private void setFirstRowId(List<CommitMessage> messages, long firstRowId) {
+        messages.forEach(
+                c -> {
+                    CommitMessageImpl impl = (CommitMessageImpl) c;
+                    List<DataFileMeta> newFiles =
+                            new ArrayList<>(impl.newFilesIncrement().newFiles());
+                    impl.newFilesIncrement().newFiles().clear();
+                    impl.newFilesIncrement()
+                            .newFiles()
+                            .addAll(
+                                    newFiles.stream()
+                                            .map(f -> f.assignFirstRowId(firstRowId))
+                                            .collect(Collectors.toList()));
+                });
     }
 
     // Helper method from TableTestBase

--- a/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceRowTrackingTest.java
+++ b/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceRowTrackingTest.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.lance;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.DataEvolutionTestBase;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.TraceableFileIO;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/** Tests for Lance file format with row tracking and data evolution. */
+public class LanceRowTrackingTest extends DataEvolutionTestBase {
+
+    @BeforeEach
+    public void beforeEach() throws Catalog.DatabaseAlreadyExistException {
+        database = "default";
+        warehouse = new Path(TraceableFileIO.SCHEME + "://" + tempPath.toString());
+        Options options = new Options();
+        options.set(WAREHOUSE, warehouse.toUri().toString());
+        CatalogContext context = CatalogContext.create(options, new TraceableFileIO.Loader(), null);
+        catalog = CatalogFactory.createCatalog(context);
+        catalog.createDatabase(database, true);
+    }
+
+    @Override
+    protected Schema schemaDefault() {
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("f0", DataTypes.INT());
+        schemaBuilder.column("f1", DataTypes.STRING());
+        schemaBuilder.column("f2", DataTypes.STRING());
+        schemaBuilder.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.FILE_FORMAT.key(), "lance");
+        return schemaBuilder.build();
+    }
+
+    @Test
+    public void testBasicWriteRead() throws Exception {
+        createTableDefault();
+
+        Schema schema = schemaDefault();
+        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
+
+        try (BatchTableWrite write = builder.newWrite().withWriteType(schema.rowType())) {
+            write.write(
+                    GenericRow.of(1, BinaryString.fromString("a"), BinaryString.fromString("b")));
+            BatchTableCommit commit = builder.newCommit();
+            commit.commit(write.prepareCommit());
+        }
+
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan());
+        // Access row data inline within forEachRemaining. Arrow-backed ColumnarRow is a
+        // mutable view whose underlying off-heap memory is freed when the reader is closed
+        // (which happens inside forEachRemaining via ConcatRecordReader).
+        AtomicInteger count = new AtomicInteger(0);
+        reader.forEachRemaining(
+                r -> {
+                    assertThat(r.getInt(0)).isEqualTo(1);
+                    assertThat(r.getString(1).toString()).isEqualTo("a");
+                    assertThat(r.getString(2).toString()).isEqualTo("b");
+                    count.incrementAndGet();
+                });
+        assertThat(count.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void testAutoRowIdAssignment() throws Exception {
+        createTableDefault();
+
+        Schema schema = schemaDefault();
+        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
+
+        try (BatchTableWrite write = builder.newWrite().withWriteType(schema.rowType())) {
+            for (int i = 0; i < 5; i++) {
+                write.write(
+                        GenericRow.of(
+                                i,
+                                BinaryString.fromString("a" + i),
+                                BinaryString.fromString("b" + i)));
+            }
+            BatchTableCommit commit = builder.newCommit();
+            commit.commit(write.prepareCommit());
+        }
+
+        try (BatchTableWrite write = builder.newWrite().withWriteType(schema.rowType())) {
+            for (int i = 5; i < 10; i++) {
+                write.write(
+                        GenericRow.of(
+                                i,
+                                BinaryString.fromString("a" + i),
+                                BinaryString.fromString("b" + i)));
+            }
+            BatchTableCommit commit = builder.newCommit();
+            commit.commit(write.prepareCommit());
+        }
+
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan());
+        AtomicInteger count = new AtomicInteger(0);
+        reader.forEachRemaining(
+                r -> {
+                    int idx = r.getInt(0);
+                    assertThat(r.getString(1).toString()).isEqualTo("a" + idx);
+                    assertThat(r.getString(2).toString()).isEqualTo("b" + idx);
+                    count.incrementAndGet();
+                });
+        assertThat(count.get()).isEqualTo(10);
+    }
+
+    @Test
+    public void testDataEvolutionBasic() throws Exception {
+        createTableDefault();
+
+        Schema schema = schemaDefault();
+        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
+
+        try (BatchTableWrite write = builder.newWrite().withWriteType(schema.rowType())) {
+            write.write(
+                    GenericRow.of(1, BinaryString.fromString("a"), BinaryString.fromString("b")));
+            BatchTableCommit commit = builder.newCommit();
+            commit.commit(write.prepareCommit());
+        }
+
+        RowType writeType1 = schema.rowType().project(Collections.singletonList("f2"));
+        try (BatchTableWrite write1 = builder.newWrite().withWriteType(writeType1)) {
+            write1.write(GenericRow.of(BinaryString.fromString("c")));
+            BatchTableCommit commit = builder.newCommit();
+            List<CommitMessage> commitables = write1.prepareCommit();
+            setFirstRowId(commitables, 0L);
+            commit.commit(commitables);
+        }
+
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan());
+        reader.forEachRemaining(
+                r -> {
+                    assertThat(r.getInt(0)).isEqualTo(1);
+                    assertThat(r.getString(1).toString()).isEqualTo("a");
+                    assertThat(r.getString(2).toString()).isEqualTo("c"); // overwritten
+                });
+    }
+
+    @Test
+    public void testOnlySomeColumns() throws Exception {
+        createTableDefault();
+
+        Schema schema = schemaDefault();
+        RowType writeType0 = schema.rowType().project(Collections.singletonList("f0"));
+        RowType writeType1 = schema.rowType().project(Collections.singletonList("f1"));
+        RowType writeType2 = schema.rowType().project(Collections.singletonList("f2"));
+
+        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
+
+        try (BatchTableWrite write0 = builder.newWrite().withWriteType(writeType0)) {
+            write0.write(GenericRow.of(1));
+            BatchTableCommit commit = builder.newCommit();
+            commit.commit(write0.prepareCommit());
+        }
+
+        try (BatchTableWrite write1 = builder.newWrite().withWriteType(writeType1)) {
+            write1.write(GenericRow.of(BinaryString.fromString("a")));
+            BatchTableCommit commit = builder.newCommit();
+            List<CommitMessage> commitables = write1.prepareCommit();
+            setFirstRowId(commitables, 0L);
+            commit.commit(commitables);
+        }
+
+        try (BatchTableWrite write2 = builder.newWrite().withWriteType(writeType2)) {
+            write2.write(GenericRow.of(BinaryString.fromString("b")));
+            BatchTableCommit commit = builder.newCommit();
+            List<CommitMessage> commitables = write2.prepareCommit();
+            setFirstRowId(commitables, 0L);
+            commit.commit(commitables);
+        }
+
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan());
+        reader.forEachRemaining(
+                r -> {
+                    assertThat(r.getInt(0)).isEqualTo(1);
+                    assertThat(r.getString(1).toString()).isEqualTo("a");
+                    assertThat(r.getString(2)).isEqualTo(BinaryString.fromString("b"));
+                });
+    }
+
+    @Test
+    public void testMultipleRows() throws Exception {
+        createTableDefault();
+
+        Schema schema = schemaDefault();
+        RowType writeType0 = schema.rowType().project(Arrays.asList("f0", "f1"));
+        RowType writeType1 = schema.rowType().project(Collections.singletonList("f2"));
+        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
+
+        try (BatchTableWrite write0 = builder.newWrite().withWriteType(writeType0)) {
+            for (int i = 0; i < 10; i++) {
+                write0.write(GenericRow.of(i, BinaryString.fromString("a" + i)));
+            }
+            BatchTableCommit commit = builder.newCommit();
+            commit.commit(write0.prepareCommit());
+        }
+
+        long rowId = getTableDefault().snapshotManager().latestSnapshot().nextRowId() - 10;
+        try (BatchTableWrite write1 = builder.newWrite().withWriteType(writeType1)) {
+            for (int i = 0; i < 10; i++) {
+                write1.write(GenericRow.of(BinaryString.fromString("b" + i)));
+            }
+            BatchTableCommit commit = builder.newCommit();
+            List<CommitMessage> commitables = write1.prepareCommit();
+            setFirstRowId(commitables, rowId);
+            commit.commit(commitables);
+        }
+
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan());
+        AtomicInteger rowCount = new AtomicInteger(0);
+        reader.forEachRemaining(r -> rowCount.incrementAndGet());
+        assertThat(rowCount.get()).isEqualTo(10);
+    }
+}

--- a/paimon-python/dev/run_mixed_tests.sh
+++ b/paimon-python/dev/run_mixed_tests.sh
@@ -670,11 +670,7 @@ main() {
     # Clean up warehouse directory after all tests
     cleanup_warehouse
 
-<<<<<<< HEAD
-    if [[ $java_write_result -eq 0 && $python_read_result -eq 0 && $python_write_result -eq 0 && $java_read_result -eq 0 && $pk_dv_result -eq 0 && $btree_index_result -eq 0 && $compressed_text_result -eq 0 && $tantivy_fulltext_result -eq 0 && $lumina_vector_result -eq 0 && $lumina_vector_btree_result -eq 0 && $compact_conflict_result -eq 0 && $blob_alter_compact_result -eq 0 ]]; then
-=======
-    if [[ $java_write_result -eq 0 && $python_read_result -eq 0 && $python_write_result -eq 0 && $java_read_result -eq 0 && $pk_dv_result -eq 0 && $btree_index_result -eq 0 && $compressed_text_result -eq 0 && $tantivy_fulltext_result -eq 0 && $lumina_vector_result -eq 0 && $compact_conflict_result -eq 0 && $blob_alter_compact_result -eq 0 && $data_evolution_result -eq 0 && $data_evolution_py_write_result -eq 0 ]]; then
->>>>>>> ab62bf51d ([lance] Support row tracking for Lance format (Java + Python))
+    if [[ $java_write_result -eq 0 && $python_read_result -eq 0 && $python_write_result -eq 0 && $java_read_result -eq 0 && $pk_dv_result -eq 0 && $btree_index_result -eq 0 && $compressed_text_result -eq 0 && $tantivy_fulltext_result -eq 0 && $lumina_vector_result -eq 0 && $lumina_vector_btree_result -eq 0 && $compact_conflict_result -eq 0 && $blob_alter_compact_result -eq 0 && $data_evolution_result -eq 0 && $data_evolution_py_write_result -eq 0 ]]; then
         echo -e "${GREEN}🎉 All tests passed! Java-Python interoperability verified.${NC}"
         return 0
     else

--- a/paimon-python/dev/run_mixed_tests.sh
+++ b/paimon-python/dev/run_mixed_tests.sh
@@ -340,6 +340,89 @@ run_compact_conflict_test() {
     fi
 }
 
+run_data_evolution_test() {
+    echo -e "${YELLOW}=== Running Data Evolution Test (Java Write, Python Read) ===${NC}"
+
+    cd "$PROJECT_ROOT"
+
+    # Java write data evolution tables (parquet/orc/avro)
+    echo "Running Maven test for JavaPyE2ETest.testDataEvolutionWrite..."
+    local core_result=0
+    if mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testDataEvolutionWrite -pl paimon-core -q -Drun.e2e.tests=true; then
+        echo -e "${GREEN}✓ Java data evolution write (parquet/orc/avro) completed successfully${NC}"
+    else
+        echo -e "${RED}✗ Java data evolution write (parquet/orc/avro) failed${NC}"
+        core_result=1
+    fi
+
+    # Java write data evolution table (lance)
+    echo "Running Maven test for JavaPyLanceE2ETest.testDataEvolutionWriteLance..."
+    local lance_result=0
+    if mvn test -Dtest=org.apache.paimon.JavaPyLanceE2ETest#testDataEvolutionWriteLance -pl paimon-lance -q -Drun.e2e.tests=true; then
+        echo -e "${GREEN}✓ Java data evolution write (lance) completed successfully${NC}"
+    else
+        echo -e "${RED}✗ Java data evolution write (lance) failed${NC}"
+        lance_result=1
+    fi
+
+    # Python read data evolution tables
+    cd "$PAIMON_PYTHON_DIR"
+    echo "Running Python test for JavaPyReadWriteTest.test_read_data_evolution_table..."
+    if python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest -k "test_read_data_evolution_table" -v; then
+        echo -e "${GREEN}✓ Python data evolution read completed successfully${NC}"
+    else
+        echo -e "${RED}✗ Python data evolution read failed${NC}"
+        return 1
+    fi
+
+    if [[ $core_result -ne 0 || $lance_result -ne 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+run_data_evolution_py_write_test() {
+    echo -e "${YELLOW}=== Running Data Evolution Test (Python Write, Java Read) ===${NC}"
+
+    cd "$PAIMON_PYTHON_DIR"
+
+    # Python write data evolution tables
+    echo "Running Python test for JavaPyReadWriteTest.test_py_write_data_evolution_table..."
+    if python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest -k "test_py_write_data_evolution_table" -v; then
+        echo -e "${GREEN}✓ Python data evolution write completed successfully${NC}"
+    else
+        echo -e "${RED}✗ Python data evolution write failed${NC}"
+        return 1
+    fi
+
+    cd "$PROJECT_ROOT"
+
+    # Java read data evolution tables (parquet/orc/avro)
+    echo "Running Maven test for JavaPyE2ETest.testReadDataEvolutionTable..."
+    local core_result=0
+    if mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testReadDataEvolutionTable -pl paimon-core -q -Drun.e2e.tests=true -Dpython.version="$PYTHON_VERSION"; then
+        echo -e "${GREEN}✓ Java data evolution read (parquet/orc/avro) completed successfully${NC}"
+    else
+        echo -e "${RED}✗ Java data evolution read (parquet/orc/avro) failed${NC}"
+        core_result=1
+    fi
+
+    # Java read data evolution table (lance)
+    echo "Running Maven test for JavaPyLanceE2ETest.testReadDataEvolutionTableLance..."
+    local lance_result=0
+    if mvn test -Dtest=org.apache.paimon.JavaPyLanceE2ETest#testReadDataEvolutionTableLance -pl paimon-lance -q -Drun.e2e.tests=true -Dpython.version="$PYTHON_VERSION"; then
+        echo -e "${GREEN}✓ Java data evolution read (lance) completed successfully${NC}"
+    else
+        echo -e "${RED}✗ Java data evolution read (lance) failed${NC}"
+        lance_result=1
+    fi
+
+    if [[ $core_result -ne 0 || $lance_result -ne 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
 run_blob_alter_compact_test() {
     echo -e "${YELLOW}=== Running Blob Alter+Compact Test (Java Write+Alter+Compact, Python Read) ===${NC}"
 
@@ -377,6 +460,8 @@ main() {
     local lumina_vector_btree_result=0
     local compact_conflict_result=0
     local blob_alter_compact_result=0
+    local data_evolution_result=0
+    local data_evolution_py_write_result=0
 
     # Detect Python version
     PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "unknown")
@@ -480,6 +565,20 @@ main() {
 
     echo ""
 
+    # Run data evolution test (Java write, Python read)
+    if ! run_data_evolution_test; then
+        data_evolution_result=1
+    fi
+
+    echo ""
+
+    # Run data evolution test (Python write, Java read)
+    if ! run_data_evolution_py_write_test; then
+        data_evolution_py_write_result=1
+    fi
+
+    echo ""
+
     echo -e "${YELLOW}=== Test Results Summary ===${NC}"
 
     if [[ $java_write_result -eq 0 ]]; then
@@ -554,12 +653,28 @@ main() {
         echo -e "${RED}✗ Blob Alter+Compact Test (Java Write+Alter+Compact, Python Read): FAILED${NC}"
     fi
 
+    if [[ $data_evolution_result -eq 0 ]]; then
+        echo -e "${GREEN}✓ Data Evolution Test (Java Write, Python Read): PASSED${NC}"
+    else
+        echo -e "${RED}✗ Data Evolution Test (Java Write, Python Read): FAILED${NC}"
+    fi
+
+    if [[ $data_evolution_py_write_result -eq 0 ]]; then
+        echo -e "${GREEN}✓ Data Evolution Test (Python Write, Java Read): PASSED${NC}"
+    else
+        echo -e "${RED}✗ Data Evolution Test (Python Write, Java Read): FAILED${NC}"
+    fi
+
     echo ""
 
     # Clean up warehouse directory after all tests
     cleanup_warehouse
 
+<<<<<<< HEAD
     if [[ $java_write_result -eq 0 && $python_read_result -eq 0 && $python_write_result -eq 0 && $java_read_result -eq 0 && $pk_dv_result -eq 0 && $btree_index_result -eq 0 && $compressed_text_result -eq 0 && $tantivy_fulltext_result -eq 0 && $lumina_vector_result -eq 0 && $lumina_vector_btree_result -eq 0 && $compact_conflict_result -eq 0 && $blob_alter_compact_result -eq 0 ]]; then
+=======
+    if [[ $java_write_result -eq 0 && $python_read_result -eq 0 && $python_write_result -eq 0 && $java_read_result -eq 0 && $pk_dv_result -eq 0 && $btree_index_result -eq 0 && $compressed_text_result -eq 0 && $tantivy_fulltext_result -eq 0 && $lumina_vector_result -eq 0 && $compact_conflict_result -eq 0 && $blob_alter_compact_result -eq 0 && $data_evolution_result -eq 0 && $data_evolution_py_write_result -eq 0 ]]; then
+>>>>>>> ab62bf51d ([lance] Support row tracking for Lance format (Java + Python))
         echo -e "${GREEN}🎉 All tests passed! Java-Python interoperability verified.${NC}"
         return 0
     else

--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -18,12 +18,15 @@
 
 from typing import List, Optional, Any
 
+import pyarrow as pa
 import pyarrow.dataset as ds
 from pyarrow import RecordBatch
 
 from pypaimon.common.file_io import FileIO
 from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
 from pypaimon.read.reader.lance_utils import to_lance_specified
+from pypaimon.schema.data_types import DataField, PyarrowFieldParser
+from pypaimon.table.special_fields import SpecialFields
 
 
 class FormatLanceReader(RecordBatchReader):
@@ -32,22 +35,37 @@ class FormatLanceReader(RecordBatchReader):
     and filters it based on the provided predicate and projection.
     """
 
-    def __init__(self, file_io: FileIO, file_path: str, read_fields: List[str],
+    def __init__(self, file_io: FileIO, file_path: str, read_fields: List[DataField],
                  push_down_predicate: Any, batch_size: int = 1024):
         """Initialize Lance reader."""
         import lance
 
+        self._read_field_names = [f.name for f in read_fields]
+
         file_path_for_lance, storage_options = to_lance_specified(file_io, file_path)
 
-        columns_for_lance = read_fields if read_fields else None
+        # Read once, then select existing columns in memory
         lance_reader = lance.file.LanceFileReader(
             file_path_for_lance,
-            storage_options=storage_options,
-            columns=columns_for_lance)
-        reader_results = lance_reader.read_all()
+            storage_options=storage_options)
+        pa_table = lance_reader.read_all().to_table()
+        file_schema_names = set(pa_table.schema.names)
 
-        # Convert to PyArrow table
-        pa_table = reader_results.to_table()
+        self.existing_fields = [f.name for f in read_fields if f.name in file_schema_names]
+        self.missing_fields = [f.name for f in read_fields if f.name not in file_schema_names]
+
+        if self.existing_fields:
+            pa_table = pa_table.select(self.existing_fields)
+
+        # Precompute output schema for missing fields
+        if self.missing_fields:
+            output_schema = PyarrowFieldParser.from_paimon_schema(read_fields)
+            self._missing_out_fields = []
+            for name in self.missing_fields:
+                idx = output_schema.get_field_index(name)
+                col_type = output_schema.field(idx).type if idx >= 0 else pa.null()
+                nullable = not SpecialFields.is_system_field(name)
+                self._missing_out_fields.append(pa.field(name, col_type, nullable=nullable))
 
         if push_down_predicate is not None:
             in_memory_dataset = ds.InMemoryDataset(pa_table)
@@ -60,10 +78,28 @@ class FormatLanceReader(RecordBatchReader):
         try:
             # Handle both scanner reader and iterator
             if hasattr(self.reader, 'read_next_batch'):
-                return self.reader.read_next_batch()
+                batch = self.reader.read_next_batch()
             else:
-                # Iterator of batches
-                return next(self.reader)
+                batch = next(self.reader)
+
+            if not self.missing_fields:
+                return batch
+
+            # Reconstruct the batch with all fields in the correct order
+            all_columns = []
+            out_fields = []
+            for field_name in self._read_field_names:
+                if field_name in self.existing_fields:
+                    col_idx = self.existing_fields.index(field_name)
+                    all_columns.append(batch.column(col_idx))
+                    out_fields.append(batch.schema.field(col_idx))
+                else:
+                    miss_idx = self.missing_fields.index(field_name)
+                    out_field = self._missing_out_fields[miss_idx]
+                    all_columns.append(pa.nulls(batch.num_rows, type=out_field.type))
+                    out_fields.append(out_field)
+            return pa.RecordBatch.from_arrays(all_columns, schema=pa.schema(out_fields))
+
         except StopIteration:
             return None
 

--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -44,19 +44,18 @@ class FormatLanceReader(RecordBatchReader):
 
         file_path_for_lance, storage_options = to_lance_specified(file_io, file_path)
 
-        # System fields (_ROW_ID, etc.) never exist in physical files
-        self.existing_fields = [f.name for f in read_fields
-                                if not SpecialFields.is_system_field(f.name)]
-        self.missing_fields = [f.name for f in read_fields
-                               if SpecialFields.is_system_field(f.name)]
-
-        # existing_fields is never empty in practice (upstream always includes data fields)
-        columns_for_lance = self.existing_fields if self.existing_fields else None
         lance_reader = lance.file.LanceFileReader(
             file_path_for_lance,
-            storage_options=storage_options,
-            columns=columns_for_lance)
+            storage_options=storage_options)
         pa_table = lance_reader.read_all().to_table()
+
+        file_schema_names = set(pa_table.schema.names)
+        self.existing_fields = [f.name for f in read_fields
+                                if f.name in file_schema_names]
+        self.missing_fields = [f.name for f in read_fields
+                               if f.name not in file_schema_names]
+        if self.existing_fields and len(self.existing_fields) < len(pa_table.schema):
+            pa_table = pa_table.select(self.existing_fields)
 
         # Precompute output schema for missing fields
         if self.missing_fields:

--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -44,16 +44,18 @@ class FormatLanceReader(RecordBatchReader):
 
         file_path_for_lance, storage_options = to_lance_specified(file_io, file_path)
 
-        # Read file once, filter to only columns that exist (zero-copy select)
+        # System fields (_ROW_ID, etc.) never exist in physical files
+        self.existing_fields = [f.name for f in read_fields
+                                if not SpecialFields.is_system_field(f.name)]
+        self.missing_fields = [f.name for f in read_fields
+                               if SpecialFields.is_system_field(f.name)]
+
+        columns_for_lance = self.existing_fields if self.existing_fields else None
         lance_reader = lance.file.LanceFileReader(
             file_path_for_lance,
-            storage_options=storage_options)
+            storage_options=storage_options,
+            columns=columns_for_lance)
         pa_table = lance_reader.read_all().to_table()
-        file_schema_names = set(pa_table.schema.names)
-        self.existing_fields = [f.name for f in read_fields if f.name in file_schema_names]
-        self.missing_fields = [f.name for f in read_fields if f.name not in file_schema_names]
-        if self.existing_fields:
-            pa_table = pa_table.select(self.existing_fields)
 
         # Precompute output schema for missing fields
         if self.missing_fields:

--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -50,6 +50,7 @@ class FormatLanceReader(RecordBatchReader):
         self.missing_fields = [f.name for f in read_fields
                                if SpecialFields.is_system_field(f.name)]
 
+        # existing_fields is never empty in practice (upstream always includes data fields)
         columns_for_lance = self.existing_fields if self.existing_fields else None
         lance_reader = lance.file.LanceFileReader(
             file_path_for_lance,

--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -44,18 +44,24 @@ class FormatLanceReader(RecordBatchReader):
 
         file_path_for_lance, storage_options = to_lance_specified(file_io, file_path)
 
-        lance_reader = lance.file.LanceFileReader(
-            file_path_for_lance,
-            storage_options=storage_options)
-        pa_table = lance_reader.read_all().to_table()
-
-        file_schema_names = set(pa_table.schema.names)
+        # Read file metadata (footer only) to get actual schema
+        file_schema_names = set(
+            lance.file.LanceFileReader(
+                file_path_for_lance, storage_options=storage_options
+            ).metadata().schema.names
+        )
         self.existing_fields = [f.name for f in read_fields
                                 if f.name in file_schema_names]
         self.missing_fields = [f.name for f in read_fields
                                if f.name not in file_schema_names]
-        if self.existing_fields and len(self.existing_fields) < len(pa_table.schema):
-            pa_table = pa_table.select(self.existing_fields)
+
+        # Read data with column pruning
+        columns_for_lance = self.existing_fields if self.existing_fields else None
+        lance_reader = lance.file.LanceFileReader(
+            file_path_for_lance,
+            storage_options=storage_options,
+            columns=columns_for_lance)
+        pa_table = lance_reader.read_all().to_table()
 
         # Precompute output schema for missing fields
         if self.missing_fields:

--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -44,19 +44,16 @@ class FormatLanceReader(RecordBatchReader):
 
         file_path_for_lance, storage_options = to_lance_specified(file_io, file_path)
 
-        # Get file schema, then read only columns that exist in the file
+        # Read file once, filter to only columns that exist (zero-copy select)
         lance_reader = lance.file.LanceFileReader(
             file_path_for_lance,
             storage_options=storage_options)
-        file_schema_names = set(lance_reader.metadata().schema.names)
+        pa_table = lance_reader.read_all().to_table()
+        file_schema_names = set(pa_table.schema.names)
         self.existing_fields = [f.name for f in read_fields if f.name in file_schema_names]
         self.missing_fields = [f.name for f in read_fields if f.name not in file_schema_names]
-
-        columns_for_lance = self.existing_fields if self.existing_fields else None
-        pa_table = lance.file.LanceFileReader(
-            file_path_for_lance,
-            storage_options=storage_options,
-            columns=columns_for_lance).read_all().to_table()
+        if self.existing_fields:
+            pa_table = pa_table.select(self.existing_fields)
 
         # Precompute output schema for missing fields
         if self.missing_fields:

--- a/paimon-python/pypaimon/read/reader/format_lance_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_lance_reader.py
@@ -44,18 +44,19 @@ class FormatLanceReader(RecordBatchReader):
 
         file_path_for_lance, storage_options = to_lance_specified(file_io, file_path)
 
-        # Read once, then select existing columns in memory
+        # Get file schema, then read only columns that exist in the file
         lance_reader = lance.file.LanceFileReader(
             file_path_for_lance,
             storage_options=storage_options)
-        pa_table = lance_reader.read_all().to_table()
-        file_schema_names = set(pa_table.schema.names)
-
+        file_schema_names = set(lance_reader.metadata().schema.names)
         self.existing_fields = [f.name for f in read_fields if f.name in file_schema_names]
         self.missing_fields = [f.name for f in read_fields if f.name not in file_schema_names]
 
-        if self.existing_fields:
-            pa_table = pa_table.select(self.existing_fields)
+        columns_for_lance = self.existing_fields if self.existing_fields else None
+        pa_table = lance.file.LanceFileReader(
+            file_path_for_lance,
+            storage_options=storage_options,
+            columns=columns_for_lance).read_all().to_table()
 
         # Precompute output schema for missing fields
         if self.missing_fields:

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -163,7 +163,9 @@ class SplitRead(ABC):
                                              self.read_fields, read_arrow_predicate, blob_as_descriptor,
                                              batch_size=batch_size)
         elif file_format == CoreOptions.FILE_FORMAT_LANCE:
-            format_reader = FormatLanceReader(self.table.file_io, file_path, read_file_fields,
+            name_to_field = {f.name: f for f in self.read_fields}
+            ordered_read_fields = [name_to_field[n] for n in read_file_fields if n in name_to_field]
+            format_reader = FormatLanceReader(self.table.file_io, file_path, ordered_read_fields,
                                               read_arrow_predicate, batch_size=batch_size)
         elif file_format == CoreOptions.FILE_FORMAT_VORTEX:
             name_to_field = {f.name: f for f in self.read_fields}

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -775,7 +775,7 @@ class JavaPyReadWriteTest(unittest.TestCase):
 
         # Write (f0, f1) columns
         write_builder = table.new_batch_write_builder()
-        table_write = write_builder.new_write()
+        table_write = write_builder.new_write().with_write_type(['f0', 'f1'])
         table_commit = write_builder.new_commit()
         data0 = pa.Table.from_pydict({
             'f0': list(range(5)),

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -739,3 +739,72 @@ class JavaPyReadWriteTest(unittest.TestCase):
         self.assertIn("conflicts", str(ctx.exception))
         tc.close()
         print(f"Conflict detected as expected: {ctx.exception}")
+
+    @parameterized.expand(get_file_format_params())
+    def test_read_data_evolution_table(self, file_format):
+        """Read data evolution tables written by Java and verify merged results."""
+        table = self.catalog.get_table(f'default.data_evolution_test_{file_format}')
+        read_builder = table.new_read_builder()
+        table_scan = read_builder.new_scan()
+        table_read = read_builder.new_read()
+        splits = table_scan.plan().splits()
+        result = table_read.to_arrow(splits)
+        result = table_sort_by(result, 'f0')
+        self.assertEqual(result.num_rows, 5)
+        for i in range(5):
+            self.assertEqual(result.column('f0')[i].as_py(), i)
+            self.assertEqual(result.column('f1')[i].as_py(), f'a{i}')
+            self.assertEqual(result.column('f2')[i].as_py(), f'b{i}')
+
+    @parameterized.expand(get_file_format_params())
+    def test_py_write_data_evolution_table(self, file_format):
+        """Python writes data evolution tables for Java to read."""
+        table_name = f'default.data_evolution_test_py_{file_format}'
+        simple_pa_schema = pa.schema([
+            ('f0', pa.int32()),
+            ('f1', pa.utf8()),
+            ('f2', pa.utf8()),
+        ])
+        schema = Schema.from_pyarrow_schema(simple_pa_schema, options={
+            'row-tracking.enabled': 'true',
+            'data-evolution.enabled': 'true',
+            'file.format': file_format,
+        })
+        self.catalog.create_table(table_name, schema, True)
+        table = self.catalog.get_table(table_name)
+
+        # Write (f0, f1) columns
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        data0 = pa.Table.from_pydict({
+            'f0': list(range(5)),
+            'f1': [f'a{i}' for i in range(5)],
+        }, schema=pa.schema([('f0', pa.int32()), ('f1', pa.utf8())]))
+        table_write.write_arrow(data0)
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+
+        # Write (f2) column with first_row_id
+        table_write = write_builder.new_write().with_write_type(['f2'])
+        table_commit = write_builder.new_commit()
+        data1 = pa.Table.from_pydict({
+            'f2': [f'b{i}' for i in range(5)],
+        }, schema=pa.schema([('f2', pa.utf8())]))
+        table_write.write_arrow(data1)
+        cmts = table_write.prepare_commit()
+        cmts[0].new_files[0].first_row_id = 0
+        table_commit.commit(cmts)
+        table_write.close()
+        table_commit.close()
+
+        # Verify read-back
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(read_builder.new_scan().plan().splits())
+        result = table_sort_by(result, 'f0')
+        self.assertEqual(result.num_rows, 5)
+        for i in range(5):
+            self.assertEqual(result.column('f0')[i].as_py(), i)
+            self.assertEqual(result.column('f1')[i].as_py(), f'a{i}')
+            self.assertEqual(result.column('f2')[i].as_py(), f'b{i}')


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Lance/Arrow reader internals (memory lifetime, column projection, selection handling) and adds cross-language row-tracking/data-evolution tests, so regressions could affect correctness or stability when reading Lance/Arrow data.
> 
> **Overview**
> Enables Lance reads/writes to work with *row tracking* and *data evolution* by tolerating missing/virtual columns during projection and returning nulls for absent fields.
> 
> Fixes Lance reader stability and correctness issues by (1) avoiding empty-selection reads, (2) filtering projected columns to only those physically present in the Lance file, and (3) keeping the current `VectorSchemaRoot` alive across batches instead of closing it in `releaseBatch()` to prevent Arrow off-heap use-after-free crashes.
> 
> Adds end-to-end Java↔Python interoperability coverage for data evolution (partial-column writes with `firstRowId` alignment) across Parquet/ORC/Avro and Lance, plus a new `LanceRowTrackingTest`, and wires these scenarios into `run_mixed_tests.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 192b657c449e47642b76fddd685186805f0400ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->