### PR TITLE
[python] Ban blob column updates in update-by-row-id

### DIFF
--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1188,6 +1188,55 @@ class DedicatedFormatWriterTest(unittest.TestCase):
         self.assertEqual(by_id[2]['name'], 'b_updated')
         self.assertEqual(by_id[2]['blob_data'], b'blob-2')
 
+    def test_upsert_normal_columns_on_blob_table(self):
+        from pypaimon import Schema
+
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('name', pa.string()),
+            ('blob_data', pa.large_binary()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+            }
+        )
+        self.catalog.create_table('test_db.blob_upsert_normal', schema, False)
+        table = self.catalog.get_table('test_db.blob_upsert_normal')
+
+        initial = pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'name': ['a', 'b', 'c'],
+            'blob_data': [b'blob-1', b'blob-2', b'blob-3'],
+        }, schema=pa_schema)
+
+        wb = table.new_batch_write_builder()
+        w = wb.new_write()
+        w.write_arrow(initial)
+        wb.new_commit().commit(w.prepare_commit())
+        w.close()
+
+        upsert_data = pa.Table.from_pydict({
+            'id': [2, 4],
+            'name': ['b_updated', 'd_new'],
+        })
+
+        ub = table.new_batch_write_builder()
+        tu = ub.new_update().with_update_type(['name'])
+        msgs = tu.upsert_by_arrow_with_key(upsert_data, upsert_keys=['id'])
+        ub.new_commit().commit(msgs)
+
+        table = self.catalog.get_table('test_db.blob_upsert_normal')
+        result = table.new_read_builder().new_read().to_arrow(
+            table.new_read_builder().new_scan().plan().splits())
+        by_id = {row['id']: row for row in result.to_pylist()}
+        self.assertEqual(by_id[2]['name'], 'b_updated')
+        self.assertEqual(by_id[2]['blob_data'], b'blob-2')
+        self.assertEqual(by_id[1]['blob_data'], b'blob-1')
+
     def test_blob_write_read_partition(self):
         """Test complete end-to-end blob functionality: write blob data and read it back to verify correctness."""
         from pypaimon import Schema

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1188,6 +1188,255 @@ class DedicatedFormatWriterTest(unittest.TestCase):
         self.assertEqual(by_id[2]['name'], 'b_updated')
         self.assertEqual(by_id[2]['blob_data'], b'blob-2')
 
