### PR TITLE
[flink] Fix StackOverflowError in BTreeIndexTopoBuilder caused by cha…

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/btree/BTreeIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/btree/BTreeIndexTopoBuilder.java
@@ -85,7 +85,7 @@ public class BTreeIndexTopoBuilder {
             PartitionPredicate partitionPredicate,
             Options userOptions)
             throws Exception {
-        DataStream<Committable> allCommitMessages = null;
+        List<DataStream<Committable>> allStreams = new ArrayList<>();
         for (String indexColumn : indexColumns) {
             BTreeGlobalIndexBuilder indexBuilder =
                     indexBuilderSupplier.get().withIndexField(indexColumn);
@@ -160,15 +160,15 @@ public class BTreeIndexTopoBuilder {
                                     recordsPerRange,
                                     maxParallelism);
 
-                    allCommitMessages =
-                            allCommitMessages == null
-                                    ? commitMessages
-                                    : allCommitMessages.union(commitMessages);
+                    allStreams.add(commitMessages);
                 }
             }
         }
-        if (allCommitMessages != null) {
-            commit(table, allCommitMessages);
+        if (!allStreams.isEmpty()) {
+            @SuppressWarnings("unchecked")
+            DataStream<Committable>[] rest =
+                    allStreams.subList(1, allStreams.size()).toArray(new DataStream[0]);
+            commit(table, allStreams.get(0).union(rest));
         }
 
         return true;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BTreeGlobalIndexITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BTreeGlobalIndexITCase.java
@@ -145,9 +145,7 @@ public class BTreeGlobalIndexITCase extends CatalogITCaseBase {
     }
 
     @Test
-    public void testBTreeIndexWithManyPartitions() throws Catalog.TableNotExistException {
-        // Regression test: building a btree index on a table with many partitions
-        // previously caused StackOverflowError due to deeply nested DataStream.union() calls.
+    void testBTreeIndexWithManyPartitions() throws Catalog.TableNotExistException {
         int numPartitions = 50;
         sql(
                 "CREATE TABLE T_MANY_PT (pt INT, id INT, name STRING) PARTITIONED BY (pt) WITH ("

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BTreeGlobalIndexITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BTreeGlobalIndexITCase.java
@@ -23,11 +23,14 @@ import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.table.FileStoreTable;
 
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -139,5 +142,66 @@ public class BTreeGlobalIndexITCase extends CatalogITCaseBase {
         sql(
                 "CALL sys.create_global_index(`table` => 'default.%s', index_column => '%s', index_type => 'btree')",
                 tableName, indexColumn);
+    }
+
+    @Test
+    void testChainedUnionOverflowAndFlatUnionFix() throws InterruptedException {
+        int totalUnions = 8 * 200; // 8 index columns × 200 partitions
+        long stackSize = 512 * 1024; // Flink JM default
+
+        // Chained union: result = result.union(new) — causes StackOverflowError
+        AtomicReference<Throwable> chainedError = new AtomicReference<>();
+        Thread chainedThread =
+                new Thread(
+                        null,
+                        () -> {
+                            try {
+                                StreamExecutionEnvironment env =
+                                        StreamExecutionEnvironment.getExecutionEnvironment();
+                                DataStream<String> all = null;
+                                for (int i = 0; i < totalUnions; i++) {
+                                    DataStream<String> s = env.fromElements("item-" + i);
+                                    all = all == null ? s : all.union(s);
+                                }
+                                all.print();
+                                env.getExecutionPlan();
+                            } catch (Throwable t) {
+                                chainedError.set(t);
+                            }
+                        },
+                        "chained-union-test",
+                        stackSize);
+        chainedThread.start();
+        chainedThread.join();
+        assertThat(chainedError.get()).isInstanceOf(StackOverflowError.class);
+
+        // Flat union: first.union(rest...) — no overflow at same stack size
+        AtomicReference<Throwable> flatError = new AtomicReference<>();
+        Thread flatThread =
+                new Thread(
+                        null,
+                        () -> {
+                            try {
+                                StreamExecutionEnvironment env =
+                                        StreamExecutionEnvironment.getExecutionEnvironment();
+                                @SuppressWarnings("unchecked")
+                                DataStream<String>[] streams = new DataStream[totalUnions];
+                                for (int i = 0; i < totalUnions; i++) {
+                                    streams[i] = env.fromElements("item-" + i);
+                                }
+                                @SuppressWarnings("unchecked")
+                                DataStream<String>[] rest = new DataStream[totalUnions - 1];
+                                System.arraycopy(streams, 1, rest, 0, totalUnions - 1);
+                                streams[0].union(rest).print();
+                                env.getExecutionPlan();
+                            } catch (Throwable t) {
+                                flatError.set(t);
+                            }
+                        },
+                        "flat-union-test",
+                        stackSize);
+        flatThread.start();
+        flatThread.join();
+        assertThat(flatError.get()).isNull();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BTreeGlobalIndexITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BTreeGlobalIndexITCase.java
@@ -145,8 +145,36 @@ public class BTreeGlobalIndexITCase extends CatalogITCaseBase {
     }
 
     @Test
-    void testChainedUnionOverflowAndFlatUnionFix() throws InterruptedException {
-        int totalUnions = 8 * 200; // 8 index columns × 200 partitions
+    public void testBTreeIndexWithManyPartitions() throws Catalog.TableNotExistException {
+        // Regression test: building a btree index on a table with many partitions
+        // previously caused StackOverflowError due to deeply nested DataStream.union() calls.
+        int numPartitions = 50;
+        sql(
+                "CREATE TABLE T_MANY_PT (pt INT, id INT, name STRING) PARTITIONED BY (pt) WITH ("
+                        + "'global-index.enabled' = 'true', "
+                        + "'row-tracking.enabled' = 'true', "
+                        + "'data-evolution.enabled' = 'true'"
+                        + ")");
+
+        for (int p = 0; p < numPartitions; p++) {
+            insertPartitionRows("T_MANY_PT", p, p * 2, 2, "r_");
+        }
+
+        buildBTreeIndexForTable("T_MANY_PT", "id");
+
+        FileStoreTable table = paimonTable("T_MANY_PT");
+        long totalRowCount =
+                table.store().newIndexFileHandler().scanEntries().stream()
+                        .filter(e -> "btree".equals(e.indexFile().indexType()))
+                        .map(IndexManifestEntry::indexFile)
+                        .mapToLong(IndexFileMeta::rowCount)
+                        .sum();
+        assertThat(totalRowCount).isEqualTo((long) numPartitions * 2);
+    }
+
+    @Test
+    void testUnionDoesNotStackOverflow() throws InterruptedException {
+        int totalUnions = 1000;
         long stackSize = 512 * 1024; // Flink JM default
 
         // Chained union: result = result.union(new) — causes StackOverflowError


### PR DESCRIPTION
…ined union

### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `Committable` streams are unioned when building BTree global indexes; while behavior should be equivalent, it affects Flink job graph construction and could impact large index builds if any union/commit assumptions differ.
> 
> **Overview**
> Prevents `StackOverflowError` during BTree global index creation by replacing the iterative `all = all.union(next)` pattern with a *flat* `first.union(rest...)` when merging many `Committable` `DataStream`s in `BTreeIndexTopoBuilder`.
> 
> Adds IT coverage for building indexes across many partitions and a regression test demonstrating chained unions overflow (and the flat-union approach does not) at Flink’s default JobManager stack size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef245ba3c838ef9bb22b3d8846f794d3b9cf080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->