### PR TITLE
Blob update fix

### DIFF
--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1138,6 +1138,72 @@ class DedicatedFormatWriterTest(unittest.TestCase):
             3: b'blob-3',
         })
 
+    def test_update_blob_column_with_rolling_files(self):
+        from pypaimon import Schema
+
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('blob_data', pa.large_binary()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'blob.target-file-size': '1KB',
+            }
+        )
+        self.catalog.create_table('test_db.blob_update_column_rolling', schema, False)
+        table = self.catalog.get_table('test_db.blob_update_column_rolling')
+
+        initial = pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'blob_data': [b'blob-1', b'blob-2', b'blob-3', b'blob-4', b'blob-5'],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(initial)
+        write_builder.new_commit().commit(writer.prepare_commit())
+        writer.close()
+
+        update_builder = table.new_batch_write_builder()
+        table_update = update_builder.new_update().with_update_type(['blob_data'])
+        payload = b'x' * 2048
+        update_data = pa.Table.from_pydict({
+            '_ROW_ID': pa.array([0, 1, 2, 3, 4], type=pa.int64()),
+            'blob_data': pa.array(
+                [payload + suffix for suffix in [b'0', b'1', b'2', b'3', b'4']],
+                type=pa.large_binary(),
+            ),
+        })
+        update_messages = table_update.update_by_arrow_with_row_id(update_data)
+
+        update_blob_files = [
+            file
+            for msg in update_messages
+            for file in msg.new_files
+            if file.file_name.endswith('.blob')
+        ]
+        self.assertGreater(len(update_blob_files), 1)
+
+        update_builder.new_commit().commit(update_messages)
+
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(read_builder.new_scan().plan().splits())
+        by_id = {
+            row['id']: row['blob_data']
+            for row in result.select(['id', 'blob_data']).to_pylist()
+        }
+        self.assertEqual(by_id, {
+            1: payload + b'0',
+            2: payload + b'1',
+            3: payload + b'2',
+            4: payload + b'3',
+            5: payload + b'4',
+        })
+
     def test_blob_write_read_partition(self):
         """Test complete end-to-end blob functionality: write blob data and read it back to verify correctness."""
         from pypaimon import Schema

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1168,13 +1168,22 @@ class DedicatedFormatWriterTest(unittest.TestCase):
         write_builder.new_commit().commit(writer.prepare_commit())
         writer.close()
 
+        row_id_builder = table.new_read_builder().with_projection(['id', '_ROW_ID'])
+        row_id_result = row_id_builder.new_read().to_arrow(
+            row_id_builder.new_scan().plan().splits())
+        row_ids_by_id = {
+            row['id']: row['_ROW_ID']
+            for row in row_id_result.select(['id', '_ROW_ID']).to_pylist()
+        }
+
         update_builder = table.new_batch_write_builder()
         table_update = update_builder.new_update().with_update_type(['blob_data'])
         payload = b'x' * 2048
+        update_ids = [1, 2, 3, 4, 5]
         update_data = pa.Table.from_pydict({
-            '_ROW_ID': pa.array([0, 1, 2, 3, 4], type=pa.int64()),
+            '_ROW_ID': pa.array([row_ids_by_id[id_] for id_ in update_ids], type=pa.int64()),
             'blob_data': pa.array(
-                [payload + suffix for suffix in [b'0', b'1', b'2', b'3', b'4']],
+                [payload + str(id_ - 1).encode() for id_ in update_ids],
                 type=pa.large_binary(),
             ),
         })

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1213,6 +1213,101 @@ class DedicatedFormatWriterTest(unittest.TestCase):
             5: payload + b'4',
         })
 