+    @unittest.skip("Blob column updates banned; re-enable when implementation is hardened")
+    def test_update_blob_column(self):
+        from pypaimon import Schema
+        from pypaimon.read.reader.format_blob_reader import FormatBlobReader
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('name', pa.string()),
+            ('blob_data', pa.large_binary()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true'
+            }
+        )
+        self.catalog.create_table('test_db.blob_update_column', schema, False)
+        table = self.catalog.get_table('test_db.blob_update_column')
+
+        initial = pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'name': ['a', 'b', 'c'],
+            'blob_data': [b'blob-1', b'blob-2', b'blob-3'],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(initial)
+        write_builder.new_commit().commit(writer.prepare_commit())
+        writer.close()
+
+        update_builder = table.new_batch_write_builder()
+        table_update = update_builder.new_update().with_update_type(['blob_data'])
+        update_data = pa.Table.from_pydict({
+            '_ROW_ID': pa.array([1], type=pa.int64()),
+            'blob_data': pa.array([b'updated-blob-2'], type=pa.large_binary()),
+        })
+        update_messages = table_update.update_by_arrow_with_row_id(update_data)
+        update_builder.new_commit().commit(update_messages)
+
+        update_files = [f for msg in update_messages for f in msg.new_files]
+        update_blob_files = [f for f in update_files if f.file_name.endswith('.blob')]
+        self.assertGreater(len(update_blob_files), 0)
+        self.assertTrue(all(f.write_cols == ['blob_data'] for f in update_files))
+        update_blob_lengths = []
+        blob_fields = [field for field in table.fields if field.name == 'blob_data']
+        for blob_file in update_blob_files:
+            blob_reader = FormatBlobReader(
+                file_io=table.file_io,
+                file_path=blob_file.file_path,
+                read_fields=['blob_data'],
+                full_fields=blob_fields,
+                push_down_predicate=None,
+                blob_as_descriptor=False,
+            )
+            update_blob_lengths.extend(blob_reader.blob_lengths)
+            blob_reader.close()
+        self.assertEqual(
+            update_blob_lengths.count(BlobFormatWriter.PLACE_HOLDER_LENGTH),
+            2,
+        )
+
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(read_builder.new_scan().plan().splits())
+        by_id = {
+            row['id']: row['blob_data']
+            for row in result.select(['id', 'blob_data']).to_pylist()
+        }
+        self.assertEqual(by_id, {
+            1: b'blob-1',
+            2: b'updated-blob-2',
+            3: b'blob-3',
+        })
+
+    @unittest.skip("Blob column updates banned; re-enable when implementation is hardened")
+    def test_update_blob_column_with_rolling_files(self):
+        from pypaimon import Schema
+
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('blob_data', pa.large_binary()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'blob.target-file-size': '1KB',
+            }
+        )
+        self.catalog.create_table('test_db.blob_update_column_rolling', schema, False)
+        table = self.catalog.get_table('test_db.blob_update_column_rolling')
+
+        initial = pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'blob_data': [b'blob-1', b'blob-2', b'blob-3', b'blob-4', b'blob-5'],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(initial)
+        write_builder.new_commit().commit(writer.prepare_commit())
+        writer.close()
+
+        row_id_builder = table.new_read_builder().with_projection(['id', '_ROW_ID'])
+        row_id_result = row_id_builder.new_read().to_arrow(
+            row_id_builder.new_scan().plan().splits())
+        row_ids_by_id = {
+            row['id']: row['_ROW_ID']
+            for row in row_id_result.select(['id', '_ROW_ID']).to_pylist()
+        }
+
+        update_builder = table.new_batch_write_builder()
+        table_update = update_builder.new_update().with_update_type(['blob_data'])
+        payload = b'x' * 2048
+        update_ids = [1, 2, 3, 4, 5]
+        update_data = pa.Table.from_pydict({
+            '_ROW_ID': pa.array([row_ids_by_id[id_] for id_ in update_ids], type=pa.int64()),
+            'blob_data': pa.array(
+                [payload + str(id_ - 1).encode() for id_ in update_ids],
+                type=pa.large_binary(),
+            ),
+        })
+        update_messages = table_update.update_by_arrow_with_row_id(update_data)
+
+        update_blob_files = [
+            file
+            for msg in update_messages
+            for file in msg.new_files
+            if file.file_name.endswith('.blob')
+        ]
+        self.assertGreater(len(update_blob_files), 1)
+
+        update_builder.new_commit().commit(update_messages)
+
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(read_builder.new_scan().plan().splits())
+        by_id = {
+            row['id']: row['blob_data']
+            for row in result.select(['id', 'blob_data']).to_pylist()
+        }
+        self.assertEqual(by_id, {
+            1: payload + b'0',
+            2: payload + b'1',
+            3: payload + b'2',
+            4: payload + b'3',
+            5: payload + b'4',
+        })
+
+    @unittest.skip("Blob column updates banned; re-enable when implementation is hardened")
+    def test_update_partial_blob_column_with_rolling_files(self):
+        from pypaimon import Schema
+        from pypaimon.read.reader.format_blob_reader import FormatBlobReader
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('blob_data', pa.large_binary()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'blob.target-file-size': '1KB',
+            }
+        )
+        self.catalog.create_table('test_db.blob_update_partial_column_rolling', schema, False)
+        table = self.catalog.get_table('test_db.blob_update_partial_column_rolling')
+
+        initial = pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'blob_data': [b'blob-1', b'blob-2', b'blob-3', b'blob-4', b'blob-5'],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(initial)
+        write_builder.new_commit().commit(writer.prepare_commit())
+        writer.close()
+
+        row_id_builder = table.new_read_builder().with_projection(['id', '_ROW_ID'])
+        row_id_result = row_id_builder.new_read().to_arrow(
+            row_id_builder.new_scan().plan().splits())
+        row_ids_by_id = {
+            row['id']: row['_ROW_ID']
+            for row in row_id_result.select(['id', '_ROW_ID']).to_pylist()
+        }
+
+        update_builder = table.new_batch_write_builder()
+        table_update = update_builder.new_update().with_update_type(['blob_data'])
+        payload = b'x' * 2048
+        update_ids = [2, 4]
+        update_data = pa.Table.from_pydict({
+            '_ROW_ID': pa.array([row_ids_by_id[id_] for id_ in update_ids], type=pa.int64()),
+            'blob_data': pa.array(
+                [payload + str(id_).encode() for id_ in update_ids],
+                type=pa.large_binary(),
+            ),
+        })
+        update_messages = table_update.update_by_arrow_with_row_id(update_data)
+
+        update_blob_files = [
+            file
+            for msg in update_messages
+            for file in msg.new_files
+            if file.file_name.endswith('.blob')
+        ]
+        self.assertGreater(len(update_blob_files), 1)
+
+        update_blob_lengths = []
+        blob_fields = [field for field in table.fields if field.name == 'blob_data']
+        for blob_file in update_blob_files:
+            blob_reader = FormatBlobReader(
+                file_io=table.file_io,
+                file_path=blob_file.file_path,
+                read_fields=['blob_data'],
+                full_fields=blob_fields,
+                push_down_predicate=None,
+                blob_as_descriptor=False,
+            )
+            update_blob_lengths.extend(blob_reader.blob_lengths)
+            blob_reader.close()
+        self.assertEqual(
+            update_blob_lengths.count(BlobFormatWriter.PLACE_HOLDER_LENGTH),
+            3,
+        )
+
+        update_builder.new_commit().commit(update_messages)
+
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(read_builder.new_scan().plan().splits())
+        by_id = {
+            row['id']: row['blob_data']
+            for row in result.select(['id', 'blob_data']).to_pylist()
+        }
+        self.assertEqual(by_id, {
+            1: b'blob-1',
+            2: payload + b'2',
+            3: b'blob-3',
+            4: payload + b'4',
+            5: b'blob-5',
+        })
+
     def test_upsert_normal_columns_on_blob_table(self):
         from pypaimon import Schema
 

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1059,10 +1059,8 @@ class DedicatedFormatWriterTest(unittest.TestCase):
             [b'first_blob', None, b'third_blob', None, b'fifth_blob'],
         )
 
