### PR TITLE
[lance] Fix zero-column read error in data evolution with BTree globa…

### DIFF
--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/jni/LanceReader.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/jni/LanceReader.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -63,6 +64,9 @@ public class LanceReader {
                     projectedRowType.getFieldNames().stream()
                             .filter(fileFieldNames::contains)
                             .collect(Collectors.toList());
+            if (existingFields.isEmpty()) {
+                existingFields = Collections.singletonList(fileFieldNames.iterator().next());
+            }
             this.arrowReader = reader.readAll(existingFields, ranges, batchSize);
         } catch (IOException e) {
             throw new RuntimeException("Failed to open Lance file: " + path, e);

--- a/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceBTreeGlobalIndexTest.java
+++ b/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceBTreeGlobalIndexTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.lance;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.disk.IOManagerImpl;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.BtreeGlobalIndexTableTest;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.TraceableFileIO;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
+
+/** Test BTree global index with Lance file format. */
+public class LanceBTreeGlobalIndexTest extends BtreeGlobalIndexTableTest {
+
+    @BeforeEach
+    public void beforeEach() throws Catalog.DatabaseAlreadyExistException {
+        database = "default";
+        warehouse = new Path(TraceableFileIO.SCHEME + "://" + tempPath.toString());
+        Options options = new Options();
+        options.set(WAREHOUSE, warehouse.toUri().toString());
+        CatalogContext context = CatalogContext.create(options, new TraceableFileIO.Loader(), null);
+        catalog = CatalogFactory.createCatalog(context);
+        catalog.createDatabase(database, true);
+        this.ioManager = new IOManagerImpl(tempPath.toString());
+    }
+
+    @Override
+    protected Schema schemaDefault() {
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("f0", DataTypes.INT());
+        schemaBuilder.column("f1", DataTypes.STRING());
+        schemaBuilder.column("f2", DataTypes.STRING());
+        schemaBuilder.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.FILE_FORMAT.key(), "lance");
+        return schemaBuilder.build();
+    }
+}


### PR DESCRIPTION
…l index

### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes column projection behavior in the Lance reader and may read an unintended fallback column when only virtual columns are requested, affecting performance and potentially downstream assumptions.
> 
> **Overview**
> Fixes a Lance read failure when the requested projection contains *no physical columns* (e.g., only virtual/framework columns during data evolution) by falling back to reading a single existing file column instead of attempting a zero-column `readAll`.
> 
> Adds `LanceBTreeGlobalIndexTest` to exercise BTree global index tables using the `lance` file format with row tracking and data evolution enabled, covering the previously failing path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ab6919ac167bf75309489bddd4585ca7dfae7ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->