+    def test_update_partial_blob_column_with_rolling_files(self):
+        from pypaimon import Schema
+        from pypaimon.read.reader.format_blob_reader import FormatBlobReader
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('blob_data', pa.large_binary()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'blob.target-file-size': '1KB',
+            }
+        )
+        self.catalog.create_table('test_db.blob_update_partial_column_rolling', schema, False)
+        table = self.catalog.get_table('test_db.blob_update_partial_column_rolling')
+
+        initial = pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'blob_data': [b'blob-1', b'blob-2', b'blob-3', b'blob-4', b'blob-5'],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(initial)
+        write_builder.new_commit().commit(writer.prepare_commit())
+        writer.close()
+
+        row_id_builder = table.new_read_builder().with_projection(['id', '_ROW_ID'])
+        row_id_result = row_id_builder.new_read().to_arrow(
+            row_id_builder.new_scan().plan().splits())
+        row_ids_by_id = {
+            row['id']: row['_ROW_ID']
+            for row in row_id_result.select(['id', '_ROW_ID']).to_pylist()
+        }
+
+        update_builder = table.new_batch_write_builder()
+        table_update = update_builder.new_update().with_update_type(['blob_data'])
+        payload = b'x' * 2048
+        update_ids = [2, 4]
+        update_data = pa.Table.from_pydict({
+            '_ROW_ID': pa.array([row_ids_by_id[id_] for id_ in update_ids], type=pa.int64()),
+            'blob_data': pa.array(
+                [payload + str(id_).encode() for id_ in update_ids],
+                type=pa.large_binary(),
+            ),
+        })
+        update_messages = table_update.update_by_arrow_with_row_id(update_data)
+
+        update_blob_files = [
+            file
+            for msg in update_messages
+            for file in msg.new_files
+            if file.file_name.endswith('.blob')
+        ]
+        self.assertGreater(len(update_blob_files), 1)
+
+        update_blob_lengths = []
+        blob_fields = [field for field in table.fields if field.name == 'blob_data']
+        for blob_file in update_blob_files:
+            blob_reader = FormatBlobReader(
+                file_io=table.file_io,
+                file_path=blob_file.file_path,
+                read_fields=['blob_data'],
+                full_fields=blob_fields,
+                push_down_predicate=None,
+                blob_as_descriptor=False,
+            )
+            update_blob_lengths.extend(blob_reader.blob_lengths)
+            blob_reader.close()
+        self.assertEqual(
+            update_blob_lengths.count(BlobFormatWriter.PLACE_HOLDER_LENGTH),
+            3,
+        )
+
+        update_builder.new_commit().commit(update_messages)
+
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(read_builder.new_scan().plan().splits())
+        by_id = {
+            row['id']: row['blob_data']
+            for row in result.select(['id', 'blob_data']).to_pylist()
+        }
+        self.assertEqual(by_id, {
+            1: b'blob-1',
+            2: payload + b'2',
+            3: b'blob-3',
+            4: payload + b'4',
+            5: b'blob-5',
+        })
+
     def test_blob_write_read_partition(self):
         """Test complete end-to-end blob functionality: write blob data and read it back to verify correctness."""
         from pypaimon import Schema

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -142,6 +142,16 @@ class TestCheckRowIdExistence(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("Row ID existence conflict", str(result))
 
+    def test_no_conflict_when_blob_file_range_is_covered_by_multiple_files(self):
+        detection = self._make_detection()
+        base = [
+            _make_entry("f1", kind=0, first_row_id=0, row_count=50),
+            _make_entry("f2", kind=0, first_row_id=50, row_count=50),
+        ]
+        delta = [_make_entry("p1.blob", kind=0, first_row_id=25, row_count=50)]
+        self.assertIsNone(
+            detection.check_row_id_existence(base, delta, next_row_id=200))
+
     def test_skip_newly_appended_files(self):
         detection = self._make_detection()
         base = []

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -127,6 +127,21 @@ class TestCheckRowIdExistence(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("Row ID existence conflict", str(result))
 
+    def test_no_conflict_when_dedicated_file_range_is_covered(self):
+        detection = self._make_detection()
+        base = [_make_entry("f1", kind=0, first_row_id=0, row_count=100)]
+        delta = [_make_entry("p1.blob", kind=0, first_row_id=20, row_count=10)]
+        self.assertIsNone(
+            detection.check_row_id_existence(base, delta, next_row_id=200))
+
+    def test_conflict_when_dedicated_file_range_is_not_covered(self):
+        detection = self._make_detection()
+        base = [_make_entry("f1", kind=0, first_row_id=0, row_count=100)]
+        delta = [_make_entry("p1.blob", kind=0, first_row_id=95, row_count=10)]
+        result = detection.check_row_id_existence(base, delta, next_row_id=200)
+        self.assertIsNotNone(result)
+        self.assertIn("Row ID existence conflict", str(result))
+
     def test_skip_newly_appended_files(self):
         detection = self._make_detection()
         base = []

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -152,6 +152,17 @@ class TestCheckRowIdExistence(unittest.TestCase):
         self.assertIsNone(
             detection.check_row_id_existence(base, delta, next_row_id=200))
 
+    def test_conflict_when_blob_file_range_is_only_covered_by_base_blob_file(self):
+        detection = self._make_detection()
+        base = [
+            _make_entry("f1", kind=0, first_row_id=0, row_count=50),
+            _make_entry("p0.blob", kind=0, first_row_id=50, row_count=50),
+        ]
+        delta = [_make_entry("p1.blob", kind=0, first_row_id=60, row_count=10)]
+        result = detection.check_row_id_existence(base, delta, next_row_id=200)
+        self.assertIsNotNone(result)
+        self.assertIn("Row ID existence conflict", str(result))
+
     def test_skip_newly_appended_files(self):
         detection = self._make_detection()
         base = []

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -127,14 +127,14 @@ class TestCheckRowIdExistence(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("Row ID existence conflict", str(result))
 
-    def test_no_conflict_when_dedicated_file_range_is_covered(self):
+    def test_no_conflict_when_blob_file_range_is_covered(self):
         detection = self._make_detection()
         base = [_make_entry("f1", kind=0, first_row_id=0, row_count=100)]
         delta = [_make_entry("p1.blob", kind=0, first_row_id=20, row_count=10)]
         self.assertIsNone(
             detection.check_row_id_existence(base, delta, next_row_id=200))
 
-    def test_conflict_when_dedicated_file_range_is_not_covered(self):
+    def test_conflict_when_blob_file_range_is_not_covered(self):
         detection = self._make_detection()
         base = [_make_entry("f1", kind=0, first_row_id=0, row_count=100)]
         delta = [_make_entry("p1.blob", kind=0, first_row_id=95, row_count=10)]

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -216,10 +216,14 @@ class ConflictDetection:
                     existing_ranges.setdefault((base.partition, base.bucket), []).append(
                         base.file.row_id_range())
 
+        existing_ranges = {
+            key: Range.sort_and_merge_overlap(ranges, True, True)
+            for key, ranges in existing_ranges.items()
+        }
+
         for entry in files_to_check:
             if self._is_dedicated_storage_file(entry.file.file_name):
-                base_ranges = Range.sort_and_merge_overlap(
-                    existing_ranges.get((entry.partition, entry.bucket), []), True, True)
+                base_ranges = existing_ranges.get((entry.partition, entry.bucket), [])
                 if not entry.file.row_id_range().exclude(base_ranges):
                     continue
 

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -279,7 +279,7 @@ class ConflictDetection:
 
     @staticmethod
     def _is_dedicated_storage_file(file_name: str) -> bool:
-        return DataFileMeta.is_blob_file(file_name) or DataFileMeta.is_vector_file(file_name)
+        return DataFileMeta.is_blob_file(file_name)
 
     def check_row_id_from_snapshot(self, latest_snapshot, commit_entries):
         if not self.data_evolution_enabled:

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -212,7 +212,7 @@ class ConflictDetection:
                 existing_index.add((
                     base.partition, base.bucket,
                     base.file.first_row_id, base.file.row_count))
-                if not self._is_blob_file(base.file.file_name):
+                if not DataFileMeta.is_blob_file(base.file.file_name):
                     existing_ranges.setdefault((base.partition, base.bucket), []).append(
                         base.file.row_id_range())
 
@@ -222,7 +222,7 @@ class ConflictDetection:
         }
 
         for entry in files_to_check:
-            if self._is_blob_file(entry.file.file_name):
+            if DataFileMeta.is_blob_file(entry.file.file_name):
                 base_ranges = existing_ranges.get((entry.partition, entry.bucket), [])
                 if not entry.file.row_id_range().exclude(base_ranges):
                     continue
@@ -263,7 +263,7 @@ class ConflictDetection:
         for group in merged_groups:
             data_files = [
                 entry for entry in group
-                if not self._is_blob_file(entry.file.file_name)
+                if not DataFileMeta.is_blob_file(entry.file.file_name)
             ]
             if not range_helper.are_all_ranges_same(data_files):
                 file_descriptions = [
@@ -280,10 +280,6 @@ class ConflictDetection:
                     + str(file_descriptions))
 
         return None
-
-    @staticmethod
-    def _is_blob_file(file_name: str) -> bool:
-        return DataFileMeta.is_blob_file(file_name)
 
     def check_row_id_from_snapshot(self, latest_snapshot, commit_entries):
         if not self.data_evolution_enabled:

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -206,13 +206,23 @@ class ConflictDetection:
             return None
 
         existing_index = set()
+        existing_ranges = {}
         for base in base_entries:
             if base.file.first_row_id is not None:
                 existing_index.add((
                     base.partition, base.bucket,
                     base.file.first_row_id, base.file.row_count))
+                if not self._is_dedicated_storage_file(base.file.file_name):
+                    existing_ranges.setdefault((base.partition, base.bucket), []).append(
+                        base.file.row_id_range())
 
         for entry in files_to_check:
+            if self._is_dedicated_storage_file(entry.file.file_name):
+                base_ranges = Range.sort_and_merge_overlap(
+                    existing_ranges.get((entry.partition, entry.bucket), []), True, True)
+                if not entry.file.row_id_range().exclude(base_ranges):
+                    continue
+
             key = (entry.partition, entry.bucket,
                    entry.file.first_row_id, entry.file.row_count)
             if key not in existing_index:
@@ -249,7 +259,7 @@ class ConflictDetection:
         for group in merged_groups:
             data_files = [
                 entry for entry in group
-                if not DataFileMeta.is_blob_file(entry.file.file_name)
+                if not self._is_dedicated_storage_file(entry.file.file_name)
             ]
             if not range_helper.are_all_ranges_same(data_files):
                 file_descriptions = [
@@ -266,6 +276,10 @@ class ConflictDetection:
                     + str(file_descriptions))
 
         return None
+
+    @staticmethod
+    def _is_dedicated_storage_file(file_name: str) -> bool:
+        return DataFileMeta.is_blob_file(file_name) or DataFileMeta.is_vector_file(file_name)
 
     def check_row_id_from_snapshot(self, latest_snapshot, commit_entries):
         if not self.data_evolution_enabled:

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -212,7 +212,7 @@ class ConflictDetection:
                 existing_index.add((
                     base.partition, base.bucket,
                     base.file.first_row_id, base.file.row_count))
-                if not self._is_dedicated_storage_file(base.file.file_name):
+                if not self._is_blob_file(base.file.file_name):
                     existing_ranges.setdefault((base.partition, base.bucket), []).append(
                         base.file.row_id_range())
 
@@ -222,7 +222,7 @@ class ConflictDetection:
         }
 
         for entry in files_to_check:
-            if self._is_dedicated_storage_file(entry.file.file_name):
+            if self._is_blob_file(entry.file.file_name):
                 base_ranges = existing_ranges.get((entry.partition, entry.bucket), [])
                 if not entry.file.row_id_range().exclude(base_ranges):
                     continue
@@ -263,7 +263,7 @@ class ConflictDetection:
         for group in merged_groups:
             data_files = [
                 entry for entry in group
-                if not self._is_dedicated_storage_file(entry.file.file_name)
+                if not self._is_blob_file(entry.file.file_name)
             ]
             if not range_helper.are_all_ranges_same(data_files):
                 file_descriptions = [
@@ -282,7 +282,7 @@ class ConflictDetection:
         return None
 
     @staticmethod
-    def _is_dedicated_storage_file(file_name: str) -> bool:
+    def _is_blob_file(file_name: str) -> bool:
         return DataFileMeta.is_blob_file(file_name)
 
     def check_row_id_from_snapshot(self, latest_snapshot, commit_entries):

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -397,6 +397,10 @@ class TableUpdateByRowId:
         for file in new_files:
             file.write_cols = file.write_cols or column_names
             if DataFileMeta.is_blob_file(file.file_name):
+                if len(file.write_cols) != 1:
+                    raise RuntimeError(
+                        f"Blob update file {file.file_name} should contain exactly one write column, "
+                        f"got {file.write_cols}")
                 blob_column = file.write_cols[0]
                 blob_start = blob_starts.get(blob_column, first_row_id)
                 file.first_row_id = blob_start

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -401,8 +401,8 @@ class TableUpdateByRowId:
             if DataFileMeta.is_blob_file(file.file_name):
                 if len(file.write_cols) != 1:
                     raise RuntimeError(
-                        f"Blob update file {file.file_name} should contain exactly one write column, "
-                        f"got {file.write_cols}")
+                        f"Blob update file {file.file_name} should contain "
+                        f"exactly one write column, got {file.write_cols}")
                 blob_column = file.write_cols[0]
                 blob_start = blob_starts.get(blob_column, first_row_id)
                 next_blob_start = blob_start + file.row_count

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -412,6 +412,10 @@ class TableUpdateByRowId:
                         f"[{blob_start}, {next_blob_start - 1}] exceeds target range "
                         f"[{first_row_id}, {blob_end - 1}]")
                 file.first_row_id = blob_start