-    def test_update_blob_column(self):
+    def test_update_blob_column_rejected(self):
         from pypaimon import Schema
-        from pypaimon.read.reader.format_blob_reader import FormatBlobReader
-        from pypaimon.write.blob_format_writer import BlobFormatWriter
 
         pa_schema = pa.schema([
             ('id', pa.int32()),
@@ -1077,8 +1075,8 @@ class DedicatedFormatWriterTest(unittest.TestCase):
                 'data-evolution.enabled': 'true'
             }
         )
-        self.catalog.create_table('test_db.blob_update_column', schema, False)
-        table = self.catalog.get_table('test_db.blob_update_column')
+        self.catalog.create_table('test_db.blob_update_rejected', schema, False)
+        table = self.catalog.get_table('test_db.blob_update_rejected')
 
         initial = pa.Table.from_pydict({
             'id': [1, 2, 3],
@@ -1098,48 +1096,16 @@ class DedicatedFormatWriterTest(unittest.TestCase):
             '_ROW_ID': pa.array([1], type=pa.int64()),
             'blob_data': pa.array([b'updated-blob-2'], type=pa.large_binary()),
         })
-        update_messages = table_update.update_by_arrow_with_row_id(update_data)
-        update_builder.new_commit().commit(update_messages)
+        with self.assertRaises(ValueError) as ctx:
+            table_update.update_by_arrow_with_row_id(update_data)
+        self.assertIn('blob', str(ctx.exception).lower())
 
