### PR TITLE
Support null blob

### DIFF
--- a/paimon-python/pypaimon/filesystem/local_file_io.py
+++ b/paimon-python/pypaimon/filesystem/local_file_io.py
@@ -420,7 +420,6 @@ class LocalFileIO(FileIO):
             if data.num_columns != 1:
                 raise RuntimeError(f"Blob format only supports a single column, got {data.num_columns} columns")
             
-            column = data.column(0)
             field = data.schema[0]
             if pyarrow.types.is_large_binary(field.type):
                 fields = [DataField(0, field.name, AtomicType("BLOB"))]

--- a/paimon-python/pypaimon/filesystem/local_file_io.py
+++ b/paimon-python/pypaimon/filesystem/local_file_io.py
@@ -33,9 +33,6 @@ from pypaimon.common.options import Options
 from pypaimon.common.uri_reader import UriReaderFactory
 from pypaimon.filesystem.local import PaimonLocalFileSystem
 from pypaimon.schema.data_types import DataField, AtomicType, PyarrowFieldParser
-from pypaimon.table.row.blob import BlobData, BlobDescriptor, Blob
-from pypaimon.table.row.generic_row import GenericRow
-from pypaimon.table.row.row_kind import RowKind
 from pypaimon.write.blob_format_writer import BlobFormatWriter
 
 
@@ -439,35 +436,7 @@ class LocalFileIO(FileIO):
             with open(file_path, 'wb') as output_stream:
                 writer = BlobFormatWriter(output_stream)
                 for i in range(num_rows):
-                    col_data = records_dict[field_name][i]
-                    if col_data is None:
-                        row = GenericRow([None], fields, RowKind.INSERT)
-                        writer.add_element(row)
-                        continue
-                    if hasattr(fields[0].type, 'type') and fields[0].type.type == "BLOB":
-                        if hasattr(col_data, 'as_py'):
-                            col_data = col_data.as_py()
-                        if isinstance(col_data, str):
-                            col_data = col_data.encode('utf-8')
-                        if isinstance(col_data, bytearray):
-                            col_data = bytes(col_data)
-
-                        if isinstance(col_data, bytes):
-                            if BlobDescriptor.is_blob_descriptor(col_data):
-                                descriptor = BlobDescriptor.deserialize(col_data)
-                                uri_reader = self.uri_reader_factory.create(descriptor.uri)
-                                blob_data = Blob.from_descriptor(uri_reader, descriptor)
-                            else:
-                                blob_data = BlobData(col_data)
-                        else:
-                            raise RuntimeError(
-                                "Blob field value must be bytes/blob or serialized BlobDescriptor bytes."
-                            )
-                        row_values = [blob_data]
-                    else:
-                        row_values = [col_data]
-                    row = GenericRow(row_values, fields, RowKind.INSERT)
-                    writer.add_element(row)
+                    writer.write_value(records_dict[field_name][i], fields, self.uri_reader_factory)
                 writer.close()
         except Exception as e:
             self.delete_quietly(path)

--- a/paimon-python/pypaimon/filesystem/local_file_io.py
+++ b/paimon-python/pypaimon/filesystem/local_file_io.py
@@ -421,9 +421,6 @@ class LocalFileIO(FileIO):
                 raise RuntimeError(f"Blob format only supports a single column, got {data.num_columns} columns")
             
             column = data.column(0)
-            if column.null_count > 0:
-                raise RuntimeError("Blob format does not support null values")
-            
             field = data.schema[0]
             if pyarrow.types.is_large_binary(field.type):
                 fields = [DataField(0, field.name, AtomicType("BLOB"))]
@@ -444,6 +441,10 @@ class LocalFileIO(FileIO):
                 writer = BlobFormatWriter(output_stream)
                 for i in range(num_rows):
                     col_data = records_dict[field_name][i]
