### PR TITLE
Lance npe fix2

### DIFF
--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
@@ -123,8 +123,7 @@ public class LanceUtils {
                 storageOptions.put(
                         STORAGE_OPTION_ENDPOINT,
                         "https://" + uri.getHost() + "." + originOptions.get(FS_OSS_ENDPOINT));
-                storageOptions.put(
-                        STORAGE_OPTION_OSS_ENDPOINT, originOptions.get(FS_OSS_ENDPOINT));
+                storageOptions.put(STORAGE_OPTION_OSS_ENDPOINT, originOptions.get(FS_OSS_ENDPOINT));
             }
             if (originOptions.get(FS_OSS_ACCESS_KEY_ID) != null) {
                 storageOptions.put(
@@ -153,8 +152,7 @@ public class LanceUtils {
         while (iterator.hasNext()) {
             Map.Entry<String, String> entry = iterator.next();
             if (entry.getValue() == null) {
-                LOG.warn(
-                        "Removing null Lance storage option value for key '{}'.", entry.getKey());
+                LOG.warn("Removing null Lance storage option value for key '{}'.", entry.getKey());
                 iterator.remove();
             }
         }

--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
@@ -25,13 +25,19 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.rest.RESTTokenFileIO;
 import org.apache.paimon.utils.Pair;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /** Utils for lance all. */
 public class LanceUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LanceUtils.class);
 
     // OSS configuration keys
     public static final String FS_OSS_ENDPOINT = "fs.oss.endpoint";
@@ -66,13 +72,16 @@ public class LanceUtils {
 
         URI uri = path.toUri();
         String schema = uri.getScheme();
+        Map<String, String> tokenOptions = null;
 
         if (fileIO instanceof RESTTokenFileIO) {
+            RESTTokenFileIO restTokenFileIO = (RESTTokenFileIO) fileIO;
             try {
-                fileIO = ((RESTTokenFileIO) fileIO).fileIO();
+                fileIO = restTokenFileIO.fileIO();
             } catch (IOException e) {
                 throw new RuntimeException("Can't get fileIO from RESTTokenFileIO", e);
             }
+            tokenOptions = restTokenFileIO.validToken().token();
         }
 
         Options originOptions;
@@ -81,6 +90,14 @@ public class LanceUtils {
                     ((HadoopOptionsProvider) fileIO).hadoopOptions(path, isRead ? "read" : "write");
         } else {
             originOptions = new Options();
+        }
+        originOptions = new Options(originOptions.toMap());
+        if (tokenOptions != null) {
+            for (Map.Entry<String, String> entry : tokenOptions.entrySet()) {
+                if (entry.getKey().startsWith(FS_PREFIX) && entry.getValue() != null) {
+                    originOptions.set(entry.getKey(), entry.getValue());
+                }
+            }
         }
 
         Path converted = path;
@@ -92,9 +109,9 @@ public class LanceUtils {
                 converted = new Path(uriString.replace("traceable:/", "file:/"));
             }
         } else if ("oss".equals(schema)) {
-            assert originOptions.containsKey(FS_OSS_ENDPOINT);
-            assert originOptions.containsKey(FS_OSS_ACCESS_KEY_ID);
-            assert originOptions.containsKey(FS_OSS_ACCESS_KEY_SECRET);
+            logMissingOssOption(originOptions, FS_OSS_ENDPOINT, path);
+            logMissingOssOption(originOptions, FS_OSS_ACCESS_KEY_ID, path);
+            logMissingOssOption(originOptions, FS_OSS_ACCESS_KEY_SECRET, path);
 
             for (String key : originOptions.keySet()) {
                 if (key.startsWith(FS_PREFIX)) {
@@ -102,30 +119,56 @@ public class LanceUtils {
                 }
             }
 
-            storageOptions.put(
-                    STORAGE_OPTION_ENDPOINT,
-                    "https://" + uri.getHost() + "." + originOptions.get(FS_OSS_ENDPOINT));
-            storageOptions.put(
-                    STORAGE_OPTION_ACCESS_KEY_ID, originOptions.get(FS_OSS_ACCESS_KEY_ID));
-            storageOptions.put(
-                    STORAGE_OPTION_OSS_ACCESS_KEY_ID, originOptions.get(FS_OSS_ACCESS_KEY_ID));
-            storageOptions.put(
-                    STORAGE_OPTION_SECRET_ACCESS_KEY, originOptions.get(FS_OSS_ACCESS_KEY_SECRET));
-            storageOptions.put(
-                    STORAGE_OPTION_OSS_SECRET_ACCESS_KEY,
-                    originOptions.get(FS_OSS_ACCESS_KEY_SECRET));
+            if (originOptions.get(FS_OSS_ENDPOINT) != null) {
+                storageOptions.put(
+                        STORAGE_OPTION_ENDPOINT,
+                        "https://" + uri.getHost() + "." + originOptions.get(FS_OSS_ENDPOINT));
+                storageOptions.put(
+                        STORAGE_OPTION_OSS_ENDPOINT, originOptions.get(FS_OSS_ENDPOINT));
+            }
+            if (originOptions.get(FS_OSS_ACCESS_KEY_ID) != null) {
+                storageOptions.put(
+                        STORAGE_OPTION_ACCESS_KEY_ID, originOptions.get(FS_OSS_ACCESS_KEY_ID));
+                storageOptions.put(
+                        STORAGE_OPTION_OSS_ACCESS_KEY_ID, originOptions.get(FS_OSS_ACCESS_KEY_ID));
+            }
+            if (originOptions.get(FS_OSS_ACCESS_KEY_SECRET) != null) {
+                storageOptions.put(
+                        STORAGE_OPTION_SECRET_ACCESS_KEY,
+                        originOptions.get(FS_OSS_ACCESS_KEY_SECRET));
+                storageOptions.put(
+                        STORAGE_OPTION_OSS_SECRET_ACCESS_KEY,
+                        originOptions.get(FS_OSS_ACCESS_KEY_SECRET));
+            }
             storageOptions.put(STORAGE_OPTION_VIRTUAL_HOSTED_STYLE, "true");
-            if (originOptions.containsKey(FS_OSS_SECURITY_TOKEN)) {
+            if (originOptions.get(FS_OSS_SECURITY_TOKEN) != null) {
                 storageOptions.put(
                         STORAGE_OPTION_SESSION_TOKEN, originOptions.get(FS_OSS_SECURITY_TOKEN));
                 storageOptions.put(
                         STORAGE_OPTION_OSS_SESSION_TOKEN, originOptions.get(FS_OSS_SECURITY_TOKEN));
             }
-            if (originOptions.containsKey(FS_OSS_ENDPOINT)) {
-                storageOptions.put(STORAGE_OPTION_OSS_ENDPOINT, originOptions.get(FS_OSS_ENDPOINT));
-            }
         }
 
+        Iterator<Map.Entry<String, String>> iterator = storageOptions.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, String> entry = iterator.next();
+            if (entry.getValue() == null) {
+                LOG.warn(
+                        "Removing null Lance storage option value for key '{}'.", entry.getKey());
+                iterator.remove();
+            }
+        }
         return Pair.of(converted, storageOptions);
+    }
+
+    private static void logMissingOssOption(Options originOptions, String key, Path path) {
+        if (!originOptions.containsKey(key) || originOptions.get(key) == null) {
+            LOG.warn(
+                    "Lance OSS storage option '{}' is missing for path '{}'. "
+                            + "Lance native may fall back to environment variables or report "
+                            + "a missing option error.",
+                    key,
+                    path);
+        }
     }
 }

--- a/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceUtilsTest.java
+++ b/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceUtilsTest.java
@@ -18,17 +18,24 @@
 
 package org.apache.paimon.format.lance;
 
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PluginFileIO;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.rest.RESTToken;
+import org.apache.paimon.rest.RESTTokenFileIO;
 import org.apache.paimon.utils.Pair;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LanceUtilsTest {
@@ -53,6 +60,33 @@ class LanceUtilsTest {
 
         void setOptions(Options opts) {
             this.options = opts;
+        }
+    }
+
+    private static class TestRESTTokenFileIO extends RESTTokenFileIO {
+        private static final long serialVersionUID = 1L;
+
+        private final FileIO fileIO;
+        private final RESTToken token;
+
+        TestRESTTokenFileIO(FileIO fileIO, Map<String, String> tokenOptions) {
+            super(
+                    CatalogContext.create(new Options()),
+                    null,
+                    Identifier.create("default", "T"),
+                    new Path("oss://my-bucket/path/to/file.lance"));
+            this.fileIO = fileIO;
+            this.token = new RESTToken(tokenOptions, Long.MAX_VALUE);
+        }
+
+        @Override
+        public FileIO fileIO() throws IOException {
+            return fileIO;
+        }
+
+        @Override
+        public RESTToken validToken() {
+            return token;
         }
     }
 
@@ -103,5 +137,99 @@ class LanceUtilsTest {
         assertEquals("test-token", storageOptions.get(LanceUtils.STORAGE_OPTION_SESSION_TOKEN));
         assertEquals("test-token", storageOptions.get(LanceUtils.STORAGE_OPTION_OSS_SESSION_TOKEN));
         assertTrue(storageOptions.containsKey(LanceUtils.FS_OSS_SECURITY_TOKEN));
+    }
+
+    @Test
+    void testOssStorageOptionsFilterNullValues() {
+        Path path = new Path("oss://my-bucket/path/to/file.lance");
+        Options options = new Options();
+        options.set(LanceUtils.FS_OSS_ENDPOINT, "oss-example-region.example.com");
+        options.set(LanceUtils.FS_OSS_ACCESS_KEY_ID, "test-access-key");
+        options.set(LanceUtils.FS_OSS_ACCESS_KEY_SECRET, "test-secret-key");
+        options.set(LanceUtils.FS_OSS_SECURITY_TOKEN, null);
+        options.set("fs.oss.null-value", null);
+
+        TestFileIO fileIO = new TestFileIO();
+        fileIO.setOptions(options);
+
+        Pair<Path, Map<String, String>> result = LanceUtils.toLanceSpecifiedForWriter(fileIO, path);
+
+        Map<String, String> storageOptions = result.getValue();
+        assertFalse(storageOptions.containsKey(LanceUtils.FS_OSS_SECURITY_TOKEN));
+        assertFalse(storageOptions.containsKey(LanceUtils.STORAGE_OPTION_SESSION_TOKEN));
+        assertFalse(storageOptions.containsKey(LanceUtils.STORAGE_OPTION_OSS_SESSION_TOKEN));
+        assertFalse(storageOptions.containsKey("fs.oss.null-value"));
+        assertFalse(storageOptions.containsValue(null));
+    }
+
+    @Test
+    void testOssStorageOptionsFromRestToken() {
+        Path path = new Path("oss://my-bucket/path/to/file.lance");
+        TestFileIO fileIO = new TestFileIO();
+        fileIO.setOptions(new Options());
+
+        Map<String, String> tokenOptions = new HashMap<>();
+        tokenOptions.put(LanceUtils.FS_OSS_ENDPOINT, "oss-example-region.example.com");
+        tokenOptions.put(LanceUtils.FS_OSS_ACCESS_KEY_ID, "test-access-key");
+        tokenOptions.put(LanceUtils.FS_OSS_ACCESS_KEY_SECRET, "test-secret-key");
+        tokenOptions.put(LanceUtils.FS_OSS_SECURITY_TOKEN, "test-token");
+
+        Pair<Path, Map<String, String>> result =
+                LanceUtils.toLanceSpecifiedForReader(
+                        new TestRESTTokenFileIO(fileIO, tokenOptions), path);
+
+        Map<String, String> storageOptions = result.getValue();
+        assertEquals(
+                "https://my-bucket.oss-example-region.example.com",
+                storageOptions.get(LanceUtils.STORAGE_OPTION_ENDPOINT));
+        assertEquals(
+                "oss-example-region.example.com",
+                storageOptions.get(LanceUtils.STORAGE_OPTION_OSS_ENDPOINT));
+        assertEquals(
+                "test-access-key", storageOptions.get(LanceUtils.STORAGE_OPTION_ACCESS_KEY_ID));
+        assertEquals(
+                "test-secret-key", storageOptions.get(LanceUtils.STORAGE_OPTION_SECRET_ACCESS_KEY));
+        assertEquals("test-token", storageOptions.get(LanceUtils.STORAGE_OPTION_SESSION_TOKEN));
+    }
+
+    @Test
+    void testRestTokenOptionsDoNotMutateFileIOOptions() {
+        Path path = new Path("oss://my-bucket/path/to/file.lance");
+        Options fileIOOptions = new Options();
+        TestFileIO fileIO = new TestFileIO();
+        fileIO.setOptions(fileIOOptions);
+
+        Map<String, String> tokenOptions = new HashMap<>();
+        tokenOptions.put(LanceUtils.FS_OSS_ENDPOINT, "oss-example-region.example.com");
+        tokenOptions.put(LanceUtils.FS_OSS_ACCESS_KEY_ID, "test-access-key");
+        tokenOptions.put(LanceUtils.FS_OSS_ACCESS_KEY_SECRET, "test-secret-key");
+
+        LanceUtils.toLanceSpecifiedForReader(new TestRESTTokenFileIO(fileIO, tokenOptions), path);
+
+        assertFalse(fileIOOptions.containsKey(LanceUtils.FS_OSS_ENDPOINT));
+        assertFalse(fileIOOptions.containsKey(LanceUtils.FS_OSS_ACCESS_KEY_ID));
+        assertFalse(fileIOOptions.containsKey(LanceUtils.FS_OSS_ACCESS_KEY_SECRET));
+    }
+
+    @Test
+    void testOssStorageOptionsSkipMissingEndpoint() {
+        Path path = new Path("oss://my-bucket/path/to/file.lance");
+        Options options = new Options();
+        options.set(LanceUtils.FS_OSS_ACCESS_KEY_ID, "test-access-key");
+        options.set(LanceUtils.FS_OSS_ACCESS_KEY_SECRET, "test-secret-key");
+
+        TestFileIO fileIO = new TestFileIO();
+        fileIO.setOptions(options);
+
+        Pair<Path, Map<String, String>> result = LanceUtils.toLanceSpecifiedForWriter(fileIO, path);
+
+        Map<String, String> storageOptions = result.getValue();
+        assertFalse(storageOptions.containsKey(LanceUtils.STORAGE_OPTION_ENDPOINT));
+        assertFalse(storageOptions.containsKey(LanceUtils.STORAGE_OPTION_OSS_ENDPOINT));
+        assertEquals(
+                "test-access-key", storageOptions.get(LanceUtils.STORAGE_OPTION_ACCESS_KEY_ID));
+        assertEquals(
+                "test-secret-key", storageOptions.get(LanceUtils.STORAGE_OPTION_SECRET_ACCESS_KEY));
+        assertFalse(storageOptions.containsValue(null));
     }
 }


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OSS credential/endpoint option construction for Lance readers/writers; behavior changes could affect access to OSS paths if option propagation differs from previous assumptions. Added tests reduce risk but this is still I/O configuration-critical.
> 
> **Overview**
> Improves `LanceUtils` OSS storage-option generation to be *null-safe* and more robust: missing required OSS options now emit warnings instead of relying on assertions, and null-valued options are removed before returning to avoid NPEs in Lance native.
> 
> Adds support for `RESTTokenFileIO` by merging token-provided `fs.*` options into a copied `Options` snapshot (avoiding mutation of the underlying `FileIO` options), and conditionally populating Lance endpoint/credential fields only when present. Updates tests to cover REST-token propagation, null filtering, and behavior when endpoint is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87f39d7f5013d9380ede81616ec74846abf1e9f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->