-        update_files = [f for msg in update_messages for f in msg.new_files]
-        update_blob_files = [f for f in update_files if f.file_name.endswith('.blob')]
-        self.assertGreater(len(update_blob_files), 0)
-        self.assertTrue(all(f.write_cols == ['blob_data'] for f in update_files))
-        update_blob_lengths = []
-        blob_fields = [field for field in table.fields if field.name == 'blob_data']
-        for blob_file in update_blob_files:
-            blob_reader = FormatBlobReader(
-                file_io=table.file_io,
-                file_path=blob_file.file_path,
-                read_fields=['blob_data'],
-                full_fields=blob_fields,
-                push_down_predicate=None,
-                blob_as_descriptor=False,
-            )
-            update_blob_lengths.extend(blob_reader.blob_lengths)
-            blob_reader.close()
-        self.assertEqual(
-            update_blob_lengths.count(BlobFormatWriter.PLACE_HOLDER_LENGTH),
-            2,
-        )
-
-        read_builder = table.new_read_builder()
-        result = read_builder.new_read().to_arrow(read_builder.new_scan().plan().splits())
-        by_id = {
-            row['id']: row['blob_data']
-            for row in result.select(['id', 'blob_data']).to_pylist()
-        }
-        self.assertEqual(by_id, {
-            1: b'blob-1',
-            2: b'updated-blob-2',
-            3: b'blob-3',
-        })
-
-    def test_update_blob_column_with_rolling_files(self):
+    def test_update_blob_and_normal_columns_rejected(self):
         from pypaimon import Schema
 
         pa_schema = pa.schema([
             ('id', pa.int32()),
+            ('name', pa.string()),
             ('blob_data', pa.large_binary()),
         ])
 
@@ -1147,16 +1113,16 @@ class DedicatedFormatWriterTest(unittest.TestCase):
             pa_schema,
             options={
                 'row-tracking.enabled': 'true',
-                'data-evolution.enabled': 'true',
-                'blob.target-file-size': '1KB',
+                'data-evolution.enabled': 'true'
             }
         )
-        self.catalog.create_table('test_db.blob_update_column_rolling', schema, False)
-        table = self.catalog.get_table('test_db.blob_update_column_rolling')
+        self.catalog.create_table('test_db.blob_update_mixed_rejected', schema, False)
+        table = self.catalog.get_table('test_db.blob_update_mixed_rejected')
 
         initial = pa.Table.from_pydict({
-            'id': [1, 2, 3, 4, 5],
-            'blob_data': [b'blob-1', b'blob-2', b'blob-3', b'blob-4', b'blob-5'],
+            'id': [1, 2, 3],
+            'name': ['a', 'b', 'c'],
+            'blob_data': [b'blob-1', b'blob-2', b'blob-3'],
         }, schema=pa_schema)
 
         write_builder = table.new_batch_write_builder()
@@ -1165,58 +1131,23 @@ class DedicatedFormatWriterTest(unittest.TestCase):
         write_builder.new_commit().commit(writer.prepare_commit())
         writer.close()
 
-        row_id_builder = table.new_read_builder().with_projection(['id', '_ROW_ID'])
-        row_id_result = row_id_builder.new_read().to_arrow(
-            row_id_builder.new_scan().plan().splits())
-        row_ids_by_id = {
-            row['id']: row['_ROW_ID']
-            for row in row_id_result.select(['id', '_ROW_ID']).to_pylist()
-        }
-
         update_builder = table.new_batch_write_builder()
