### PR TITLE
Ray merge into safety fix

### DIFF
--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -369,6 +369,10 @@ and `num_unchanged` is always `0`; conditional clauses (added later) can
 make `num_unchanged > 0`.
 
 **Notes:**
+- Partition key columns cannot be updated by matched clauses. If the target
+  table is partitioned, `merge_into` raises an error when `when_matched` is
+  specified, because cross-partition row movement is not implemented.
+  Not-matched inserts into partitioned tables work normally.
 - Blob columns are not written by `merge_into`: update leaves the existing
   `.blob` files untouched, and insert fills blob columns with `NULL`. The
   source data does not need to (and should not) carry blob columns.

--- a/paimon-python/pypaimon/ray/data_evolution_merge_into.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_into.py
@@ -126,15 +126,11 @@ def _prepare(target, source, catalog_options, when_matched, when_not_matched, on
         c for c in full_target_field_names if c not in blob_cols
     ]
     on_map = dict(zip(target_on_cols, source_on_cols))
-    partition_keys = set(table.partition_keys)
-    if when_matched and partition_keys:
-        updated_partition_keys = partition_keys & set(settable_field_names)
-        if updated_partition_keys:
-            raise ValueError(
-                f"merge_into does not support updating partition key "
-                f"columns {sorted(updated_partition_keys)}; "
-                f"cross-partition row movement is not implemented."
-            )
+    if when_matched and table.partition_keys:
+        raise ValueError(
+            "merge_into does not support matched clauses on partitioned "
+            "tables; cross-partition row movement is not implemented."
+        )
     matched_specs = [
         _NormalizedClause(
             spec=_normalize_set_spec(

--- a/paimon-python/pypaimon/ray/data_evolution_merge_into.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_into.py
@@ -126,6 +126,15 @@ def _prepare(target, source, catalog_options, when_matched, when_not_matched, on
         c for c in full_target_field_names if c not in blob_cols
     ]
     on_map = dict(zip(target_on_cols, source_on_cols))
+    partition_keys = set(table.partition_keys)
+    if when_matched and partition_keys:
+        updated_partition_keys = partition_keys & set(settable_field_names)
+        if updated_partition_keys:
+            raise ValueError(
+                f"merge_into does not support updating partition key "
+                f"columns {sorted(updated_partition_keys)}; "
+                f"cross-partition row movement is not implemented."
+            )
     matched_specs = [
         _NormalizedClause(
             spec=_normalize_set_spec(
@@ -261,7 +270,6 @@ def _execute_and_commit(
             f.row_count for m in insert_msgs for f in m.new_files
         )
         all_msgs.extend(insert_msgs)
-    # TODO: add global-index update action check after PR #8045 merges
     if all_msgs:
         wb = table.new_batch_write_builder()
         tc = wb.new_commit()

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -450,7 +450,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
 
         self.assertEqual(self._snapshot_id(target), before)
 
-    def test_partitioned_update_rejects_partition_key_change(self):
+    def test_partitioned_matched_update_rejected(self):
         pt_schema = pa.schema([
             ('pt', pa.string()),
             ('id', pa.int32()),
@@ -480,7 +480,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 when_matched=[WhenMatched(update='*')],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
-        self.assertIn('partition key', str(ctx.exception))
+        self.assertIn('partitioned', str(ctx.exception))
 
     def test_partitioned_insert_allowed(self):
         pt_schema = pa.schema([

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -450,6 +450,75 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
 
         self.assertEqual(self._snapshot_id(target), before)
 
+    def test_partitioned_update_rejects_partition_key_change(self):
+        pt_schema = pa.schema([
+            ('pt', pa.string()),
+            ('id', pa.int32()),
+            ('name', pa.string()),
+        ])
+        name = f'default.tbl_{uuid.uuid4().hex[:8]}'
+        s = Schema.from_pyarrow_schema(
+            pt_schema, partition_keys=['pt'], options=self.de_options,
+        )
+        self.catalog.create_table(name, s, False)
+
+        source = pa.Table.from_pydict(
+            {
+                'pt': ['a'],
+                'id': pa.array([1], type=pa.int32()),
+                'name': ['x'],
+            },
+            schema=pt_schema,
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            merge_into(
+                target=name,
+                source=source,
+                catalog_options=self.catalog_options,
+                on=['id'],
+                when_matched=[WhenMatched(update='*')],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+        self.assertIn('partition key', str(ctx.exception))
+
+    def test_partitioned_insert_allowed(self):
+        pt_schema = pa.schema([
+            ('pt', pa.string()),
+            ('id', pa.int32()),
+            ('name', pa.string()),
+        ])
+        name = f'default.tbl_{uuid.uuid4().hex[:8]}'
+        s = Schema.from_pyarrow_schema(
+            pt_schema, partition_keys=['pt'], options=self.de_options,
+        )
+        self.catalog.create_table(name, s, False)
+
+        source = pa.Table.from_pydict(
+            {
+                'pt': ['a', 'b'],
+                'id': pa.array([1, 2], type=pa.int32()),
+                'name': ['x', 'y'],
+            },
+            schema=pt_schema,
+        )
+
+        merge_into(
+            target=name,
+            source=source,
+            catalog_options=self.catalog_options,
+            on=['id'],
+            when_not_matched=[WhenNotMatched(insert='*')],
+            num_partitions=_TEST_NUM_PARTITIONS,
+        )
+
+        table = self.catalog.get_table(name)
+        rb = table.new_read_builder()
+        splits = rb.new_scan().plan().splits()
+        out = rb.new_read().to_arrow(splits).sort_by('id').to_pydict()
+        self.assertEqual(out['id'], [1, 2])
+        self.assertEqual(out['pt'], ['a', 'b'])
+
 
 class TargetProjectionTest(unittest.TestCase):
 


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow API guard and documentation with tests; no changes to commit or update logic for allowed paths.
> 
> **Overview**
> **Ray `merge_into` now fails fast** when the target is partitioned and any `when_matched` clause is present, because matched updates could imply cross-partition row movement, which is not implemented.
> 
> During `_prepare`, if `when_matched` is non-empty and `table.partition_keys` is set, a **`ValueError`** is raised with a clear message. **`when_not_matched` inserts on partitioned tables are unchanged** and still supported.
> 
> The Ray Data docs **Notes** section documents this limitation. A stale **TODO** about a post–PR #8045 global-index update check was removed from the commit path. **Tests** cover rejected matched updates and successful not-matched inserts on partitioned data-evolution tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 538391f6f81d8ae1a39daa26e4daef0addc228bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->