### PR TITLE
Overwrite fix

### DIFF
--- a/paimon-python/pypaimon/tests/overwrite_changes_cache_test.py
+++ b/paimon-python/pypaimon/tests/overwrite_changes_cache_test.py
@@ -1,0 +1,318 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Regression test for caching of OVERWRITE changes across commit retries.
+
+On every OVERWRITE retry, pypaimon re-scanned the full target partitions to
+recompute the files to delete. Under concurrent writers this made each retry as
+expensive as the first attempt. OverwriteChangesProvider caches the existing
+files of the target partitions and, on retry, reuses them when the snapshots in
+between are all APPEND and have not touched the target partitions (verified by a
+cheap DELTA probe), instead of a full re-scan.
+
+The test deterministically forces ``K`` conflicts, each advancing the latest
+snapshot with an append to an unrelated partition, and asserts the full scan
+runs once (not ``K + 1``) and the cache is advanced by a delta probe per retry.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import pandas as pd
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.write.commit.overwrite_changes_provider import OverwriteChangesProvider
+
+
+class OverwriteChangesCacheTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="ow_cache_")
+        self.warehouse = os.path.join(self.temp_dir, 'wh')
+        self.catalog = CatalogFactory.create({"warehouse": self.warehouse})
+        self.catalog.create_database("test_db", True)
+
+        pa_schema = pa.schema([('f0', pa.int32()), ('f1', pa.string())])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            partition_keys=['f0'],
+            options={'dynamic-partition-overwrite': 'false'},
+        )
+        self.catalog.create_table('test_db.t', schema, False)
+        self.table = self.catalog.get_table('test_db.t')
+
+        # Seed: f0=1 is the overwrite target, f0=2 untouched.
+        self._append(pd.DataFrame({'f0': [1, 1, 2], 'f1': ['a', 'b', 'c']}))
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _append(self, df):
+        wb = self.table.new_batch_write_builder()
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(df)
+        c.commit(w.prepare_commit())
+        w.close()
+        c.close()
+
+    def test_overwrite_scan_runs_once_not_once_per_retry(self):
+        K = 3  # force 3 conflicts; the 4th attempt wins
+
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': ['new']}))
+        messages = w.prepare_commit()
+
+        fsc = c.file_store_commit
+
+        # --- count provider full scans and delta probes (class-level spies) ---
+        counts = {'full_scan': 0, 'probe': 0}
+        orig_full = OverwriteChangesProvider._full_scan
+        orig_probe = OverwriteChangesProvider._delta_touches_target
+
+        def spy_full(self, *a, **k):
+            counts['full_scan'] += 1
+            return orig_full(self, *a, **k)
+
+        def spy_probe(self, *a, **k):
+            counts['probe'] += 1
+            return orig_probe(self, *a, **k)
+
+        # --- inject K CAS conflicts; each advances latest via an APPEND to an
+        #     unrelated partition (f0=99) so the delta probe finds the target
+        #     (f0=1) untouched and the cache is reused.
+        orig_cas = fsc.snapshot_commit.commit
+        cas = {'fails': 0}
+
+        def patched_cas(snapshot, statistics):
+            if snapshot.commit_kind == "OVERWRITE" and cas['fails'] < K:
+                cas['fails'] += 1
+                self._append(pd.DataFrame({'f0': [99], 'f1': [f'x{cas["fails"]}']}))
+                return False
+            return orig_cas(snapshot, statistics)
+
+        fsc.snapshot_commit.commit = patched_cas
+        OverwriteChangesProvider._full_scan = spy_full
+        OverwriteChangesProvider._delta_touches_target = spy_probe
+        try:
+            c.commit(messages)
+            c.close()
+        finally:
+            OverwriteChangesProvider._full_scan = orig_full
+            OverwriteChangesProvider._delta_touches_target = orig_probe
+
+        # Harness sanity: we really did force K conflicts and then converged.
+        self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
+
+        print(f"\n[overwrite-cache] K={K} conflicts -> "
+              f"full_scan={counts['full_scan']}, probe={counts['probe']} "
+              f"(target: full_scan=1, probe=K)")
+
+        # #7894: the full overwrite scan runs once; each retry reuses the cache
+        # after a cheap delta probe of the (unrelated) intervening append.
+        self.assertEqual(
+            counts['full_scan'], 1,
+            f"full overwrite scan ran {counts['full_scan']}x; should run once and "
+            f"reuse the cache on retries")
+        self.assertEqual(
+            counts['probe'], K,
+            f"delta probe ran {counts['probe']}x; should probe once per retry "
+            f"(= K = {K})")
+
+        # Sanity: f0=1 overwritten, f0=2 preserved, f0=99 appended K times.
+        read_builder = self.table.new_read_builder()
+        actual = read_builder.new_read().to_pandas(
+            read_builder.new_scan().plan().splits())
+        self.assertEqual(sorted(actual[actual['f0'] == 1]['f1'].tolist()), ['new'])
+        self.assertEqual(sorted(actual[actual['f0'] == 2]['f1'].tolist()), ['c'])
+        self.assertEqual(len(actual[actual['f0'] == 99]), K)
+
+    def test_cache_rebuilt_when_concurrent_append_hits_target_partition(self):
+        # Concurrent appends hit the overwrite target; probe sees it touched -> rebuild.
+        K = 3
+
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': ['new']}))
+        messages = w.prepare_commit()
+
+        fsc = c.file_store_commit
+
+        counts = {'full_scan': 0, 'probe': 0}
+        orig_full = OverwriteChangesProvider._full_scan
+        orig_probe = OverwriteChangesProvider._delta_touches_target
+
+        def spy_full(self, *a, **k):
+            counts['full_scan'] += 1
+            return orig_full(self, *a, **k)
+
+        def spy_probe(self, *a, **k):
+            counts['probe'] += 1
+            return orig_probe(self, *a, **k)
+
+        orig_cas = fsc.snapshot_commit.commit
+        cas = {'fails': 0}
+
+        def patched_cas(snapshot, statistics):
+            if snapshot.commit_kind == "OVERWRITE" and cas['fails'] < K:
+                cas['fails'] += 1
+                self._append(pd.DataFrame({'f0': [1], 'f1': [f'y{cas["fails"]}']}))
+                return False
+            return orig_cas(snapshot, statistics)
+
+        fsc.snapshot_commit.commit = patched_cas
+        OverwriteChangesProvider._full_scan = spy_full
+        OverwriteChangesProvider._delta_touches_target = spy_probe
+        try:
+            c.commit(messages)
+            c.close()
+        finally:
+            OverwriteChangesProvider._full_scan = orig_full
+            OverwriteChangesProvider._delta_touches_target = orig_probe
+
+        self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
+
+        # Target touched each retry => cache rebuilds; full scan runs every attempt.
+        self.assertEqual(counts['full_scan'], K + 1,
+                         f"full scan ran {counts['full_scan']}x; cache must rebuild "
+                         f"when the target partition is touched")
+        self.assertEqual(counts['probe'], K,
+                         f"delta probe ran {counts['probe']}x; once per retry (= K)")
+
+        # Overwrite wins: f0=1 is just 'new', f0=2 untouched.
+        read_builder = self.table.new_read_builder()
+        actual = read_builder.new_read().to_pandas(
+            read_builder.new_scan().plan().splits())
+        self.assertEqual(sorted(actual[actual['f0'] == 1]['f1'].tolist()), ['new'])
+        self.assertEqual(sorted(actual[actual['f0'] == 2]['f1'].tolist()), ['c'])
+
+    def _overwrite_partition(self, part_val, f1_val):
+        wb = self.table.new_batch_write_builder().overwrite({'f0': part_val})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [part_val], 'f1': [f1_val]}))
+        c.commit(w.prepare_commit())
+        w.close()
+        c.close()
+
+    def _run_with_conflicts(self, c, messages, K, concurrent_fn):
+        # Run an overwrite commit, forcing K CAS conflicts (each calls
+        # concurrent_fn(i) to advance the latest snapshot). Returns this commit's
+        # own OverwriteChangesProvider so the caller can read its counters
+        # (only this provider, not any concurrent writer's).
+        fsc = c.file_store_commit
+        captured = {}
+        orig_factory = fsc._overwrite_changes_provider
+
+        def capturing_factory(*a, **k):
+            captured['provider'] = orig_factory(*a, **k)
+            return captured['provider']
+
+        fsc._overwrite_changes_provider = capturing_factory
+
+        orig_cas = fsc.snapshot_commit.commit
+        cas = {'fails': 0}
+
+        def patched_cas(snapshot, statistics):
+            if snapshot.commit_kind == "OVERWRITE" and cas['fails'] < K:
+                cas['fails'] += 1
+                concurrent_fn(cas['fails'])
+                return False
+            return orig_cas(snapshot, statistics)
+
+        fsc.snapshot_commit.commit = patched_cas
+
+        c.commit(messages)
+        c.close()
+
+        self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
+        return captured['provider']
+
+    def test_cache_rebuilt_on_non_append_snapshot(self):
+        # A non-APPEND (OVERWRITE) snapshot between retries forces a rebuild even
+        # though it only touches an unrelated partition.
+        K = 2
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': ['new']}))
+        provider = self._run_with_conflicts(
+            c, w.prepare_commit(), K,
+            lambda i: self._overwrite_partition(99, f'z{i}'))
+
+        self.assertEqual(provider.full_scan_count, K + 1)   # rebuilt every retry
+        self.assertEqual(provider.delta_probe_count, K)     # probed, bailed at kind check
+
+    def test_whole_table_overwrite_always_full_scans(self):
+        # Whole-table overwrite (no partition filter) can never reuse the cache.
+        K = 2
+        wb = self.table.new_batch_write_builder().overwrite()
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': ['new']}))
+        provider = self._run_with_conflicts(
+            c, w.prepare_commit(), K,
+            lambda i: self._append(pd.DataFrame({'f0': [99], 'f1': [f'x{i}']})))
+
+        self.assertEqual(provider.full_scan_count, K + 1)   # null filter -> always full scan
+        self.assertEqual(provider.delta_probe_count, 0)     # never enters the probe loop
+
+        read_builder = self.table.new_read_builder()
+        actual = read_builder.new_read().to_pandas(
+            read_builder.new_scan().plan().splits())
+        self.assertEqual(sorted(actual['f1'].tolist()), ['new'])
+
+    def test_dynamic_partition_overwrite_reuses_cache(self):
+        # Dynamic-partition overwrite is scoped to the data's partitions, so an
+        # unrelated concurrent append lets the cache be reused.
+        pa_schema = pa.schema([('f0', pa.int32()), ('f1', pa.string())])
+        schema = Schema.from_pyarrow_schema(pa_schema, partition_keys=['f0'])
+        self.catalog.create_table('test_db.t_dyn', schema, False)
+        table = self.catalog.get_table('test_db.t_dyn')
+
+        def append(df):
+            wb = table.new_batch_write_builder()
+            w = wb.new_write()
+            c = wb.new_commit()
+            w.write_pandas(df)
+            c.commit(w.prepare_commit())
+            w.close()
+            c.close()
+
+        append(pd.DataFrame({'f0': [1, 1, 2], 'f1': ['a', 'b', 'c']}))
+
+        K = 3
+        wb = table.new_batch_write_builder().overwrite()  # dynamic: filter from data (f0=1)
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': ['new']}))
+        provider = self._run_with_conflicts(
+            c, w.prepare_commit(), K,
+            lambda i: append(pd.DataFrame({'f0': [99], 'f1': [f'x{i}']})))
+
+        self.assertEqual(provider.full_scan_count, 1)   # target f0=1 untouched -> reuse
+        self.assertEqual(provider.delta_probe_count, K)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
+++ b/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
@@ -1,0 +1,332 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Conflict-detection base scan is reused across commit retries.
+
+The first attempt full-scans the changed partitions; later retries reuse that
+base and read only the incremental changes since (read_incremental_changes).
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import pandas as pd
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
+
+
+class OverwriteCommitConflictTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="ow_conflict_")
+        self.warehouse = os.path.join(self.temp_dir, 'wh')
+        self.catalog = CatalogFactory.create({"warehouse": self.warehouse})
+        self.catalog.create_database("test_db", True)
+
+        pa_schema = pa.schema([('f0', pa.int32()), ('f1', pa.string())])
+        # Static overwrite, scoped to the explicit partition f0=1.
+        schema = Schema.from_pyarrow_schema(
+            pa_schema, partition_keys=['f0'],
+            options={'dynamic-partition-overwrite': 'false'})
+        self.catalog.create_table('test_db.t', schema, False)
+        self.table = self.catalog.get_table('test_db.t')
+
+        # f0=1 is the overwrite target, f0=2 untouched.
+        self._append(pd.DataFrame({'f0': [1, 1, 2], 'f1': ['a', 'b', 'c']}))
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _append(self, df):
+        wb = self.table.new_batch_write_builder()
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(df)
+        c.commit(w.prepare_commit())
+        w.close()
+        c.close()
+
+    def _overwrite_target(self, f1_val):
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': [f1_val]}))
+        c.commit(w.prepare_commit())
+        w.close()
+        c.close()
+
+    def _compact_target(self, f1_val):
+        # pypaimon has no compact API; produce a COMPACT-kind snapshot by running
+        # an overwrite of f0=1 but labelling the snapshot COMPACT.
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        tc = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': [f1_val]}))
+        cfsc = tc.file_store_commit
+        orig_try = cfsc._try_commit
+        cfsc._try_commit = lambda commit_kind, *a, **k: orig_try("COMPACT", *a, **k)
+        tc.commit(w.prepare_commit())
+        w.close()
+        tc.close()
+
+    def test_conflict_scan_runs_once_not_once_per_retry(self):
+        K = 3
+
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': ['new']}))
+        messages = w.prepare_commit()
+
+        fsc = c.file_store_commit
+        counts = {'full_scan': 0, 'incremental': 0}
+        orig_full = fsc.commit_scanner.read_all_entries_from_changed_partitions
+        orig_incr = fsc.commit_scanner.read_incremental_changes
+
+        def spy_full(*a, **k):
+            counts['full_scan'] += 1
+            return orig_full(*a, **k)
+
+        def spy_incr(*a, **k):
+            counts['incremental'] += 1
+            return orig_incr(*a, **k)
+
+        fsc.commit_scanner.read_all_entries_from_changed_partitions = spy_full
+        fsc.commit_scanner.read_incremental_changes = spy_incr
+
+        orig_cas = fsc.snapshot_commit.commit
+        cas = {'fails': 0}
+
+        def patched_cas(snapshot, statistics):
+            # Each conflict appends to an unrelated partition (f0=99), advancing
+            # latest, then fails our CAS.
+            if snapshot.commit_kind == "OVERWRITE" and cas['fails'] < K:
+                cas['fails'] += 1
+                self._append(pd.DataFrame({'f0': [99], 'f1': [f'x{cas["fails"]}']}))
+                return False
+            return orig_cas(snapshot, statistics)
+
+        fsc.snapshot_commit.commit = patched_cas
+
+        c.commit(messages)
+        c.close()
+
+        self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
+        self.assertEqual(counts['full_scan'], 1)   # once, then incremental on retry
+        self.assertEqual(counts['incremental'], K)
+
+        read_builder = self.table.new_read_builder()
+        actual = read_builder.new_read().to_pandas(
+            read_builder.new_scan().plan().splits())
+        self.assertEqual(sorted(actual[actual['f0'] == 1]['f1'].tolist()), ['new'])
+        self.assertEqual(sorted(actual[actual['f0'] == 2]['f1'].tolist()), ['c'])
+        self.assertEqual(len(actual[actual['f0'] == 99]), K)
+
+    def test_incremental_merge_when_concurrent_append_hits_target_partition(self):
+        # Concurrent appends hit the target partition, so the incremental read is
+        # non-empty and must be merged into the reused base.
+        K = 3
+
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': ['new']}))
+        messages = w.prepare_commit()
+
+        fsc = c.file_store_commit
+        full_scans = {'n': 0}
+        incr_lengths = []
+        captured = []
+        orig_full = fsc.commit_scanner.read_all_entries_from_changed_partitions
+        orig_incr = fsc.commit_scanner.read_incremental_changes
+        orig_check = fsc.conflict_detection.check_conflicts
+
+        def spy_full(*a, **k):
+            full_scans['n'] += 1
+            return orig_full(*a, **k)
+
+        def spy_incr(*a, **k):
+            r = orig_incr(*a, **k)
+            incr_lengths.append(None if r is None else len(r))
+            return r
+
+        def spy_check(latest_snapshot, base_entries, delta_entries, *a, **k):
+            captured.append((latest_snapshot, list(base_entries), list(delta_entries)))
+            return orig_check(latest_snapshot, base_entries, delta_entries, *a, **k)
+
+        fsc.commit_scanner.read_all_entries_from_changed_partitions = spy_full
+        fsc.commit_scanner.read_incremental_changes = spy_incr
+        fsc.conflict_detection.check_conflicts = spy_check
+
+        orig_cas = fsc.snapshot_commit.commit
+        cas = {'fails': 0}
+
+        def patched_cas(snapshot, statistics):
+            if snapshot.commit_kind == "OVERWRITE" and cas['fails'] < K:
+                cas['fails'] += 1
+                self._append(pd.DataFrame({'f0': [1], 'f1': [f'y{cas["fails"]}']}))
+                return False
+            return orig_cas(snapshot, statistics)
+
+        fsc.snapshot_commit.commit = patched_cas
+
+        c.commit(messages)
+        c.close()
+
+        self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
+        self.assertEqual(full_scans['n'], 1)
+        self.assertEqual(len(incr_lengths), K)
+        self.assertTrue(all(incr_lengths),
+                        f"expected non-empty incremental on every retry, got {incr_lengths}")
+
+        # The incremental-merged base must equal a fresh full scan.
+        last_snapshot, merged_base, last_delta = captured[-1]
+        full = orig_full(last_snapshot, last_delta)
+        self.assertEqual(
+            set(e.identifier() for e in merged_base),
+            set(e.identifier() for e in full))
+
+        read_builder = self.table.new_read_builder()
+        actual = read_builder.new_read().to_pandas(
+            read_builder.new_scan().plan().splits())
+        self.assertEqual(sorted(actual[actual['f0'] == 1]['f1'].tolist()), ['new'])
+        self.assertEqual(sorted(actual[actual['f0'] == 2]['f1'].tolist()), ['c'])
+
+    def test_falls_back_to_full_scan_when_intermediate_snapshot_missing(self):
+        # A missing intermediate snapshot -> read_incremental_changes returns None
+        # and the retry falls back to a full scan.
+        K = 1
+        missing_id = self.table.snapshot_manager().get_latest_snapshot().id + 1
+
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': ['new']}))
+        messages = w.prepare_commit()
+
+        fsc = c.file_store_commit
+        full_scans = {'n': 0}
+        incr_results = []
+        orig_full = fsc.commit_scanner.read_all_entries_from_changed_partitions
+        orig_incr = fsc.commit_scanner.read_incremental_changes
+
+        def spy_full(*a, **k):
+            full_scans['n'] += 1
+            return orig_full(*a, **k)
+
+        def spy_incr(*a, **k):
+            r = orig_incr(*a, **k)
+            incr_results.append(r)
+            return r
+
+        fsc.commit_scanner.read_all_entries_from_changed_partitions = spy_full
+        fsc.commit_scanner.read_incremental_changes = spy_incr
+
+        # Only the scanner's lookups see missing_id as absent; the commit's own
+        # manager (bound earlier) is untouched.
+        real_mgr = fsc.commit_scanner.table.snapshot_manager()
+
+        class _Wrap:
+            def __getattr__(self, name):
+                return getattr(real_mgr, name)
+
+            def get_snapshot_by_id(self, i):
+                return None if i == missing_id else real_mgr.get_snapshot_by_id(i)
+
+        fsc.commit_scanner.table.snapshot_manager = lambda: _Wrap()
+
+        orig_cas = fsc.snapshot_commit.commit
+        cas = {'fails': 0}
+
+        def patched_cas(snapshot, statistics):
+            if snapshot.commit_kind == "OVERWRITE" and cas['fails'] < K:
+                cas['fails'] += 1
+                self._append(pd.DataFrame({'f0': [99], 'f1': ['x']}))
+                return False
+            return orig_cas(snapshot, statistics)
+
+        fsc.snapshot_commit.commit = patched_cas
+
+        c.commit(messages)
+        c.close()
+
+        self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
+        self.assertIn(None, incr_results)          # incremental bailed on missing
+        self.assertEqual(full_scans['n'], 2)       # first attempt + fallback
+
+    def test_incremental_merge_across_non_append_snapshot(self):
+        self._assert_merge_equals_full_scan(self._overwrite_target)
+
+    def test_incremental_merge_across_compact_snapshot(self):
+        self._assert_merge_equals_full_scan(self._compact_target)
+
+    def _assert_merge_equals_full_scan(self, concurrent_fn):
+        # A non-APPEND snapshot (OVERWRITE/COMPACT, delta = ADD+DELETE) lands
+        # between retries; the merged base must still equal a fresh full scan.
+        K = 2
+
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': ['new']}))
+        messages = w.prepare_commit()
+
+        fsc = c.file_store_commit
+        captured = []
+        orig_check = fsc.conflict_detection.check_conflicts
+        orig_full = fsc.commit_scanner.read_all_entries_from_changed_partitions
+
+        def spy_check(latest_snapshot, base_entries, delta_entries, *a, **k):
+            captured.append((latest_snapshot, list(base_entries), list(delta_entries)))
+            return orig_check(latest_snapshot, base_entries, delta_entries, *a, **k)
+
+        fsc.conflict_detection.check_conflicts = spy_check
+
+        orig_cas = fsc.snapshot_commit.commit
+        cas = {'fails': 0}
+
+        def patched_cas(snapshot, statistics):
+            if snapshot.commit_kind == "OVERWRITE" and cas['fails'] < K:
+                cas['fails'] += 1
+                concurrent_fn(f'z{cas["fails"]}')
+                return False
+            return orig_cas(snapshot, statistics)
+
+        fsc.snapshot_commit.commit = patched_cas
+
+        c.commit(messages)
+        c.close()
+
+        self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
+
+        last_snapshot, merged_base, last_delta = captured[-1]
+        full = orig_full(last_snapshot, last_delta)
+        self.assertEqual(
+            set(e.identifier() for e in merged_base),
+            set(e.identifier() for e in full))
+
+        read_builder = self.table.new_read_builder()
+        actual = read_builder.new_read().to_pandas(
+            read_builder.new_scan().plan().splits())
+        self.assertEqual(sorted(actual[actual['f0'] == 1]['f1'].tolist()), ['new'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/partition_predicate_test.py
+++ b/paimon-python/pypaimon/tests/partition_predicate_test.py
@@ -174,7 +174,7 @@ class TestOverwritePartitionPredicate(unittest.TestCase):
 
     def _extract_partition_predicate(self, commit):
         entries_plan = commit._try_commit.call_args[1]['commit_entries_plan']
-        with patch('pypaimon.write.file_store_commit.FileScanner') as mock_cls:
+        with patch('pypaimon.write.commit.overwrite_changes_provider.FileScanner') as mock_cls:
             mock_cls.return_value.read_manifest_entries.return_value = []
             commit.manifest_list_manager.read_all.return_value = []
             entries_plan(Mock(id=1))

--- a/paimon-python/pypaimon/write/commit/commit_scanner.py
+++ b/paimon-python/pypaimon/write/commit/commit_scanner.py
@@ -97,16 +97,18 @@ class CommitScanner:
         ).read_manifest_entries(delta_manifests)
 
     def read_incremental_raw_entries_from_changed_partitions(self, snapshot: Snapshot,
-                                                             commit_entries: List[ManifestEntry]):
-        """Like ``read_incremental_entries_from_changed_partitions`` but
-        preserves DELETE entries (kind=1). The regular method funnels through
-        ``read_entries_parallel`` which discards standalone DELETEs.
+                                                             commit_entries: List[ManifestEntry],
+                                                             partition_filter=None):
+        """Like ``read_incremental_entries_from_changed_partitions`` but preserves
+        DELETE entries (kind=1). ``partition_filter`` may be passed to avoid
+        rebuilding it per call.
         """
         delta_manifests = self.manifest_list_manager.read_delta(snapshot)
         if not delta_manifests:
             return []
 
-        partition_filter = self._build_partition_filter_from_entries(commit_entries)
+        if partition_filter is None:
+            partition_filter = self._build_partition_filter_from_entries(commit_entries)
         mfm = ManifestFileManager(self.table)
         entries = []
         for mf in delta_manifests:
@@ -114,6 +116,25 @@ class CommitScanner:
                 if partition_filter is not None and not partition_filter.test(entry.partition):
                     continue
                 entries.append(entry)
+        return entries
+
+    def read_incremental_changes(self, from_snapshot: Snapshot, to_snapshot: Snapshot,
+                                 commit_entries: List[ManifestEntry]) -> Optional[List[ManifestEntry]]:
+        """Delta entries (incl. DELETEs) in ``(from_snapshot, to_snapshot]``,
+        changed-partition filtered, so a retry can reuse the prior base and read
+        only the changes since. Returns None on a missing snapshot (caller then
+        full-scans). Mirrors Java ``CommitScanner#readIncrementalChanges``.
+        """
+        snapshot_manager = self.table.snapshot_manager()
+        partition_filter = self._build_partition_filter_from_entries(commit_entries)
+        entries = []
+        for snapshot_id in range(from_snapshot.id + 1, to_snapshot.id + 1):
+            snapshot = snapshot_manager.get_snapshot_by_id(snapshot_id)
+            if snapshot is None:
+                return None
+            entries.extend(
+                self.read_incremental_raw_entries_from_changed_partitions(
+                    snapshot, commit_entries, partition_filter))
         return entries
 
     def _build_partition_filter_from_entries(self, entries: List[ManifestEntry]):

--- a/paimon-python/pypaimon/write/commit/overwrite_changes_provider.py
+++ b/paimon-python/pypaimon/write/commit/overwrite_changes_provider.py
@@ -1,0 +1,136 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import List, Optional
+
+from pypaimon.manifest.schema.manifest_entry import ManifestEntry
+from pypaimon.read.scanner.file_scanner import FileScanner
+from pypaimon.snapshot.snapshot import Snapshot
+from pypaimon.table.row.generic_row import GenericRow
+
+
+class OverwriteChangesProvider:
+    """Builds the commit entries (DELETE existing + ADD new) for an OVERWRITE,
+    caching the existing files of the target partitions across commit retries
+    to avoid repeated full scans.
+
+    On retry, if the latest snapshot advanced, the cache is reused only when the
+    snapshots in between are all APPEND and have not touched the target
+    partitions; otherwise it is rebuilt by a full scan. A whole-table overwrite
+    (``partition_filter is None``) always rebuilds. Mirrors Java
+    ``OverwriteChangesProvider`` (#7894).
+    """
+
+    def __init__(self, table, manifest_list_manager, snapshot_manager,
+                 partition_filter, commit_messages):
+        self.table = table
+        self.manifest_list_manager = manifest_list_manager
+        self.snapshot_manager = snapshot_manager
+        self.partition_filter = partition_filter
+        self.commit_messages = commit_messages
+
+        self._cached_snapshot: Optional[Snapshot] = None
+        self._cached_entries: List[ManifestEntry] = []
+
+        # Counters for tests / observability (mirrors Java @VisibleForTesting).
+        self.full_scan_count = 0
+        self.delta_probe_count = 0
+
+    def provide(self, latest_snapshot: Optional[Snapshot]) -> List[ManifestEntry]:
+        if latest_snapshot is None:
+            # Empty table: nothing existing to delete, just add the new files.
+            return self._build_result([])
+
+        if self._cached_snapshot is None:
+            self._cached_entries = self._full_scan(latest_snapshot)
+            self._cached_snapshot = latest_snapshot
+        elif self._cached_snapshot.id > latest_snapshot.id:
+            raise RuntimeError(
+                f"Cached snapshot id {self._cached_snapshot.id} is greater than "
+                f"latest snapshot id {latest_snapshot.id}")
+        elif self._cached_snapshot.id < latest_snapshot.id:
+            if not self._can_use_cache(latest_snapshot):
+                self._cached_entries = self._full_scan(latest_snapshot)
+            self._cached_snapshot = latest_snapshot
+        # cached_snapshot.id == latest_snapshot.id -> reuse cache as-is
+
+        return self._build_result(self._cached_entries)
+
+    def _full_scan(self, latest_snapshot: Snapshot) -> List[ManifestEntry]:
+        self.full_scan_count += 1
+        return (FileScanner(self.table, lambda: ([], None),
+                            partition_predicate=self.partition_filter)
+                .read_manifest_entries(self.manifest_list_manager.read_all(latest_snapshot)))
+
+    def _can_use_cache(self, latest_snapshot: Snapshot) -> bool:
+        if self.partition_filter is None:
+            # Whole-table overwrite: any concurrent commit touches the target,
+            # so skip the delta probe and force a full scan.
+            return False
+        for snapshot_id in range(self._cached_snapshot.id + 1, latest_snapshot.id + 1):
+            self.delta_probe_count += 1
+            try:
+                snapshot = self.snapshot_manager.get_snapshot_by_id(snapshot_id)
+                if snapshot is None:
+                    return False
+                if snapshot.commit_kind != "APPEND":
+                    # Only APPEND snapshots produce a reliable DELTA manifest for
+                    # probing; other kinds may rewrite/reorganize manifests.
+                    return False
+                if self._delta_touches_target(snapshot):
+                    return False
+            except Exception:
+                # e.g. the snapshot is being expired; a full scan is always safe.
+                return False
+        return True
+
+    def _delta_touches_target(self, snapshot: Snapshot) -> bool:
+        delta_manifests = self.manifest_list_manager.read_delta(snapshot)
+        if not delta_manifests:
+            return False
+        # Only APPEND snapshots are probed (see _can_use_cache), so the delta has
+        # no standalone DELETEs; FileScanner's partition predicate prunes at the
+        # manifest-file level before reading entries.
+        entries = (FileScanner(self.table, lambda: ([], None),
+                               partition_predicate=self.partition_filter)
+                   .read_manifest_entries(delta_manifests))
+        return len(entries) > 0
+
+    def _build_result(self, existing_entries: List[ManifestEntry]) -> List[ManifestEntry]:
+        entries = []
+        # Existing files of the target partitions become DELETE entries. Build
+        # fresh entries so the cached (kind=0) entries are never mutated.
+        for entry in existing_entries:
+            entries.append(ManifestEntry(
+                kind=1,
+                partition=entry.partition,
+                bucket=entry.bucket,
+                total_buckets=entry.total_buckets,
+                file=entry.file,
+            ))
+        # New files being written by this overwrite.
+        for msg in self.commit_messages:
+            partition = GenericRow(list(msg.partition), self.table.partition_keys_fields)
+            for file in msg.new_files:
+                entries.append(ManifestEntry(
+                    kind=0,
+                    partition=partition,
+                    bucket=msg.bucket,
+                    total_buckets=self.table.total_buckets,
+                    file=file,
+                ))
+        return entries

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -31,7 +31,6 @@ from pypaimon.manifest.schema.file_entry import FileEntry
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 
 from pypaimon.manifest.schema.manifest_file_meta import ManifestFileMeta
-from pypaimon.read.scanner.file_scanner import FileScanner
 from pypaimon.snapshot.snapshot import Snapshot
 from pypaimon.snapshot.snapshot_commit import (PartitionStatistics,
                                                SnapshotCommit)
@@ -40,6 +39,7 @@ from pypaimon.table.row.offset_row import OffsetRow
 from pypaimon.write.commit.commit_rollback import CommitRollback
 from pypaimon.write.commit.commit_scanner import CommitScanner
 from pypaimon.write.commit.conflict_detection import ConflictDetection
+from pypaimon.write.commit.overwrite_changes_provider import OverwriteChangesProvider
 from pypaimon.table.special_fields import SpecialFields
 from pypaimon.write.commit_callback import CommitCallback, CommitCallbackContext
 from pypaimon.write.commit_message import CommitMessage
@@ -222,11 +222,11 @@ class FileStoreCommit:
         changelog_entries = self._collect_changelog_entries(commit_messages)
 
         if not skip_overwrite:
+            provider = self._overwrite_changes_provider(partition_filter, commit_messages)
             self._try_commit(
                 commit_kind="OVERWRITE",
                 commit_identifier=commit_identifier,
-                commit_entries_plan=lambda snapshot: self._generate_overwrite_entries(
-                    snapshot, partition_filter, commit_messages),
+                commit_entries_plan=provider.provide,
                 changelog_entries=changelog_entries,
                 detect_conflicts=True,
                 allow_rollback=False,
@@ -265,22 +265,22 @@ class FileStoreCommit:
 
         partition_filter = predicate_builder.or_predicates(partition_predicates)
 
+        provider = self._overwrite_changes_provider(partition_filter, [])
         self._try_commit(
             commit_kind="OVERWRITE",
             commit_identifier=commit_identifier,
-            commit_entries_plan=lambda snapshot: self._generate_overwrite_entries(
-                snapshot, partition_filter, []),
+            commit_entries_plan=provider.provide,
             detect_conflicts=True,
             allow_rollback=False,
         )
 
     def truncate_table(self, commit_identifier: int) -> None:
         """Truncate the entire table, deleting all data."""
+        provider = self._overwrite_changes_provider(None, [])
         self._try_commit(
             commit_kind="OVERWRITE",
             commit_identifier=commit_identifier,
-            commit_entries_plan=lambda snapshot: self._generate_overwrite_entries(
-                snapshot, None, []),
+            commit_entries_plan=provider.provide,
             detect_conflicts=True,
             allow_rollback=False,
         )
@@ -603,26 +603,17 @@ class FileStoreCommit:
                                    f"in {msg.partition} does not belong to this partition")
         return partition_filter
 
-    def _generate_overwrite_entries(self, latest_snapshot, partition_filter, commit_messages):
-        """Generate commit entries for OVERWRITE mode based on latest snapshot."""
-        entries = []
-        current_entries = [] if latest_snapshot is None \
-            else (FileScanner(self.table, lambda: ([], None), partition_predicate=partition_filter).
-                  read_manifest_entries(self.manifest_list_manager.read_all(latest_snapshot)))
-        for entry in current_entries:
-            entry.kind = 1  # DELETE
-            entries.append(entry)
-        for msg in commit_messages:
-            partition = GenericRow(list(msg.partition), self.table.partition_keys_fields)
-            for file in msg.new_files:
-                entries.append(ManifestEntry(
-                    kind=0,  # ADD
-                    partition=partition,
-                    bucket=msg.bucket,
-                    total_buckets=self.table.total_buckets,
-                    file=file
-                ))
-        return entries
+    def _overwrite_changes_provider(self, partition_filter, commit_messages):
+        """Build a stateful provider of OVERWRITE commit entries that caches the
+        existing files of the target partitions across retries (see
+        OverwriteChangesProvider). One instance per overwrite operation."""
+        return OverwriteChangesProvider(
+            self.table,
+            self.manifest_list_manager,
+            self.snapshot_manager,
+            partition_filter,
+            commit_messages,
+        )
 
     def _commit_retry_wait(self, retry_count: int):
 

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -27,6 +27,7 @@ from pypaimon.manifest.manifest_file_manager import ManifestFileManager
 from pypaimon.manifest.manifest_file_merger import ManifestFileMerger
 from pypaimon.manifest.manifest_list_manager import ManifestListManager
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.manifest.schema.file_entry import FileEntry
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 
 from pypaimon.manifest.schema.manifest_file_meta import ManifestFileMeta
@@ -63,9 +64,13 @@ class SuccessResult(CommitResult):
 
 class RetryResult(CommitResult):
 
-    def __init__(self, latest_snapshot, exception: Optional[Exception] = None):
+    def __init__(self, latest_snapshot, exception: Optional[Exception] = None,
+                 base_data_files: Optional[List[ManifestEntry]] = None):
         self.latest_snapshot = latest_snapshot
         self.exception = exception
+        # Base entries as of latest_snapshot, carried so the next attempt reuses
+        # them and reads only the incremental changes.
+        self.base_data_files = base_data_files
 
     def is_success(self) -> bool:
         return False
@@ -374,17 +379,36 @@ class FileStoreCommit:
         # process snapshot
         new_snapshot_id = latest_snapshot.id + 1 if latest_snapshot else 1
 
-        # Conflict detection: read base entries from latest snapshot, then check conflicts
+        # Base entries for conflict detection. On retry, reuse the previous
+        # attempt's base + read only the incremental changes (mirrors Java).
+        base_data_files = None
         if detect_conflicts and latest_snapshot is not None:
-            base_entries = self.commit_scanner.read_all_entries_from_changed_partitions(
-                latest_snapshot, commit_entries)
+            incremental = None
+            if (retry_result is not None
+                    and retry_result.latest_snapshot is not None
+                    and retry_result.base_data_files is not None):
+                incremental = self.commit_scanner.read_incremental_changes(
+                    retry_result.latest_snapshot, latest_snapshot, commit_entries)
+            if incremental is not None:
+                base_data_files = list(retry_result.base_data_files)
+                if incremental:
+                    base_data_files.extend(incremental)
+                    base_data_files = FileEntry.merge_entries(base_data_files)
+            else:
+                # First attempt, or incremental could not be built (missing
+                # snapshot): scan the changed partitions in full.
+                base_data_files = self.commit_scanner.read_all_entries_from_changed_partitions(
+                    latest_snapshot, commit_entries)
+
             conflict_exception = self.conflict_detection.check_conflicts(
-                latest_snapshot, base_entries, commit_entries, commit_kind)
+                latest_snapshot, base_data_files, commit_entries, commit_kind)
 
             if conflict_exception is not None:
                 if allow_rollback and self.rollback is not None:
                     if self.rollback.try_to_rollback(latest_snapshot):
-                        return RetryResult(latest_snapshot, conflict_exception)
+                        # Rolled back: base/snapshot no longer valid; next attempt
+                        # re-scans from scratch (matches Java RollbackRetryResult).
+                        return RetryResult(None, conflict_exception)
                 raise conflict_exception
 
         # Apply row tracking logic after conflict detection (matches Java ordering)
@@ -492,11 +516,11 @@ class FileStoreCommit:
                         commit_kind,
                         commit_time_s,
                     )
-                    return RetryResult(latest_snapshot, None)
+                    return RetryResult(latest_snapshot, None, base_data_files=base_data_files)
         except Exception as e:
             # Commit exception, not sure about the situation and should not clean up the files
             logger.warning("Retry commit for exception.", exc_info=True)
-            return RetryResult(latest_snapshot, e)
+            return RetryResult(latest_snapshot, e, base_data_files=base_data_files)
 
         logger.info(
             "Successfully commit snapshot %d to table %s by user %s "


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core commit/overwrite and conflict-detection paths where incorrect caching or merge logic could delete wrong files or miss conflicts; behavior is heavily tested but still touches concurrent-write semantics.
> 
> **Overview**
> **OVERWRITE commits no longer full-rescan target partitions on every CAS retry.** A new `OverwriteChangesProvider` builds DELETE+ADD entries once (or rebuilds when unsafe), reusing cached manifest entries when intervening snapshots are APPEND-only and do not touch the target partitions via a cheap delta probe; whole-table overwrites and non-APPEND or target-touching concurrent writes still force full scans.
> 
> **Conflict detection on retry** reuses the prior attempt’s base manifest entries and merges `CommitScanner.read_incremental_changes` deltas (with fallback to a full partition scan if a snapshot is missing). `RetryResult` now carries `base_data_files` through failed attempts; rollback clears the cached base for a fresh scan.
> 
> Adds regression tests for cache reuse, invalidation paths, and incremental conflict merging; `partition_predicate_test` mocks `FileScanner` on the provider module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3883e41602ca55adecfe19358c3e0a6747130ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->