-        table_update = update_builder.new_update().with_update_type(['blob_data'])
-        payload = b'x' * 2048
-        update_ids = [1, 2, 3, 4, 5]
+        table_update = update_builder.new_update().with_update_type(['name', 'blob_data'])
         update_data = pa.Table.from_pydict({
-            '_ROW_ID': pa.array([row_ids_by_id[id_] for id_ in update_ids], type=pa.int64()),
-            'blob_data': pa.array(
-                [payload + str(id_ - 1).encode() for id_ in update_ids],
-                type=pa.large_binary(),
-            ),
+            '_ROW_ID': pa.array([1], type=pa.int64()),
+            'name': ['updated'],
+            'blob_data': pa.array([b'updated-blob'], type=pa.large_binary()),
         })
-        update_messages = table_update.update_by_arrow_with_row_id(update_data)
+        with self.assertRaises(ValueError) as ctx:
+            table_update.update_by_arrow_with_row_id(update_data)
+        self.assertIn('blob', str(ctx.exception).lower())
 
-        update_blob_files = [
-            file
-            for msg in update_messages
-            for file in msg.new_files
-            if file.file_name.endswith('.blob')
-        ]
-        self.assertGreater(len(update_blob_files), 1)
-
-        update_builder.new_commit().commit(update_messages)
-
-        read_builder = table.new_read_builder()
-        result = read_builder.new_read().to_arrow(read_builder.new_scan().plan().splits())
-        by_id = {
-            row['id']: row['blob_data']
-            for row in result.select(['id', 'blob_data']).to_pylist()
-        }
-        self.assertEqual(by_id, {
-            1: payload + b'0',
-            2: payload + b'1',
-            3: payload + b'2',
-            4: payload + b'3',
-            5: payload + b'4',
-        })
-
-    def test_update_partial_blob_column_with_rolling_files(self):
+    def test_update_normal_columns_on_blob_table(self):
         from pypaimon import Schema
-        from pypaimon.read.reader.format_blob_reader import FormatBlobReader
-        from pypaimon.write.blob_format_writer import BlobFormatWriter
 
         pa_schema = pa.schema([
             ('id', pa.int32()),
+            ('name', pa.string()),
             ('blob_data', pa.large_binary()),
         ])
 
@@ -1224,16 +1155,16 @@ class DedicatedFormatWriterTest(unittest.TestCase):
             pa_schema,
             options={
                 'row-tracking.enabled': 'true',
-                'data-evolution.enabled': 'true',
-                'blob.target-file-size': '1KB',
+                'data-evolution.enabled': 'true'
             }
         )
-        self.catalog.create_table('test_db.blob_update_partial_column_rolling', schema, False)
-        table = self.catalog.get_table('test_db.blob_update_partial_column_rolling')
+        self.catalog.create_table('test_db.blob_update_normal_ok', schema, False)
+        table = self.catalog.get_table('test_db.blob_update_normal_ok')
 
         initial = pa.Table.from_pydict({
-            'id': [1, 2, 3, 4, 5],
-            'blob_data': [b'blob-1', b'blob-2', b'blob-3', b'blob-4', b'blob-5'],
+            'id': [1, 2, 3],
+            'name': ['a', 'b', 'c'],
+            'blob_data': [b'blob-1', b'blob-2', b'blob-3'],
         }, schema=pa_schema)
 
         write_builder = table.new_batch_write_builder()
@@ -1242,68 +1173,20 @@ class DedicatedFormatWriterTest(unittest.TestCase):
         write_builder.new_commit().commit(writer.prepare_commit())
         writer.close()
 
