### PR TITLE
[python] Add Ray blob feature update e2e and docs

### DIFF
--- a/docs/docs/learn-paimon/scenario-guide.mdx
+++ b/docs/docs/learn-paimon/scenario-guide.mdx
@@ -536,13 +536,13 @@ a Blob column `payload`, and a non-Blob feature column `feature` to update.
 import ray
 from pypaimon.ray import read_paimon, merge_into, WhenMatched, source_col
 
-catalog_options = {"warehouse": "s3://my-bucket/warehouse"}
+catalog_options = {"warehouse": "/path/to/warehouse"}
 target = "db.item_features"
 num_partitions = 1024
 
 # Keys selected by an upstream job. This can also come from another Paimon table,
 # Parquet files, or any Ray Dataset.
-records_to_process = ray.data.read_parquet("s3://my-bucket/records-to-process/")
+records_to_process = ray.data.read_parquet("/path/to/records-to-process/")
 
 # Read only the columns needed for this job.
 target_rows = read_paimon(

--- a/docs/docs/learn-paimon/scenario-guide.mdx
+++ b/docs/docs/learn-paimon/scenario-guide.mdx
@@ -525,6 +525,65 @@ and merges them at read time. This is ideal for:
 - Iterative ML feature engineering — add, update, or refine features as your model evolves.
 - Reducing I/O cost and storage overhead for frequent partial column updates.
 
+#### Distributed Feature Backfill with Ray
+
+For pipelines that derive features from large payloads, keep the payload in Blob columns and update only the derived
+feature columns. Ray can read the records to process, run distributed computation, and call PyPaimon's Ray `merge_into`
+to write feature values back to the data-evolution table. The example assumes the target table has a key column `id`,
+a Blob column `payload`, and a non-Blob feature column `feature` to update.
+
+```python
+import ray
+from pypaimon.ray import read_paimon, merge_into, WhenMatched, source_col
+
+catalog_options = {"warehouse": "s3://my-bucket/warehouse"}
+target = "db.item_features"
+num_partitions = 1024
+
+# Keys selected by an upstream job. This can also come from another Paimon table,
+# Parquet files, or any Ray Dataset.
+records_to_process = ray.data.read_parquet("s3://my-bucket/records-to-process/")
+
+# Read only the columns needed for this job.
+target_rows = read_paimon(
+    target,
+    catalog_options=catalog_options,
+    projection=["id", "payload"],
+)
+
+selected = records_to_process.join(
+    target_rows,
+    join_type="inner",
+    num_partitions=num_partitions,
+    on=("id",),
+)
+
+def compute_feature(batch):
+    # Call your model service here. This example only keeps the shape simple.
+    payloads = batch["payload"].to_pylist()
+    return {
+        "id": batch["id"].to_pylist(),
+        "new_feature": [len(v) if v is not None else 0 for v in payloads],
+    }
+
+updates = selected.map_batches(compute_feature, batch_format="pyarrow")
+
+merge_into(
+    target=target,
+    source=updates,
+    catalog_options=catalog_options,
+    on=["id"],
+    when_matched=[
+        WhenMatched(update={"feature": source_col("new_feature")})
+    ],
+    num_partitions=num_partitions,
+)
+```
+
+`merge_into` rewrites only the matched non-Blob columns. Existing Blob files stay unchanged, so the source dataset does
+not need to carry Blob columns when it only updates feature fields. For very large key lists, tune Ray resources and
+`num_partitions`; selecting target rows is still a distributed join.
+
 ### Scenario 11: Python AI Pipeline (PyPaimon)
 
 **When:** You are building ML training or inference pipelines in Python and need to read/write Paimon tables natively

--- a/docs/docs/learn-paimon/scenario-guide.mdx
+++ b/docs/docs/learn-paimon/scenario-guide.mdx
@@ -555,7 +555,7 @@ selected = records_to_process.join(
     target_rows,
     join_type="inner",
     num_partitions=num_partitions,
-    on=("id",),
+    on=["id"],
 )
 
 def compute_feature(batch):

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -409,6 +409,9 @@ columns (`s.*`). Requires the `datafusion` package: `pip install pypaimon[sql]`.
 counts the rows actually updated (after condition filtering). `num_unchanged`
 is `0` in the current implementation.
 
+For an end-to-end feature update workflow on Blob tables, see
+[Distributed Feature Backfill with Ray](../learn-paimon/scenario-guide#distributed-feature-backfill-with-ray).
+
 **Notes:**
 - Partition key columns cannot be updated by matched clauses. If the target
   table is partitioned, `merge_into` raises an error when `when_matched` is

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -550,7 +550,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             target_rows,
             join_type='inner',
             num_partitions=num_partitions,
-            on=('id',),
+            on=['id'],
         )
 
         def compute_feature(batch):

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -28,7 +28,7 @@ import ray
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.ray import (
-    WhenMatched, WhenNotMatched, merge_into,
+    WhenMatched, WhenNotMatched, merge_into, read_paimon,
     source_col, target_col, lit,
 )
 
@@ -515,6 +515,76 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             )
         )
         self.assertEqual({'payload'}, _blob_col_names(fake_table))