+                    if col_data is None:
+                        row = GenericRow([None], fields, RowKind.INSERT)
+                        writer.add_element(row)
+                        continue
                     if hasattr(fields[0].type, 'type') and fields[0].type.type == "BLOB":
                         if hasattr(col_data, 'as_py'):
                             col_data = col_data.as_py()

--- a/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
+++ b/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
@@ -655,8 +655,6 @@ class PyArrowFileIO(FileIO):
             if data.num_columns != 1:
                 raise RuntimeError(f"Blob format only supports a single column, got {data.num_columns} columns")
             column = data.column(0)
-            if column.null_count > 0:
-                raise RuntimeError("Blob format does not support null values")
             field = data.schema[0]
             if pyarrow.types.is_large_binary(field.type):
                 fields = [DataField(0, field.name, AtomicType("BLOB"))]
@@ -670,6 +668,10 @@ class PyArrowFileIO(FileIO):
                 writer = BlobFormatWriter(output_stream)
                 for i in range(num_rows):
                     col_data = records_dict[field_name][i]
+                    if col_data is None:
+                        row = GenericRow([None], fields, RowKind.INSERT)
+                        writer.add_element(row)
+                        continue
                     if hasattr(fields[0].type, 'type') and fields[0].type.type == "BLOB":
                         if hasattr(col_data, 'as_py'):
                             col_data = col_data.as_py()

--- a/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
+++ b/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
@@ -38,9 +38,6 @@ from pypaimon.common.uri_reader import UriReaderFactory
 from pypaimon.filesystem.jindo_file_system_handler import JindoFileSystemHandler, JINDO_AVAILABLE
 from pypaimon.schema.data_types import (AtomicType, DataField,
                                         PyarrowFieldParser)
-from pypaimon.table.row.blob import Blob, BlobData, BlobDescriptor
-from pypaimon.table.row.generic_row import GenericRow
-from pypaimon.table.row.row_kind import RowKind
 from pypaimon.write.blob_format_writer import BlobFormatWriter
 
 
@@ -666,35 +663,7 @@ class PyArrowFileIO(FileIO):
             with self.new_output_stream(path) as output_stream:
                 writer = BlobFormatWriter(output_stream)
                 for i in range(num_rows):
-                    col_data = records_dict[field_name][i]
-                    if col_data is None:
-                        row = GenericRow([None], fields, RowKind.INSERT)
-                        writer.add_element(row)
-                        continue
-                    if hasattr(fields[0].type, 'type') and fields[0].type.type == "BLOB":
-                        if hasattr(col_data, 'as_py'):
-                            col_data = col_data.as_py()
-                        if isinstance(col_data, str):
-                            col_data = col_data.encode('utf-8')
-                        if isinstance(col_data, bytearray):
-                            col_data = bytes(col_data)
-
-                        if isinstance(col_data, bytes):
-                            if BlobDescriptor.is_blob_descriptor(col_data):
-                                descriptor = BlobDescriptor.deserialize(col_data)
-                                uri_reader = self.uri_reader_factory.create(descriptor.uri)
-                                blob_data = Blob.from_descriptor(uri_reader, descriptor)
-                            else:
-                                blob_data = BlobData(col_data)
-                        else:
-                            raise RuntimeError(
-                                "Blob field value must be bytes/blob or serialized BlobDescriptor bytes."
-                            )
-                        row_values = [blob_data]
-                    else:
-                        row_values = [col_data]
-                    row = GenericRow(row_values, fields, RowKind.INSERT)
-                    writer.add_element(row)
+                    writer.write_value(records_dict[field_name][i], fields, self.uri_reader_factory)
                 writer.close()
 
         except Exception as e:

--- a/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
+++ b/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
@@ -654,7 +654,6 @@ class PyArrowFileIO(FileIO):
         try:
             if data.num_columns != 1:
                 raise RuntimeError(f"Blob format only supports a single column, got {data.num_columns} columns")
-            column = data.column(0)
             field = data.schema[0]
             if pyarrow.types.is_large_binary(field.type):
                 fields = [DataField(0, field.name, AtomicType("BLOB"))]