-        row_id_builder = table.new_read_builder().with_projection(['id', '_ROW_ID'])
-        row_id_result = row_id_builder.new_read().to_arrow(
-            row_id_builder.new_scan().plan().splits())
-        row_ids_by_id = {
-            row['id']: row['_ROW_ID']
-            for row in row_id_result.select(['id', '_ROW_ID']).to_pylist()
-        }
-
         update_builder = table.new_batch_write_builder()
-        table_update = update_builder.new_update().with_update_type(['blob_data'])
-        payload = b'x' * 2048
-        update_ids = [2, 4]
+        table_update = update_builder.new_update().with_update_type(['name'])
         update_data = pa.Table.from_pydict({
-            '_ROW_ID': pa.array([row_ids_by_id[id_] for id_ in update_ids], type=pa.int64()),
-            'blob_data': pa.array(
-                [payload + str(id_).encode() for id_ in update_ids],
-                type=pa.large_binary(),
-            ),
+            '_ROW_ID': pa.array([1], type=pa.int64()),
+            'name': ['b_updated'],
         })
-        update_messages = table_update.update_by_arrow_with_row_id(update_data)
-
-        update_blob_files = [
-            file
-            for msg in update_messages
-            for file in msg.new_files
-            if file.file_name.endswith('.blob')
-        ]
-        self.assertGreater(len(update_blob_files), 1)
-
-        update_blob_lengths = []
-        blob_fields = [field for field in table.fields if field.name == 'blob_data']
-        for blob_file in update_blob_files:
-            blob_reader = FormatBlobReader(
-                file_io=table.file_io,
-                file_path=blob_file.file_path,
-                read_fields=['blob_data'],
-                full_fields=blob_fields,
-                push_down_predicate=None,
-                blob_as_descriptor=False,
-            )
-            update_blob_lengths.extend(blob_reader.blob_lengths)
-            blob_reader.close()
-        self.assertEqual(
-            update_blob_lengths.count(BlobFormatWriter.PLACE_HOLDER_LENGTH),
-            3,
-        )
-
-        update_builder.new_commit().commit(update_messages)
+        msgs = table_update.update_by_arrow_with_row_id(update_data)
+        update_builder.new_commit().commit(msgs)
 
         read_builder = table.new_read_builder()
         result = read_builder.new_read().to_arrow(read_builder.new_scan().plan().splits())
-        by_id = {
-            row['id']: row['blob_data']
-            for row in result.select(['id', 'blob_data']).to_pylist()
-        }
-        self.assertEqual(by_id, {
-            1: b'blob-1',
-            2: payload + b'2',
-            3: b'blob-3',
-            4: payload + b'4',
-            5: b'blob-5',
-        })
+        by_id = {row['id']: row for row in result.to_pylist()}
+        self.assertEqual(by_id[2]['name'], 'b_updated')
+        self.assertEqual(by_id[2]['blob_data'], b'blob-2')
 
     def test_blob_write_read_partition(self):
         """Test complete end-to-end blob functionality: write blob data and read it back to verify correctness."""

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1236,6 +1236,8 @@ class DedicatedFormatWriterTest(unittest.TestCase):
         self.assertEqual(by_id[2]['name'], 'b_updated')
         self.assertEqual(by_id[2]['blob_data'], b'blob-2')
         self.assertEqual(by_id[1]['blob_data'], b'blob-1')
+        self.assertEqual(by_id[4]['name'], 'd_new')
+        self.assertIsNone(by_id[4]['blob_data'])
 
     def test_blob_write_read_partition(self):
         """Test complete end-to-end blob functionality: write blob data and read it back to verify correctness."""

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1100,7 +1100,7 @@ class DedicatedFormatWriterTest(unittest.TestCase):
             table_update.update_by_arrow_with_row_id(update_data)
         self.assertIn('blob', str(ctx.exception).lower())
 
-    def test_update_blob_and_normal_columns_rejected(self):
+    def test_update_blob_and_normal_columns_filters_blob(self):
         from pypaimon import Schema
 
         pa_schema = pa.schema([
@@ -1116,8 +1116,8 @@ class DedicatedFormatWriterTest(unittest.TestCase):
                 'data-evolution.enabled': 'true'
             }
         )
