### PR TITLE
Upsert list fix

### DIFF
--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -623,6 +623,18 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
             [[('a', '1')], [('k2', 'dict_val')], [('b', '2')]],
             result3['meta'].to_pylist())
 
+        self._do_update(table, pa.Table.from_pydict({
+            '_ROW_ID': pa.array([row_ids[0]], type=pa.int64()),
+            'meta': [[('a', None)]],
+        }, schema=pa.schema([
+            ('_ROW_ID', pa.int64()),
+            ('meta', pa.map_(pa.string(), pa.string())),
+        ])), ['meta'])
+        result4 = self._read_all(table).sort_by('id')
+        self.assertEqual(
+            [[('a', None)], [('k2', 'dict_val')], [('b', '2')]],
+            result4['meta'].to_pylist())
+
 
 # ======================================================================
 # Mode-specific mixins (add the ``update_by_arrow_with_row_id`` primitive)

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -613,15 +613,30 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
             [[('k1', 'new1')], [('k2', 'dict_val')], [('k3', 'new3')]],
             result2['meta'].to_pylist())
 
+        with self.assertRaisesRegex(ValueError, "schema-less dict"):
+            self._do_update(table, pa.Table.from_pydict({
+                '_ROW_ID': pa.array([row_ids[0], row_ids[2]],
+                                    type=pa.int64()),
+                'meta': [{'a': '1'}, {'b': '2'}],
+            }), ['meta'])
+
         self._do_update(table, pa.Table.from_pydict({
             '_ROW_ID': pa.array([row_ids[0], row_ids[2]],
                                 type=pa.int64()),
-            'meta': [{'a': '1'}, {'b': '2'}],
+            'meta': pa.array(
+                [[('a', '1')], [('b', '2')]],
+                type=pa.map_(pa.string(), pa.string())),
         }), ['meta'])
         result3 = self._read_all(table).sort_by('id')
         self.assertEqual(
             [[('a', '1')], [('k2', 'dict_val')], [('b', '2')]],
             result3['meta'].to_pylist())
+
+        with self.assertRaisesRegex(ValueError, "schema-less dict"):
+            self._do_update(table, pa.Table.from_pydict({
+                '_ROW_ID': pa.array([row_ids[0]], type=pa.int64()),
+                'meta': [{'a': None}],
+            }), ['meta'])
 
         self._do_update(table, pa.Table.from_pydict({
             '_ROW_ID': pa.array([row_ids[0]], type=pa.int64()),

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -570,6 +570,40 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
         # Rows 3 & 4 must remain at seed values
         self.assertEqual([40, 45], ages[3:])
 
+    def test_update_list_and_map_columns(self):
+        list_map_schema = pa.schema([
+            ('id', pa.int32()),
+            ('tags', pa.list_(pa.string())),
+            ('meta', pa.map_(pa.string(), pa.string())),
+        ])
+        table = self._create_table(pa_schema=list_map_schema)
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'tags': [['a', 'b'], ['c'], ['d', 'e']],
+            'meta': [[('k1', 'v1')], [('k2', 'v2')], [('k3', 'v3')]],
+        }, schema=list_map_schema))
+
+        rb = table.new_read_builder().with_projection(
+            ['id', '_ROW_ID'])
+        rid_result = rb.new_read().to_arrow(
+            rb.new_scan().plan().splits()).sort_by('id')
+        row_ids = rid_result['_ROW_ID'].to_pylist()
+
+        self._do_update(table, pa.Table.from_pydict({
+            '_ROW_ID': pa.array([row_ids[0], row_ids[2]],
+                                type=pa.int64()),
+            'tags': [['x', 'y'], ['z']],
+            'meta': [[('k1', 'new1')], [('k3', 'new3')]],
+        }), ['tags', 'meta'])
+
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual(
+            [['x', 'y'], ['c'], ['z']],
+            result['tags'].to_pylist())
+        self.assertEqual(
+            [[('k1', 'new1')], [('k2', 'v2')], [('k3', 'new3')]],
+            result['meta'].to_pylist())
+
 
 # ======================================================================
 # Mode-specific mixins (add the ``update_by_arrow_with_row_id`` primitive)

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -613,6 +613,16 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
             [[('k1', 'new1')], [('k2', 'dict_val')], [('k3', 'new3')]],
             result2['meta'].to_pylist())
 