+                # Only update-by-row-id blob delta files use the 0/0 sentinel;
+                # regular blob writes keep their per-row sequence range.
+                file.min_sequence_number = 0
+                file.max_sequence_number = 0
                 blob_starts[blob_column] = next_blob_start
             else:
                 file.first_row_id = first_row_id

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -375,9 +375,7 @@ class TableUpdateByRowId:
                 new_files.extend(blob_writer.prepare_commit())
 
             if new_files:
-                for file in new_files:
-                    file.first_row_id = first_row_id
-                    file.write_cols = file.write_cols or column_names
+                self._assign_update_file_metadata(new_files, first_row_id, column_names)
                 self.commit_messages.append(
                     CommitMessage(
                         partition=partition_tuple,
@@ -391,3 +389,17 @@ class TableUpdateByRowId:
                 file_store_write.close()
             for blob_writer in blob_writers:
                 blob_writer.close()
+
+    @staticmethod
+    def _assign_update_file_metadata(new_files: List[DataFileMeta], first_row_id: int,
+                                     column_names: List[str]):
+        blob_starts = {}
+        for file in new_files:
+            file.write_cols = file.write_cols or column_names
+            if DataFileMeta.is_blob_file(file.file_name):
+                blob_column = file.write_cols[0]
+                blob_start = blob_starts.get(blob_column, first_row_id)
+                file.first_row_id = blob_start
+                blob_starts[blob_column] = blob_start + file.row_count
+            else:
+                file.first_row_id = first_row_id

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -375,7 +375,8 @@ class TableUpdateByRowId:
                 new_files.extend(blob_writer.prepare_commit())
 
             if new_files:
-                self._assign_update_file_metadata(new_files, first_row_id, column_names)
+                self._assign_update_file_metadata(
+                    new_files, first_row_id, column_names, original_data.num_rows)
                 self.commit_messages.append(
                     CommitMessage(
                         partition=partition_tuple,
@@ -392,7 +393,8 @@ class TableUpdateByRowId:
 
     @staticmethod
     def _assign_update_file_metadata(new_files: List[DataFileMeta], first_row_id: int,
-                                     column_names: List[str]):
+                                     column_names: List[str], expected_row_count: int):
+        blob_end = first_row_id + expected_row_count
         blob_starts = {}
         for file in new_files:
             file.write_cols = file.write_cols or column_names
@@ -403,7 +405,20 @@ class TableUpdateByRowId:
                         f"got {file.write_cols}")
                 blob_column = file.write_cols[0]
                 blob_start = blob_starts.get(blob_column, first_row_id)
+                next_blob_start = blob_start + file.row_count
+                if next_blob_start > blob_end:
+                    raise RuntimeError(
+                        f"Blob update file {file.file_name} row-id range "
+                        f"[{blob_start}, {next_blob_start - 1}] exceeds target range "
+                        f"[{first_row_id}, {blob_end - 1}]")
                 file.first_row_id = blob_start
-                blob_starts[blob_column] = blob_start + file.row_count
+                blob_starts[blob_column] = next_blob_start
             else:
                 file.first_row_id = first_row_id
+
+        for blob_column, next_blob_start in blob_starts.items():
+            if next_blob_start != blob_end:
+                raise RuntimeError(
+                    f"Blob update column {blob_column} covers row ids "
+                    f"[{first_row_id}, {next_blob_start - 1}], expected "
+                    f"[{first_row_id}, {blob_end - 1}]")

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -396,6 +396,8 @@ class TableUpdateByRowId:
                                      column_names: List[str], expected_row_count: int):
         blob_end = first_row_id + expected_row_count
         blob_starts = {}
+        # BlobWriter.prepare_commit preserves write/rolling order, which is required
+        # for assigning continuous row-id ranges to rolled blob files.
         for file in new_files:
             file.write_cols = file.write_cols or column_names
             if DataFileMeta.is_blob_file(file.file_name):

--- a/paimon-python/pypaimon/write/writer/blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/blob_writer.py
@@ -183,8 +183,9 @@ class BlobWriter(AppendOnlyDataWriter):
             value_null_counts = [0]
 
         if self.options.data_evolution_enabled(False):
+            # Row-tracking commit stamps files with min_sequence_number == 0 to the snapshot id.
             min_seq = 0
-            max_seq = row_count - 1
+            max_seq = 0
         else:
             min_seq = self.sequence_generator.current - row_count
             max_seq = self.sequence_generator.current - 1

--- a/paimon-python/pypaimon/write/writer/blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/blob_writer.py
@@ -213,7 +213,7 @@ class BlobWriter(AppendOnlyDataWriter):
         ))
 
     def prepare_commit(self):