--- a/paimon-python/pypaimon/read/reader/format_blob_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_blob_reader.py
@@ -95,12 +95,12 @@ class FormatBlobReader(RecordBatchReader):
                     break
                 blob = blob_row.values[0]
                 for field_name in self._fields:
-                    blob_descriptor = blob.to_descriptor()
-                    if self._blob_as_descriptor:
-                        blob_data = blob_descriptor.serialize()
+                    if blob is None:
+                        pydict_data[field_name].append(None)
+                    elif self._blob_as_descriptor:
+                        pydict_data[field_name].append(blob.to_descriptor().serialize())
                     else:
-                        blob_data = blob.to_data()
-                    pydict_data[field_name].append(blob_data)
+                        pydict_data[field_name].append(blob.to_data())
 
                 records_in_batch += 1
                 if records_in_batch >= read_size:
@@ -163,8 +163,11 @@ class FormatBlobReader(RecordBatchReader):
             blob_offsets = []
             offset = 0
             for length in blob_lengths:
-                blob_offsets.append(offset)
-                offset += length
+                if length == -1:
+                    blob_offsets.append(-1)
+                else:
+                    blob_offsets.append(offset)
+                    offset += length
             self.blob_lengths = blob_lengths
             self.blob_offsets = blob_offsets
 
@@ -188,13 +191,16 @@ class BlobRecordIterator:
     def __next__(self) -> GenericRow:
         if self.current_position >= len(self.blob_lengths):
             raise StopIteration
+        fields = [DataField(0, self.field_name, AtomicType("BLOB"))]
+        if self.blob_lengths[self.current_position] == -1:
+            self.current_position += 1
+            return GenericRow([None], fields, RowKind.INSERT)
         # Create blob reference for the current blob
         # Skip magic number (4 bytes) and exclude length (8 bytes) + CRC (4 bytes) = 12 bytes
         blob_offset = self.blob_offsets[self.current_position] + self.MAGIC_NUMBER_SIZE  # Skip magic number
         blob_length = self.blob_lengths[self.current_position] - self.METADATA_OVERHEAD
         blob = Blob.from_file(self.file_io, self.file_path, blob_offset, blob_length)
         self.current_position += 1
-        fields = [DataField(0, self.field_name, AtomicType("BLOB"))]
         return GenericRow([blob], fields, RowKind.INSERT)
 
     def returned_position(self) -> int:

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -745,17 +745,14 @@ class BlobEndToEndTest(unittest.TestCase):
             file_io.write_blob(multi_column_url, multi_column_table)
         self.assertIn("single column", str(context.exception))
 
-        # Test that FileIO.write_blob rejects null values
+        # Test that FileIO.write_blob supports null values
         null_schema = pa.schema([pa.field("blob_with_nulls", pa.large_binary())])
         null_table = pa.table([[b"data", None]], schema=null_schema)
 
         null_file = Path(self.temp_dir) / "null_data.blob"
         null_file_url = _to_url(null_file)
-
-        # Should throw RuntimeError for null values
-        with self.assertRaises(RuntimeError) as context:
-            file_io.write_blob(null_file_url, null_table)
-        self.assertIn("null values", str(context.exception))
+        file_io.write_blob(null_file_url, null_table)
+        self.assertTrue(file_io.exists(null_file_url))
 
         # ========== Test FormatBlobReader with complex type schema ==========
         # Create a valid blob file first
@@ -1027,17 +1024,14 @@ class BlobEndToEndTest(unittest.TestCase):
             "Field must be Blob/BlobData instance" in str(context.exception)
         )
 
-        # Test that blob format rejects tables with null values
+        # Test that blob format supports tables with null values
         null_schema = pa.schema([pa.field("blob_with_null", pa.large_binary())])
         null_table = pa.table([[b"data", None, b"more_data"]], schema=null_schema)
 
         null_file = Path(self.temp_dir) / "with_nulls.blob"
         null_file_url = _to_url(null_file)