-        self.catalog.create_table('test_db.blob_update_mixed_rejected', schema, False)
-        table = self.catalog.get_table('test_db.blob_update_mixed_rejected')
+        self.catalog.create_table('test_db.blob_update_mixed_filtered', schema, False)
+        table = self.catalog.get_table('test_db.blob_update_mixed_filtered')
 
         initial = pa.Table.from_pydict({
             'id': [1, 2, 3],
@@ -1135,12 +1135,17 @@ class DedicatedFormatWriterTest(unittest.TestCase):
         table_update = update_builder.new_update().with_update_type(['name', 'blob_data'])
         update_data = pa.Table.from_pydict({
             '_ROW_ID': pa.array([1], type=pa.int64()),
-            'name': ['updated'],
+            'name': ['b_updated'],
             'blob_data': pa.array([b'updated-blob'], type=pa.large_binary()),
         })
-        with self.assertRaises(ValueError) as ctx:
-            table_update.update_by_arrow_with_row_id(update_data)
-        self.assertIn('blob', str(ctx.exception).lower())
+        msgs = table_update.update_by_arrow_with_row_id(update_data)
+        update_builder.new_commit().commit(msgs)
+
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(read_builder.new_scan().plan().splits())
+        by_id = {row['id']: row for row in result.to_pylist()}
+        self.assertEqual(by_id[2]['name'], 'b_updated')
+        self.assertEqual(by_id[2]['blob_data'], b'blob-2')
 
     def test_update_normal_columns_on_blob_table(self):
         from pypaimon import Schema

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -167,6 +167,12 @@ class TableUpdateByRowId:
         if SpecialFields.ROW_ID.name not in data.column_names:
             raise ValueError(f"Input data must contain {SpecialFields.ROW_ID.name} column")
 
+        blob_cols = [c for c in column_names if self._is_blob_column(c)]
+        if blob_cols:
+            raise ValueError(
+                f"update-by-row-id does not support updating blob columns: {blob_cols}. "
+                f"Remove blob columns from the update list.")
+
         for col_name in column_names:
             if col_name not in self.table.field_names:
                 raise ValueError(f"Column {col_name} not found in table schema")

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -16,8 +16,11 @@
 # under the License.
 
 import bisect
+import logging
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 import numpy as np
 import pyarrow as pa
@@ -169,9 +172,14 @@ class TableUpdateByRowId:
 
         blob_cols = [c for c in column_names if self._is_blob_column(c)]
         if blob_cols:
-            raise ValueError(
-                f"update-by-row-id does not support updating blob columns: {blob_cols}. "
-                f"Remove blob columns from the update list.")
+            logger.warning(
+                "update-by-row-id does not support updating blob columns, "
+                "ignoring: %s", blob_cols)
+            column_names = [c for c in column_names if c not in blob_cols]
+            if not column_names:
+                raise ValueError(
+                    "No non-blob columns to update after filtering blob columns: "
+                    f"{blob_cols}")
 
         for col_name in column_names:
             if col_name not in self.table.field_names:


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes write-path behavior for blob tables during row-id updates; callers that relied on blob updates will now error or silently skip blob fields, though data integrity for non-blob updates is preserved.
> 
> **Overview**
> **Update-by-row-id** no longer applies changes to BLOB columns. In `TableUpdateByRowId.update_columns`, blob fields are dropped from the update set (with a warning); if nothing non-blob remains, the call fails with `ValueError`. Normal-column updates and upserts on blob tables are unchanged.
> 
> Tests cover blob-only rejection, mixed blob+normal updates (only normal columns apply), and upsert of non-blob columns. Existing end-to-end blob update tests are **skipped** until blob update support is hardened again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7656097669a4800187d8b3cfb9cada29b801effa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->