+        self._do_update(table, pa.Table.from_pydict({
+            '_ROW_ID': pa.array([row_ids[0], row_ids[2]],
+                                type=pa.int64()),
+            'meta': [{'a': '1'}, {'b': '2'}],
+        }), ['meta'])
+        result3 = self._read_all(table).sort_by('id')
+        self.assertEqual(
+            [[('a', '1')], [('k2', 'dict_val')], [('b', '2')]],
+            result3['meta'].to_pylist())
+
 
 # ======================================================================
 # Mode-specific mixins (add the ``update_by_arrow_with_row_id`` primitive)

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -604,6 +604,15 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
             [[('k1', 'new1')], [('k2', 'v2')], [('k3', 'new3')]],
             result['meta'].to_pylist())
 
+        self._do_update(table, pa.Table.from_pydict({
+            '_ROW_ID': pa.array([row_ids[1]], type=pa.int64()),
+            'meta': [{'k2': 'dict_val'}],
+        }), ['meta'])
+        result2 = self._read_all(table).sort_by('id')
+        self.assertEqual(
+            [[('k1', 'new1')], [('k2', 'dict_val')], [('k3', 'new3')]],
+            result2['meta'].to_pylist())
+
 
 # ======================================================================
 # Mode-specific mixins (add the ``update_by_arrow_with_row_id`` primitive)

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -354,10 +354,15 @@ class TableUpdateByRowId:
                 if row is None:
                     converted.append(None)
                 elif isinstance(row, dict):
-                    # Drop Arrow struct padding for missing dict keys.
-                    converted.append(
-                        [(k, v) for k, v in row.items()
-                         if v is not None])
+                    if pa.types.is_struct(col.type) and any(
+                            v is None for v in row.values()):
+                        raise ValueError(
+                            "Cannot coerce schema-less dict input with null "
+                            "values to map type. PyArrow represents both "
+                            "missing dict keys and explicit null map values "
+                            "as None; pass an explicit map-typed array or "
+                            "list-of-pairs instead.")
+                    converted.append(list(row.items()))
                 else:
                     converted.append(
                         [tuple(pair) for pair in row])

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -337,15 +337,15 @@ class TableUpdateByRowId:
                         original_col, mask, update_col)
                 except pa.lib.ArrowNotImplementedError:
                     n = original_data.num_rows
-                    chunks = []
-                    for i in range(n):
-                        if i in update_positions:
-                            chunks.append(update_col.slice(
-                                update_positions[i], 1))
-                        else:
-                            chunks.append(original_col.slice(i, 1))
-                    merged_columns[col_name] = pa.concat_arrays(
-                        chunks)
+                    combined = pa.concat_arrays(
+                        [original_col, update_col])
+                    offset = len(original_col)
+                    indices = [
+                        offset + update_positions[i]
+                        if i in update_positions else i
+                        for i in range(n)]
+                    merged_columns[col_name] = combined.take(
+                        pa.array(indices))
 
         merged_table = pa.table(merged_columns) if merged_columns else None
 

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -318,7 +318,9 @@ class TableUpdateByRowId:
                     pylist = update_col.to_pylist()
                     if pa.types.is_map(original_col.type):
                         pylist = [
-                            [tuple(pair) for pair in row]
+                            list(row.items())
+                            if isinstance(row, dict)
+                            else [tuple(pair) for pair in row]
                             if row is not None else None
                             for row in pylist
                         ]

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -19,6 +19,7 @@ import bisect
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
+import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 
@@ -310,22 +311,8 @@ class TableUpdateByRowId:
             update_col = update_by_col[col_name]
             original_col = original_data[col_name].combine_chunks()
             if update_col.type != original_col.type:
-                try:
-                    update_col = update_col.cast(original_col.type)
-                except (pa.lib.ArrowNotImplementedError,
-                        pa.lib.ArrowInvalid,
-                        pa.lib.ArrowTypeError):
-                    pylist = update_col.to_pylist()
-                    if pa.types.is_map(original_col.type):
-                        pylist = [
-                            list(row.items())
-                            if isinstance(row, dict)
-                            else [tuple(pair) for pair in row]
-                            if row is not None else None
-                            for row in pylist
-                        ]
-                    update_col = pa.array(
-                        pylist, type=original_col.type)
+                update_col = self._coerce_column(
+                    update_col, original_col.type)
             if self._is_blob_column(col_name):
                 blob_columns[col_name] = [
                     update_col[update_positions[i]].as_py()
@@ -342,16 +329,39 @@ class TableUpdateByRowId:
                     combined = pa.concat_arrays(
                         [original_col, update_col])
                     offset = len(original_col)
-                    indices = [
-                        offset + update_positions[i]
-                        if i in update_positions else i
-                        for i in range(n)]
+                    indices = np.arange(n, dtype=np.int64)
+                    for orig_pos, upd_idx in update_positions.items():
+                        indices[orig_pos] = offset + upd_idx
                     merged_columns[col_name] = combined.take(
                         pa.array(indices))
 
         merged_table = pa.table(merged_columns) if merged_columns else None
 
         return merged_table, blob_columns
+
+    @staticmethod
+    def _coerce_column(col: pa.Array, target_type: pa.DataType) -> pa.Array:
+        try:
+            return col.cast(target_type)
+        except (pa.lib.ArrowNotImplementedError,
+                pa.lib.ArrowInvalid,
+                pa.lib.ArrowTypeError):
+            pass
+        pylist = col.to_pylist()
+        if pa.types.is_map(target_type):
+            converted = []
+            for row in pylist:
+                if row is None:
+                    converted.append(None)
+                elif isinstance(row, dict):
+                    converted.append(
+                        [(k, v) for k, v in row.items()
+                         if v is not None])
+                else:
+                    converted.append(
+                        [tuple(pair) for pair in row])
+            pylist = converted
+        return pa.array(pylist, type=target_type)
 
     def _is_blob_column(self, column_name: str) -> bool:
         for table_field in self.table.fields:

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -309,6 +309,21 @@ class TableUpdateByRowId:
         for col_name in column_names:
             update_col = update_by_col[col_name]
             original_col = original_data[col_name].combine_chunks()
+            if update_col.type != original_col.type:
+                try:
+                    update_col = update_col.cast(original_col.type)
+                except (pa.lib.ArrowNotImplementedError,
+                        pa.lib.ArrowInvalid,
+                        pa.lib.ArrowTypeError):
+                    pylist = update_col.to_pylist()
+                    if pa.types.is_map(original_col.type):
+                        pylist = [
+                            [tuple(pair) for pair in row]
+                            if row is not None else None
+                            for row in pylist
+                        ]
+                    update_col = pa.array(
+                        pylist, type=original_col.type)
             if self._is_blob_column(col_name):
                 blob_columns[col_name] = [
                     update_col[update_positions[i]].as_py()
@@ -317,10 +332,20 @@ class TableUpdateByRowId:
                     for i in range(original_data.num_rows)
                 ]
             else:
-                # replace_with_mask fills mask=True positions with update values in order
-                merged_columns[col_name] = pc.replace_with_mask(
-                    original_col, mask, update_col.cast(original_col.type)
-                )
+                try:
+                    merged_columns[col_name] = pc.replace_with_mask(
+                        original_col, mask, update_col)
+                except pa.lib.ArrowNotImplementedError:
+                    n = original_data.num_rows
+                    chunks = []
+                    for i in range(n):
+                        if i in update_positions:
+                            chunks.append(update_col.slice(
+                                update_positions[i], 1))
+                        else:
+                            chunks.append(original_col.slice(i, 1))
+                    merged_columns[col_name] = pa.concat_arrays(
+                        chunks)
 
         merged_table = pa.table(merged_columns) if merged_columns else None
 

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -354,6 +354,7 @@ class TableUpdateByRowId:
                 if row is None:
                     converted.append(None)
                 elif isinstance(row, dict):
+                    # Drop Arrow struct padding for missing dict keys.
                     converted.append(
                         [(k, v) for k, v in row.items()
                          if v is not None])


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core merge behavior for all column types during row-id updates (new coercion path and fallback), though scoped to data-evolution write paths and covered by new nested-type tests.
> 
> **Overview**
> **Row-id column updates** now handle **list** and **map** fields when the incoming PyArrow column type does not match the stored column (e.g. list-of-pairs vs map, or dict-shaped update values).
> 
> In `table_update_by_row_id.py`, merge logic **coerces** update columns via new `_coerce_column` (cast when possible; for maps, normalize dicts and list-of-pairs, with a clear error for ambiguous schema-less dicts that contain nulls). Merging tries `pc.replace_with_mask` on coerced arrays and, on `ArrowNotImplementedError`, uses a **concat + indexed take** fallback (numpy indices) instead of failing.
> 
> Adds **`test_update_list_and_map_columns`** to cover list/map updates, dict-to-map coercion, explicit map arrays, and null map values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6207dcaa590593def4e59b62aed365640665d9a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->