-
-        # Should reject null values
-        with self.assertRaises(RuntimeError) as context:
-            file_io.write_blob(null_file_url, null_table)
-        self.assertIn("null values", str(context.exception))
+        file_io.write_blob(null_file_url, null_table)
+        self.assertTrue(file_io.exists(null_file_url))
 
     def test_blob_write_with_raw_bytes_starting_with_v1_prefix(self):
         file_io = LocalFileIO(self.temp_dir, Options({}))
@@ -1157,6 +1151,54 @@ class BlobEndToEndTest(unittest.TestCase):
         # With blob_as_descriptor=False, we should get the actual blob content
         self.assertEqual(read_content_bytes, test_content)
         reader_content.close()
+
+    def test_null_blob_write(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        output = io.BytesIO()
+        writer = BlobFormatWriter(output)
+
+        row_with_null = GenericRow(
+            [None],
+            [DataField(0, "blob_field", AtomicType("BLOB"))],
+            RowKind.INSERT
+        )
+        writer.add_element(row_with_null)
+        self.assertEqual(writer.lengths, [-1])
+        self.assertEqual(writer.position, 0)
+
+    def test_null_blob_read(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        blob_file_path = os.path.join(self.temp_dir, "null_blob.blob")
+
+        output = open(blob_file_path, 'wb')
+        writer = BlobFormatWriter(output)
+        fields = [DataField(0, "blob_field", AtomicType("BLOB"))]
+        writer.add_element(GenericRow([BlobData(b"hello")], fields, RowKind.INSERT))
+        writer.add_element(GenericRow([None], fields, RowKind.INSERT))
+        writer.add_element(GenericRow([BlobData(b"world")], fields, RowKind.INSERT))
+        writer.close()
+
+        blob_field_name = "blob_field"
+        read_fields = [DataField(0, blob_field_name, AtomicType("BLOB"))]
+        reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=[blob_field_name],
+            full_fields=read_fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False
+        )
+
+        batch = reader.read_arrow_batch()
+        self.assertIsNotNone(batch)
+        self.assertEqual(batch.num_rows, 3)
+        self.assertEqual(batch.column(0)[0].as_py(), b"hello")
+        self.assertIsNone(batch.column(0)[1].as_py())
+        self.assertEqual(batch.column(0)[2].as_py(), b"world")
+        reader.close()
 
 
 class OffsetInputStreamTest(unittest.TestCase):

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -1200,6 +1200,41 @@ class BlobEndToEndTest(unittest.TestCase):
         self.assertEqual(batch.column(0)[2].as_py(), b"world")
         reader.close()
 
+    def test_null_blob_read_as_descriptor(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        blob_file_path = os.path.join(self.temp_dir, "null_desc.blob")
+
+        output = open(blob_file_path, 'wb')
+        writer = BlobFormatWriter(output)
+        fields = [DataField(0, "blob_field", AtomicType("BLOB"))]
+        writer.add_element(GenericRow([BlobData(b"hello")], fields, RowKind.INSERT))
+        writer.add_element(GenericRow([None], fields, RowKind.INSERT))
+        writer.add_element(GenericRow([BlobData(b"world")], fields, RowKind.INSERT))
+        writer.close()
+
+        blob_field_name = "blob_field"
+        read_fields = [DataField(0, blob_field_name, AtomicType("BLOB"))]
+        reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=[blob_field_name],
+            full_fields=read_fields,
+            push_down_predicate=None,
+            blob_as_descriptor=True
+        )
+
+        batch = reader.read_arrow_batch()
+        self.assertIsNotNone(batch)
+        self.assertEqual(batch.num_rows, 3)
+        desc0 = BlobDescriptor.deserialize(batch.column(0)[0].as_py())
+        self.assertEqual(desc0.uri, blob_file_path)
+        self.assertIsNone(batch.column(0)[1].as_py())
+        desc2 = BlobDescriptor.deserialize(batch.column(0)[2].as_py())
+        self.assertEqual(desc2.uri, blob_file_path)
+        reader.close()
+
 
 class OffsetInputStreamTest(unittest.TestCase):
 

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -745,14 +745,28 @@ class BlobEndToEndTest(unittest.TestCase):
             file_io.write_blob(multi_column_url, multi_column_table)
         self.assertIn("single column", str(context.exception))
 
-        # Test that FileIO.write_blob supports null values
+        # Test that FileIO.write_blob supports null values and round-trips correctly
         null_schema = pa.schema([pa.field("blob_with_nulls", pa.large_binary())])
         null_table = pa.table([[b"data", None]], schema=null_schema)
 
         null_file = Path(self.temp_dir) / "null_data.blob"
         null_file_url = _to_url(null_file)
         file_io.write_blob(null_file_url, null_table)
-        self.assertTrue(file_io.exists(null_file_url))
+
+        null_read_fields = [DataField(0, "blob_with_nulls", AtomicType("BLOB"))]
+        null_reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=str(null_file),
+            read_fields=["blob_with_nulls"],
+            full_fields=null_read_fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False
+        )
+        null_batch = null_reader.read_arrow_batch()
+        self.assertEqual(null_batch.num_rows, 2)
+        self.assertEqual(null_batch.column(0)[0].as_py(), b"data")
+        self.assertIsNone(null_batch.column(0)[1].as_py())
+        null_reader.close()
 
         # ========== Test FormatBlobReader with complex type schema ==========
         # Create a valid blob file first
