### PR TITLE
[python] Parallelize vector search and full-text search split processing

### DIFF
--- a/paimon-python/pypaimon/table/source/full_text_read.py
+++ b/paimon-python/pypaimon/table/source/full_text_read.py
@@ -18,7 +18,9 @@
 
 """Full-text read to read index files."""
 
+import os
 from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
 from typing import List, Optional
 
 from pypaimon.globalindex.full_text_search import FullTextSearch
@@ -60,12 +62,19 @@ class FullTextReadImpl(FullTextRead):
         if not splits:
             return GlobalIndexResult.create_empty()
 
+        thread_num = self._table.options.global_index_thread_num() or os.cpu_count()
+
+        with ThreadPoolExecutor(max_workers=thread_num) as executor:
+            futures = [
+                executor.submit(
+                    self._eval, s.row_range_start, s.row_range_end,
+                    s.full_text_index_files)
+                for s in splits
+            ]
+
         merged_scores = {}
-        for split in splits:
-            split_result = self._eval(
-                split.row_range_start, split.row_range_end,
-                split.full_text_index_files
-            )
+        for future in futures:
+            split_result = future.result()
             if split_result is not None:
                 score_getter = split_result.score_getter()
                 for row_id in split_result.results():

--- a/paimon-python/pypaimon/table/source/vector_search_read.py
+++ b/paimon-python/pypaimon/table/source/vector_search_read.py
@@ -18,7 +18,9 @@
 
 """Vector search read to read index files."""
 
+import os
 from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
 
 from pypaimon.globalindex.global_index_meta import GlobalIndexIOMeta
 from pypaimon.globalindex.global_index_result import GlobalIndexResult
@@ -56,13 +58,19 @@ class VectorSearchReadImpl(VectorSearchRead):
             return GlobalIndexResult.create_empty()
 
         pre_filter = self._pre_filter(splits)
+        thread_num = self._table.options.global_index_thread_num() or os.cpu_count()
+
+        with ThreadPoolExecutor(max_workers=thread_num) as executor:
+            futures = [
+                executor.submit(
+                    self._eval, s.row_range_start, s.row_range_end,
+                    s.vector_index_files, pre_filter)
+                for s in splits
+            ]
 
         merged_scores = {}
-        for split in splits:
-            split_result = self._eval(
-                split.row_range_start, split.row_range_end,
-                split.vector_index_files, pre_filter
-            )
+        for future in futures:
+            split_result = future.result()
             if split_result is not None:
                 score_getter = split_result.score_getter()
                 for row_id in split_result.results():

--- a/paimon-python/pypaimon/tests/vector_search_filter_test.py
+++ b/paimon-python/pypaimon/tests/vector_search_filter_test.py
@@ -42,6 +42,11 @@ from pypaimon.utils.roaring_bitmap import RoaringBitmap64
 # ----------------------------- table stubs ---------------------------------
 
 
+class _StubOptions:
+    def global_index_thread_num(self):
+        return None
+
+
 class _StubSchema:
     def __init__(self):
         self.options = {}
@@ -56,6 +61,7 @@ class _StubTable:
         self.partition_keys: List[str] = [
             f.name for f in self.partition_keys_fields]
         self.table_schema = _StubSchema()
+        self.options = _StubOptions()
         self.file_io = object()
         self._entries = entries
 


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces multithreaded execution for split evaluation, which can change performance characteristics and expose thread-safety or resource-exhaustion issues in index readers/file IO.
> 
> **Overview**
> Parallelizes vector search and full-text search split processing by executing per-split `_eval` calls via a `ThreadPoolExecutor`, then merging scored results as before.
> 
> Adds configurable concurrency using `table.options.global_index_thread_num()` (fallback to `os.cpu_count()`), and updates the vector search filter tests’ stub table to provide the new `options.global_index_thread_num()` hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e404de34ee36b818541ee2d49662c5f990b680cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->