+
+    def test_blob_table_feature_update(self):
+        blob_schema = pa.schema([
+            ('id', pa.int32()),
+            ('payload', pa.large_binary()),
+            ('feature', pa.int32()),
+        ])
+        name = f'default.tbl_{uuid.uuid4().hex[:8]}'
+        schema = Schema.from_pyarrow_schema(blob_schema, options=self.de_options)
+        self.catalog.create_table(name, schema, False)
+        self._write(
+            name,
+            pa.Table.from_pydict(
+                {
+                    'id': pa.array([1, 2, 3], type=pa.int32()),
+                    'payload': [b'aa', b'bbb', b'cccc'],
+                    'feature': pa.array([10, 20, 30], type=pa.int32()),
+                },
+                schema=blob_schema,
+            ),
+        )
+
+        num_partitions = _TEST_NUM_PARTITIONS
+        records_to_process = ray.data.from_arrow(pa.Table.from_pydict({
+            'id': pa.array([1, 3], type=pa.int32()),
+        }))
+        target_rows = read_paimon(
+            name,
+            self.catalog_options,
+            projection=['id', 'payload'],
+        )
+        selected = records_to_process.join(
+            target_rows,
+            join_type='inner',
+            num_partitions=num_partitions,
+            on=('id',),
+        )
+
+        def compute_feature(batch):
+            payloads = batch['payload'].to_pylist()
+            return pa.Table.from_pydict({
+                'id': batch['id'],
+                'new_feature': pa.array(
+                    [len(v) if v is not None else 0 for v in payloads],
+                    type=pa.int32(),
+                ),
+            })
+
+        updates = selected.map_batches(compute_feature, batch_format='pyarrow')
+        metrics = merge_into(
+            target=name,
+            source=updates,
+            catalog_options=self.catalog_options,
+            on=['id'],
+            when_matched=[
+                WhenMatched(update={'feature': source_col('new_feature')})
+            ],
+            num_partitions=num_partitions,
+        )
+
+        table = self.catalog.get_table(name)
+        rb = table.new_read_builder()
+        splits = rb.new_scan().plan().splits()
+        out = rb.new_read().to_arrow(splits).sort_by('id').to_pydict()
+        self.assertEqual(out['id'], [1, 2, 3])
+        self.assertEqual(out['feature'], [2, 20, 4])
+        self.assertEqual(out['payload'], [b'aa', b'bbb', b'cccc'])
+        self.assertEqual(metrics, {
+            'num_matched': 2, 'num_inserted': 0, 'num_unchanged': 0,
+        })
 
     def test_combined_writes_single_snapshot(self):
         target = self._create_table()


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test coverage only; no changes to merge_into or Ray runtime behavior.
> 
> **Overview**
> Documents **distributed feature backfill on data-evolution Blob tables** using Ray: join keys to projected target rows (`read_paimon`), compute features in `map_batches`, and write back with `merge_into` so only non-Blob columns change.
> 
> Adds a matching **integration test** (`test_blob_table_feature_update`) that exercises `read_paimon` → join → `merge_into` and asserts updated features while **Blob `payload` bytes stay intact**. The Ray Data **Merge Into** page now links to the new scenario-guide section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3880a799cb3c0e67069599a4c6a788e4eb9f026a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->