@@ -1024,14 +1038,29 @@ class BlobEndToEndTest(unittest.TestCase):
             "Field must be Blob/BlobData instance" in str(context.exception)
         )
 
-        # Test that blob format supports tables with null values
+        # Test that blob format supports tables with null values (round-trip)
         null_schema = pa.schema([pa.field("blob_with_null", pa.large_binary())])
         null_table = pa.table([[b"data", None, b"more_data"]], schema=null_schema)
 
         null_file = Path(self.temp_dir) / "with_nulls.blob"
         null_file_url = _to_url(null_file)
         file_io.write_blob(null_file_url, null_table)
-        self.assertTrue(file_io.exists(null_file_url))
+
+        null_read_fields = [DataField(0, "blob_with_null", AtomicType("BLOB"))]
+        null_reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=str(null_file),
+            read_fields=["blob_with_null"],
+            full_fields=null_read_fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False
+        )
+        null_batch = null_reader.read_arrow_batch()
+        self.assertEqual(null_batch.num_rows, 3)
+        self.assertEqual(null_batch.column(0)[0].as_py(), b"data")
+        self.assertIsNone(null_batch.column(0)[1].as_py())
+        self.assertEqual(null_batch.column(0)[2].as_py(), b"more_data")
+        null_reader.close()
 
     def test_blob_write_with_raw_bytes_starting_with_v1_prefix(self):
         file_io = LocalFileIO(self.temp_dir, Options({}))

--- a/paimon-python/pypaimon/write/blob_format_writer.py
+++ b/paimon-python/pypaimon/write/blob_format_writer.py
@@ -17,7 +17,7 @@
 
 import struct
 import zlib
-from typing import BinaryIO, List, Optional
+from typing import BinaryIO, List
 
 from pypaimon.table.row.blob import Blob, BlobData, BlobDescriptor
 from pypaimon.common.delta_varint_compressor import DeltaVarintCompressor

--- a/paimon-python/pypaimon/write/blob_format_writer.py
+++ b/paimon-python/pypaimon/write/blob_format_writer.py
@@ -17,9 +17,9 @@
 
 import struct
 import zlib
-from typing import BinaryIO, List
+from typing import BinaryIO, List, Optional
 
