### PR TITLE
[python] Fix RecursionError when chaining many or_/and_ calls in Glob…

### DIFF
--- a/paimon-python/pypaimon/globalindex/global_index_result.py
+++ b/paimon-python/pypaimon/globalindex/global_index_result.py
@@ -43,15 +43,13 @@ class GlobalIndexResult(ABC):
 
     def and_(self, other: 'GlobalIndexResult') -> 'GlobalIndexResult':
         """Returns the intersection of this result and the other result."""
-        return LazyGlobalIndexResult(
-            lambda: RoaringBitmap64.and_(self.results(), other.results())
-        )
+        result = RoaringBitmap64.and_(self.results(), other.results())
+        return LazyGlobalIndexResult(lambda: result)
 
     def or_(self, other: 'GlobalIndexResult') -> 'GlobalIndexResult':
         """Returns the union of this result and the other result."""
-        return LazyGlobalIndexResult(
-            lambda: RoaringBitmap64.or_(self.results(), other.results())
-        )
+        result = RoaringBitmap64.or_(self.results(), other.results())
+        return LazyGlobalIndexResult(lambda: result)
 
     def is_empty(self) -> bool:
         """Check if the result is empty."""

--- a/paimon-python/pypaimon/globalindex/global_index_result.py
+++ b/paimon-python/pypaimon/globalindex/global_index_result.py
@@ -43,13 +43,15 @@ class GlobalIndexResult(ABC):
 
     def and_(self, other: 'GlobalIndexResult') -> 'GlobalIndexResult':
         """Returns the intersection of this result and the other result."""
-        result = RoaringBitmap64.and_(self.results(), other.results())
-        return LazyGlobalIndexResult(lambda: result)
+        return SimpleGlobalIndexResult(
+            RoaringBitmap64.and_(self.results(), other.results())
+        )
 
     def or_(self, other: 'GlobalIndexResult') -> 'GlobalIndexResult':
         """Returns the union of this result and the other result."""
-        result = RoaringBitmap64.or_(self.results(), other.results())
-        return LazyGlobalIndexResult(lambda: result)
+        return SimpleGlobalIndexResult(
+            RoaringBitmap64.or_(self.results(), other.results())
+        )
 
     def is_empty(self) -> bool:
         """Check if the result is empty."""
@@ -83,6 +85,15 @@ class GlobalIndexResult(ABC):
                 result.add_range(r.from_, r.to)
             return result
         return LazyGlobalIndexResult(create_bitmap)
+
+
+class SimpleGlobalIndexResult(GlobalIndexResult):
+
+    def __init__(self, result: RoaringBitmap64):
+        self._result = result
+
+    def results(self) -> RoaringBitmap64:
+        return self._result
 
 
 class LazyGlobalIndexResult(GlobalIndexResult):

--- a/paimon-python/pypaimon/tests/global_index_test.py
+++ b/paimon-python/pypaimon/tests/global_index_test.py
@@ -1,3 +1,21 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 import unittest
 
 from pypaimon.globalindex.global_index_result import GlobalIndexResult

--- a/paimon-python/pypaimon/tests/global_index_test.py
+++ b/paimon-python/pypaimon/tests/global_index_test.py
@@ -1,0 +1,23 @@
+import unittest
+
+from pypaimon.globalindex.global_index_result import GlobalIndexResult
+from pypaimon.utils.range import Range
+
+
+class GlobalIndexTest(unittest.TestCase):
+
+    def test_chained_or(self):
+        result = GlobalIndexResult.create_empty()
+        for i in range(600):
+            other = GlobalIndexResult.from_range(Range(i * 10, i * 10 + 5))
+            result = result.or_(other)
+
+        self.assertEqual(result.results().cardinality(), 3600)
+
+    def test_chained_and(self):
+        result = GlobalIndexResult.from_range(Range(0, 10000))
+        for i in range(600):
+            other = GlobalIndexResult.from_range(Range(0, 10000))
+            result = result.and_(other)
+
+        self.assertEqual(result.results().cardinality(), 10001)


### PR DESCRIPTION
…alIndexResult

### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes evaluation strategy for `and_`/`or_` from lazy to eager, which may affect memory/CPU characteristics on large bitmaps even though semantics remain the same.
> 
> **Overview**
> Fixes `RecursionError`/stack-depth issues when chaining many `GlobalIndexResult.or_()` and `and_()` calls by returning an eagerly computed bitmap result instead of nesting `LazyGlobalIndexResult` suppliers.
> 
> Introduces `SimpleGlobalIndexResult` to hold a materialized `RoaringBitmap64`, and adds unit tests that chain 600 `or_`/`and_` operations to verify correctness and prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad0d12ae5c6bd83788e3cdb54b83fdff9ec47e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->