-        """Prepare commit, ensuring all data is written."""
+        """Prepare commit, preserving blob files in write/rolling order."""
         # Close current file if open.
         if self.current_writer is not None:
             self.close_current_writer()

--- a/paimon-python/pypaimon/write/writer/blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/blob_writer.py
@@ -182,13 +182,8 @@ class BlobWriter(AppendOnlyDataWriter):
             max_value_stats = [None]
             value_null_counts = [0]
 
-        if self.options.data_evolution_enabled(False):
-            # Row-tracking commit stamps files with min_sequence_number == 0 to the snapshot id.
-            min_seq = 0
-            max_seq = 0
-        else:
-            min_seq = self.sequence_generator.current - row_count
-            max_seq = self.sequence_generator.current - 1
+        min_seq = self.sequence_generator.current - row_count
+        max_seq = self.sequence_generator.current - 1
         self.sequence_generator.start = self.sequence_generator.current
 
         self.committed_files.append(DataFileMeta.create(

--- a/paimon-python/pypaimon/write/writer/blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/blob_writer.py
@@ -182,8 +182,12 @@ class BlobWriter(AppendOnlyDataWriter):
             max_value_stats = [None]
             value_null_counts = [0]
 
-        min_seq = self.sequence_generator.current - row_count
-        max_seq = self.sequence_generator.current - 1
+        if self.options.data_evolution_enabled(False):
+            min_seq = 0
+            max_seq = row_count - 1
+        else:
+            min_seq = self.sequence_generator.current - row_count
+            max_seq = self.sequence_generator.current - 1
         self.sequence_generator.start = self.sequence_generator.current
 
         self.committed_files.append(DataFileMeta.create(


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches data-evolution commit conflict logic and blob update metadata; incorrect row-id assignment could cause read/commit failures, but changes are scoped and heavily tested.
> 
> **Overview**
> Fixes **row-by-id blob column updates** when rolling produces multiple `.blob` files, and aligns **commit row-ID existence checks** with how those blob deltas reference rows.
> 
> **Update path:** `_assign_update_file_metadata` replaces assigning the same `first_row_id` to every new file. Rolled blob files get **contiguous row-id slices** per column (in write/rolling order), `min_sequence_number` / `max_sequence_number` set to **0/0** for update deltas, and validation that ranges match the update batch size.
> 
> **Conflict detection:** Delta `.blob` files no longer require an exact `(firstRowId, rowCount)` match in the snapshot index. Their row-id range must be **covered by merged non-blob base file ranges**; coverage only from base blob files still counts as a conflict.
> 
> New integration tests cover full/partial updates with `blob.target-file-size` rolling and unit tests for the blob range rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8059cb3587387bed9caed06a2971b5000bd4a912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->