-from pypaimon.table.row.blob import Blob, BlobData
+from pypaimon.table.row.blob import Blob, BlobData, BlobDescriptor
 from pypaimon.common.delta_varint_compressor import DeltaVarintCompressor
 
 
@@ -87,6 +87,40 @@ class BlobFormatWriter:
         self.output_stream.write(data)
         self.position += len(data)
         return crc32
+
+    def write_value(self, col_data, fields, uri_reader_factory=None) -> None:
+        from pypaimon.table.row.generic_row import GenericRow
+        from pypaimon.table.row.row_kind import RowKind
+
+        if col_data is None:
+            self.lengths.append(-1)
+            return
+
+        if hasattr(fields[0].type, 'type') and fields[0].type.type == "BLOB":
+            if hasattr(col_data, 'as_py'):
+                col_data = col_data.as_py()
+            if isinstance(col_data, str):
+                col_data = col_data.encode('utf-8')
+            if isinstance(col_data, bytearray):
+                col_data = bytes(col_data)
+
+            if isinstance(col_data, bytes):
+                if BlobDescriptor.is_blob_descriptor(col_data):
+                    descriptor = BlobDescriptor.deserialize(col_data)
+                    uri_reader = uri_reader_factory.create(descriptor.uri)
+                    blob_value = Blob.from_descriptor(uri_reader, descriptor)
+                else:
+                    blob_value = BlobData(col_data)
+            else:
+                raise RuntimeError(
+                    "Blob field value must be bytes/blob or serialized BlobDescriptor bytes."
+                )
+            row_values = [blob_value]
+        else:
+            row_values = [col_data]
+
+        row = GenericRow(row_values, fields, RowKind.INSERT)
+        self.add_element(row)
 
     def reach_target_size(self, target_size: int) -> bool:
         return self.position >= target_size

--- a/paimon-python/pypaimon/write/blob_format_writer.py
+++ b/paimon-python/pypaimon/write/blob_format_writer.py
@@ -40,7 +40,8 @@ class BlobFormatWriter:
 
         blob_value = row.values[0]
         if blob_value is None:
-            raise ValueError("BlobFormatWriter only supports non-null blob")
+            self.lengths.append(-1)
+            return
 
         if not isinstance(blob_value, Blob):
             raise ValueError("Field must be Blob/BlobData instance")

--- a/paimon-python/pypaimon/write/blob_format_writer.py
+++ b/paimon-python/pypaimon/write/blob_format_writer.py
@@ -92,11 +92,15 @@ class BlobFormatWriter:
         from pypaimon.table.row.generic_row import GenericRow
         from pypaimon.table.row.row_kind import RowKind
 
+        is_blob = hasattr(fields[0].type, 'type') and fields[0].type.type == "BLOB"
+
         if col_data is None:
+            if not is_blob:
+                raise RuntimeError("Null values are only supported for BLOB type fields")
             self.lengths.append(-1)
             return
 
-        if hasattr(fields[0].type, 'type') and fields[0].type.type == "BLOB":
+        if is_blob:
             if hasattr(col_data, 'as_py'):
                 col_data = col_data.as_py()
             if isinstance(col_data, str):


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the blob file encoding/decoding to represent null entries (using `-1` lengths) and alters `write_blob` behavior, which could affect compatibility and edge cases when reading/writing existing blob files.
> 
> **Overview**
> Enables **null BLOB values** to be written and read in the blob file format.
> 
> `LocalFileIO.write_blob` and `PyArrowFileIO.write_blob` now allow nulls and delegate per-row coercion/descriptor handling to a new `BlobFormatWriter.write_value`, removing the previous “reject nulls” validation and inlined conversion logic.
> 
> `BlobFormatWriter` and `FormatBlobReader` are updated to encode null entries as a `-1` length in the index and to return `None` rows/Arrow values accordingly; tests are updated/added to assert null round-trips (including `blob_as_descriptor=True`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f05fee98d43bd4e987964e71d9312f6e015afa9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->