### PR TITLE
[python] Split manifest files by target size during commit and compac…

### DIFF
--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -232,18 +232,22 @@ class ManifestFileManager:
                 writer.write(self._to_avro_record(entry))
                 if buf.tell() >= suggested_file_size:
                     writer.flush()
+                    avro_bytes = buf.getvalue()
                     file_name = f"{name_prefix}-{len(result)}"
-                    self._flush(file_name, buf.getvalue())
-                    result.append(self._build_meta(file_name, entries[chunk_start:i + 1]))
+                    self._flush(file_name, avro_bytes)
+                    result.append(self._build_meta(
+                        file_name, entries[chunk_start:i + 1], len(avro_bytes)))
                     chunk_start = i + 1
                     buf = BytesIO()
                     writer = Writer(buf, MANIFEST_ENTRY_SCHEMA, sync_interval=sync_interval)
 
             if chunk_start < len(entries):
                 writer.flush()
+                avro_bytes = buf.getvalue()
                 file_name = f"{name_prefix}-{len(result)}"
-                self._flush(file_name, buf.getvalue())
-                result.append(self._build_meta(file_name, entries[chunk_start:]))
+                self._flush(file_name, avro_bytes)
+                result.append(self._build_meta(
+                    file_name, entries[chunk_start:], len(avro_bytes)))
         except Exception:
             for meta in result:
                 self.file_io.delete_quietly(f"{self.manifest_path}/{meta.file_name}")
@@ -302,7 +306,8 @@ class ManifestFileManager:
             self.file_io.delete_quietly(manifest_path)
             raise RuntimeError(f"Failed to write manifest file: {e}") from e
 
-    def _build_meta(self, file_name: str, entries: List[ManifestEntry]) -> ManifestFileMeta:
+    def _build_meta(self, file_name: str, entries: List[ManifestEntry],
+                    file_size: int = None) -> ManifestFileMeta:
         added_file_count = 0
         deleted_file_count = 0
         schema_id = None
@@ -337,10 +342,12 @@ class ManifestFileManager:
             if max_row_id is None or file_range.to > max_row_id:
                 max_row_id = file_range.to
 
-        manifest_file_path = f"{self.manifest_path}/{file_name}"
+        if file_size is None:
+            manifest_file_path = f"{self.manifest_path}/{file_name}"
+            file_size = self.table.file_io.get_file_size(manifest_file_path)
         return ManifestFileMeta(
             file_name=file_name,
-            file_size=self.table.file_io.get_file_size(manifest_file_path),
+            file_size=file_size,
             num_added_files=added_file_count,
             num_deleted_files=deleted_file_count,
             partition_stats=SimpleStats(

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -37,6 +37,8 @@ from pypaimon.table.row.binary_row import BinaryRow
 class ManifestFileManager:
     """Writer for manifest files in Avro format using unified FileIO."""
 
+    _AVRO_SYNC_INTERVAL = 16000
+
     def __init__(self, table):
         from pypaimon.table.file_store_table import FileStoreTable
 
@@ -220,7 +222,7 @@ class ManifestFileManager:
 
         from fastavro.write import Writer
 
-        sync_interval = min(16000, suggested_file_size)
+        sync_interval = min(self._AVRO_SYNC_INTERVAL, suggested_file_size)
         result = []
         chunk_start = 0
         buf = BytesIO()

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -368,4 +368,3 @@ class ManifestFileManager:
             min_row_id=min_row_id,
             max_row_id=max_row_id,
         )
-

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -369,6 +369,3 @@ class ManifestFileManager:
             max_row_id=max_row_id,
         )
 
-    def write_with_meta(self, file_name, entries: List[ManifestEntry]) -> ManifestFileMeta:
-        self.write(file_name, entries)
-        return self._build_meta(file_name, entries)

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -212,6 +212,8 @@ class ManifestFileManager:
         fastavro.writer(buf, MANIFEST_ENTRY_SCHEMA, self._to_avro_records(entries))
         self._flush(file_name, buf.getvalue())
 
+    _ROLLING_SAMPLE_SIZE = 64
+
     def rolling_write(self, entries: List[ManifestEntry],
                       suggested_file_size: int,
                       name_prefix: str) -> List[ManifestFileMeta]:
@@ -219,15 +221,23 @@ class ManifestFileManager:
             return []
 
         avro_records = self._to_avro_records(entries)
-        buf = BytesIO()
-        fastavro.writer(buf, MANIFEST_ENTRY_SCHEMA, avro_records)
-        total_size = buf.tell()
 
-        if total_size <= suggested_file_size:
-            file_name = f"{name_prefix}-0"
-            self._flush(file_name, buf.getvalue())
-            return [self._build_meta(file_name, entries)]
-        entries_per_chunk = max(1, int(len(entries) * suggested_file_size / total_size))
+        sample_n = min(self._ROLLING_SAMPLE_SIZE, len(entries))
+        sample_buf = BytesIO()
+        fastavro.writer(sample_buf, MANIFEST_ENTRY_SCHEMA, avro_records[:sample_n])
+        avg_entry_size = max(1, sample_buf.tell() / sample_n)
+
+        if avg_entry_size * len(entries) <= suggested_file_size:
+            # Likely fits in one file — serialize all and verify
+            buf = BytesIO()
+            fastavro.writer(buf, MANIFEST_ENTRY_SCHEMA, avro_records)
+            if buf.tell() <= suggested_file_size:
+                file_name = f"{name_prefix}-0"
+                self._flush(file_name, buf.getvalue())
+                return [self._build_meta(file_name, entries)]
+            avg_entry_size = buf.tell() / len(entries)
+
+        entries_per_chunk = max(1, int(suggested_file_size / avg_entry_size))
         pos = 0
         result = []
         try:

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -208,15 +208,9 @@ class ManifestFileManager:
         return fields
 
     def write(self, file_name, entries: List[ManifestEntry]):
-        manifest_path = f"{self.manifest_path}/{file_name}"
-        try:
-            buffer = BytesIO()
-            fastavro.writer(buffer, MANIFEST_ENTRY_SCHEMA, self._to_avro_records(entries))
-            with self.file_io.new_output_stream(manifest_path) as output_stream:
-                output_stream.write(buffer.getvalue())
-        except Exception as e:
-            self.file_io.delete_quietly(manifest_path)
-            raise RuntimeError(f"Failed to write manifest file: {e}") from e
+        buf = BytesIO()
+        fastavro.writer(buf, MANIFEST_ENTRY_SCHEMA, self._to_avro_records(entries))
+        self._flush(file_name, buf.getvalue())
 
     def rolling_write(self, entries: List[ManifestEntry],
                       suggested_file_size: int,
@@ -230,19 +224,27 @@ class ManifestFileManager:
         total_size = buf.tell()
 
         if total_size <= suggested_file_size:
-            return [self._flush_and_build_meta(base_name, entries, buf.getvalue())]
+            self._flush(base_name, buf.getvalue())
+            return [self._build_meta(base_name, entries)]
 
-        num_files = max(1, (total_size + suggested_file_size - 1) // suggested_file_size)
-        chunk_size = max(1, (len(entries) + num_files - 1) // num_files)
-        result = []
+        # Estimate chunk size from average entry size to avoid a second full serialization.
+        avg_entry_size = total_size / len(entries)
+        entries_per_file = max(1, int(suggested_file_size / avg_entry_size))
         name_prefix = base_name.rsplit('-', 1)[0] if base_name[-1].isdigit() and '-' in base_name else base_name
-        for i in range(0, len(entries), chunk_size):
-            chunk_entries = entries[i:i + chunk_size]
-            chunk_records = avro_records[i:i + chunk_size]
-            file_name = f"{name_prefix}-{len(result)}"
-            chunk_buf = BytesIO()
-            fastavro.writer(chunk_buf, MANIFEST_ENTRY_SCHEMA, chunk_records)
-            result.append(self._flush_and_build_meta(file_name, chunk_entries, chunk_buf.getvalue()))
+        result = []
+        try:
+            for i in range(0, len(entries), entries_per_file):
+                chunk_records = avro_records[i:i + entries_per_file]
+                chunk_entries = entries[i:i + entries_per_file]
+                file_name = f"{name_prefix}-{len(result)}"
+                chunk_buf = BytesIO()
+                fastavro.writer(chunk_buf, MANIFEST_ENTRY_SCHEMA, chunk_records)
+                self._flush(file_name, chunk_buf.getvalue())
+                result.append(self._build_meta(file_name, chunk_entries))
+        except Exception:
+            for meta in result:
+                self.file_io.delete_quietly(f"{self.manifest_path}/{meta.file_name}")
+            raise
         return result
 
     def _to_avro_records(self, entries: List[ManifestEntry]) -> List[dict]:
@@ -287,8 +289,7 @@ class ManifestFileManager:
             })
         return records
 
-    def _flush_and_build_meta(self, file_name: str, entries: List[ManifestEntry],
-                              avro_bytes: bytes) -> ManifestFileMeta:
+    def _flush(self, file_name: str, avro_bytes: bytes):
         manifest_path = f"{self.manifest_path}/{file_name}"
         try:
             with self.file_io.new_output_stream(manifest_path) as output_stream:
@@ -296,7 +297,6 @@ class ManifestFileManager:
         except Exception as e:
             self.file_io.delete_quietly(manifest_path)
             raise RuntimeError(f"Failed to write manifest file: {e}") from e
-        return self._build_meta(file_name, entries)
 
     def _build_meta(self, file_name: str, entries: List[ManifestEntry]) -> ManifestFileMeta:
         added_file_count = 0

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -227,20 +227,32 @@ class ManifestFileManager:
             self._flush(base_name, buf.getvalue())
             return [self._build_meta(base_name, entries)]
 
-        # Estimate chunk size from average entry size to avoid a second full serialization.
-        avg_entry_size = total_size / len(entries)
-        entries_per_file = max(1, int(suggested_file_size / avg_entry_size))
         name_prefix = base_name.rsplit('-', 1)[0] if base_name[-1].isdigit() and '-' in base_name else base_name
+        entries_per_chunk = max(1, int(len(entries) * suggested_file_size / total_size))
+        pos = 0
         result = []
         try:
-            for i in range(0, len(entries), entries_per_file):
-                chunk_records = avro_records[i:i + entries_per_file]
-                chunk_entries = entries[i:i + entries_per_file]
-                file_name = f"{name_prefix}-{len(result)}"
+            while pos < len(entries):
+                end = min(pos + entries_per_chunk, len(entries))
                 chunk_buf = BytesIO()
-                fastavro.writer(chunk_buf, MANIFEST_ENTRY_SCHEMA, chunk_records)
+                fastavro.writer(chunk_buf, MANIFEST_ENTRY_SCHEMA, avro_records[pos:end])
+                chunk_size = chunk_buf.tell()
+
+                # Adaptive: if chunk overshoots, shrink and re-serialize
+                if chunk_size > suggested_file_size and end - pos > 1:
+                    end = pos + max(1, int((end - pos) * suggested_file_size / chunk_size))
+                    chunk_buf = BytesIO()
+                    fastavro.writer(chunk_buf, MANIFEST_ENTRY_SCHEMA, avro_records[pos:end])
+                    chunk_size = chunk_buf.tell()
+
+                file_name = f"{name_prefix}-{len(result)}"
                 self._flush(file_name, chunk_buf.getvalue())
-                result.append(self._build_meta(file_name, chunk_entries))
+                result.append(self._build_meta(file_name, entries[pos:end]))
+
+                # Adapt entries_per_chunk for next iteration based on actual size
+                if chunk_size > 0:
+                    entries_per_chunk = max(1, int((end - pos) * suggested_file_size / chunk_size))
+                pos = end
         except Exception:
             for meta in result:
                 self.file_io.delete_quietly(f"{self.manifest_path}/{meta.file_name}")

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -224,6 +224,7 @@ class ManifestFileManager:
 
         sync_interval = min(self._AVRO_SYNC_INTERVAL, suggested_file_size)
         result = []
+        written_files = []
         chunk_start = 0
         buf = BytesIO()
         writer = Writer(buf, MANIFEST_ENTRY_SCHEMA, sync_interval=sync_interval)
@@ -235,6 +236,7 @@ class ManifestFileManager:
                     avro_bytes = buf.getvalue()
                     file_name = f"{name_prefix}-{len(result)}"
                     self._flush(file_name, avro_bytes)
+                    written_files.append(file_name)
                     result.append(self._build_meta(
                         file_name, entries[chunk_start:i + 1], len(avro_bytes)))
                     chunk_start = i + 1
@@ -246,11 +248,12 @@ class ManifestFileManager:
                 avro_bytes = buf.getvalue()
                 file_name = f"{name_prefix}-{len(result)}"
                 self._flush(file_name, avro_bytes)
+                written_files.append(file_name)
                 result.append(self._build_meta(
                     file_name, entries[chunk_start:], len(avro_bytes)))
         except Exception:
-            for meta in result:
-                self.file_io.delete_quietly(f"{self.manifest_path}/{meta.file_name}")
+            for fname in written_files:
+                self.file_io.delete_quietly(f"{self.manifest_path}/{fname}")
             raise
         return result
 

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -208,9 +208,47 @@ class ManifestFileManager:
         return fields
 
     def write(self, file_name, entries: List[ManifestEntry]):
-        avro_records = []
+        manifest_path = f"{self.manifest_path}/{file_name}"
+        try:
+            buffer = BytesIO()
+            fastavro.writer(buffer, MANIFEST_ENTRY_SCHEMA, self._to_avro_records(entries))
+            with self.file_io.new_output_stream(manifest_path) as output_stream:
+                output_stream.write(buffer.getvalue())
+        except Exception as e:
+            self.file_io.delete_quietly(manifest_path)
+            raise RuntimeError(f"Failed to write manifest file: {e}") from e
+
+    def rolling_write(self, entries: List[ManifestEntry],
+                      suggested_file_size: int,
+                      base_name: str) -> List[ManifestFileMeta]:
+        if not entries:
+            return []
+
+        avro_records = self._to_avro_records(entries)
+        buf = BytesIO()
+        fastavro.writer(buf, MANIFEST_ENTRY_SCHEMA, avro_records)
+        total_size = buf.tell()
+
+        if total_size <= suggested_file_size:
+            return [self._flush_and_build_meta(base_name, entries, buf.getvalue())]
+
+        num_files = max(1, (total_size + suggested_file_size - 1) // suggested_file_size)
+        chunk_size = max(1, (len(entries) + num_files - 1) // num_files)
+        result = []
+        name_prefix = base_name.rsplit('-', 1)[0] if base_name[-1].isdigit() and '-' in base_name else base_name
+        for i in range(0, len(entries), chunk_size):
+            chunk_entries = entries[i:i + chunk_size]
+            chunk_records = avro_records[i:i + chunk_size]
+            file_name = f"{name_prefix}-{len(result)}"
+            chunk_buf = BytesIO()
+            fastavro.writer(chunk_buf, MANIFEST_ENTRY_SCHEMA, chunk_records)
+            result.append(self._flush_and_build_meta(file_name, chunk_entries, chunk_buf.getvalue()))
+        return result
+
+    def _to_avro_records(self, entries: List[ManifestEntry]) -> List[dict]:
+        records = []
         for entry in entries:
-            avro_record = {
+            records.append({
                 "_VERSION": 2,
                 "_KIND": entry.kind,
                 "_PARTITION": GenericRowSerializer.to_bytes(entry.partition),
@@ -246,22 +284,21 @@ class ManifestFileManager:
                     "_FIRST_ROW_ID": entry.file.first_row_id,
                     "_WRITE_COLS": entry.file.write_cols,
                 }
-            }
-            avro_records.append(avro_record)
+            })
+        return records
 
+    def _flush_and_build_meta(self, file_name: str, entries: List[ManifestEntry],
+                              avro_bytes: bytes) -> ManifestFileMeta:
         manifest_path = f"{self.manifest_path}/{file_name}"
         try:
-            buffer = BytesIO()
-            fastavro.writer(buffer, MANIFEST_ENTRY_SCHEMA, avro_records)
-            avro_bytes = buffer.getvalue()
             with self.file_io.new_output_stream(manifest_path) as output_stream:
                 output_stream.write(avro_bytes)
         except Exception as e:
             self.file_io.delete_quietly(manifest_path)
             raise RuntimeError(f"Failed to write manifest file: {e}") from e
+        return self._build_meta(file_name, entries)
 
-    def write_with_meta(self, file_name, entries: List[ManifestEntry]) -> ManifestFileMeta:
-        self.write(file_name, entries)
+    def _build_meta(self, file_name: str, entries: List[ManifestEntry]) -> ManifestFileMeta:
         added_file_count = 0
         deleted_file_count = 0
         schema_id = None
@@ -317,3 +354,7 @@ class ManifestFileManager:
             min_row_id=min_row_id,
             max_row_id=max_row_id,
         )
+
+    def write_with_meta(self, file_name, entries: List[ManifestEntry]) -> ManifestFileMeta:
+        self.write(file_name, entries)
+        return self._build_meta(file_name, entries)

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -212,7 +212,7 @@ class ManifestFileManager:
         fastavro.writer(buf, MANIFEST_ENTRY_SCHEMA, self._to_avro_records(entries))
         self._flush(file_name, buf.getvalue())
 
-    _ROLLING_SAMPLE_SIZE = 64
+    _CHECK_ROLLING_RECORD_CNT = 100
 
     def rolling_write(self, entries: List[ManifestEntry],
                       suggested_file_size: int,
@@ -220,95 +220,79 @@ class ManifestFileManager:
         if not entries:
             return []
 
-        avro_records = self._to_avro_records(entries)
+        from fastavro.write import Writer
 
-        sample_n = min(self._ROLLING_SAMPLE_SIZE, len(entries))
-        sample_buf = BytesIO()
-        fastavro.writer(sample_buf, MANIFEST_ENTRY_SCHEMA, avro_records[:sample_n])
-        avg_entry_size = max(1, sample_buf.tell() / sample_n)
-
-        if avg_entry_size * len(entries) <= suggested_file_size:
-            # Likely fits in one file — serialize all and verify
-            buf = BytesIO()
-            fastavro.writer(buf, MANIFEST_ENTRY_SCHEMA, avro_records)
-            if buf.tell() <= suggested_file_size:
-                file_name = f"{name_prefix}-0"
-                self._flush(file_name, buf.getvalue())
-                return [self._build_meta(file_name, entries)]
-            avg_entry_size = buf.tell() / len(entries)
-
-        entries_per_chunk = max(1, int(suggested_file_size / avg_entry_size))
-        pos = 0
         result = []
+        chunk_start = 0
+        buf = BytesIO()
+        writer = Writer(buf, MANIFEST_ENTRY_SCHEMA)
         try:
-            while pos < len(entries):
-                end = min(pos + entries_per_chunk, len(entries))
-                chunk_buf = BytesIO()
-                fastavro.writer(chunk_buf, MANIFEST_ENTRY_SCHEMA, avro_records[pos:end])
-                chunk_size = chunk_buf.tell()
+            for i, entry in enumerate(entries):
+                writer.write(self._to_avro_record(entry))
+                if (i + 1) % self._CHECK_ROLLING_RECORD_CNT == 0:
+                    writer.flush()
+                    if buf.tell() >= suggested_file_size:
+                        writer.dump()
+                        file_name = f"{name_prefix}-{len(result)}"
+                        self._flush(file_name, buf.getvalue())
+                        result.append(self._build_meta(file_name, entries[chunk_start:i + 1]))
+                        chunk_start = i + 1
+                        buf = BytesIO()
+                        writer = Writer(buf, MANIFEST_ENTRY_SCHEMA)
 
-                # Adaptive: if chunk overshoots, shrink and re-serialize
-                if chunk_size > suggested_file_size and end - pos > 1:
-                    end = pos + max(1, int((end - pos) * suggested_file_size / chunk_size))
-                    chunk_buf = BytesIO()
-                    fastavro.writer(chunk_buf, MANIFEST_ENTRY_SCHEMA, avro_records[pos:end])
-                    chunk_size = chunk_buf.tell()
-
+            if chunk_start < len(entries):
+                writer.dump()
                 file_name = f"{name_prefix}-{len(result)}"
-                self._flush(file_name, chunk_buf.getvalue())
-                result.append(self._build_meta(file_name, entries[pos:end]))
-
-                # Adapt entries_per_chunk for next iteration based on actual size
-                if chunk_size > 0:
-                    entries_per_chunk = max(1, int((end - pos) * suggested_file_size / chunk_size))
-                pos = end
+                self._flush(file_name, buf.getvalue())
+                result.append(self._build_meta(file_name, entries[chunk_start:]))
         except Exception:
             for meta in result:
                 self.file_io.delete_quietly(f"{self.manifest_path}/{meta.file_name}")
             raise
         return result
 
+    @staticmethod
+    def _to_avro_record(entry: ManifestEntry) -> dict:
+        return {
+            "_VERSION": 2,
+            "_KIND": entry.kind,
+            "_PARTITION": GenericRowSerializer.to_bytes(entry.partition),
+            "_BUCKET": entry.bucket,
+            "_TOTAL_BUCKETS": entry.total_buckets,
+            "_FILE": {
+                "_FILE_NAME": entry.file.file_name,
+                "_FILE_SIZE": entry.file.file_size,
+                "_ROW_COUNT": entry.file.row_count,
+                "_MIN_KEY": GenericRowSerializer.to_bytes(entry.file.min_key),
+                "_MAX_KEY": GenericRowSerializer.to_bytes(entry.file.max_key),
+                "_KEY_STATS": {
+                    "_MIN_VALUES": GenericRowSerializer.to_bytes(entry.file.key_stats.min_values),
+                    "_MAX_VALUES": GenericRowSerializer.to_bytes(entry.file.key_stats.max_values),
+                    "_NULL_COUNTS": entry.file.key_stats.null_counts,
+                },
+                "_VALUE_STATS": {
+                    "_MIN_VALUES": GenericRowSerializer.to_bytes(entry.file.value_stats.min_values),
+                    "_MAX_VALUES": GenericRowSerializer.to_bytes(entry.file.value_stats.max_values),
+                    "_NULL_COUNTS": entry.file.value_stats.null_counts,
+                },
+                "_MIN_SEQUENCE_NUMBER": entry.file.min_sequence_number,
+                "_MAX_SEQUENCE_NUMBER": entry.file.max_sequence_number,
+                "_SCHEMA_ID": entry.file.schema_id,
+                "_LEVEL": entry.file.level,
+                "_EXTRA_FILES": entry.file.extra_files,
+                "_CREATION_TIME": entry.file.creation_time.get_millisecond() if entry.file.creation_time else None,
+                "_DELETE_ROW_COUNT": entry.file.delete_row_count,
+                "_EMBEDDED_FILE_INDEX": entry.file.embedded_index,
+                "_FILE_SOURCE": entry.file.file_source,
+                "_VALUE_STATS_COLS": entry.file.value_stats_cols,
+                "_EXTERNAL_PATH": entry.file.external_path,
+                "_FIRST_ROW_ID": entry.file.first_row_id,
+                "_WRITE_COLS": entry.file.write_cols,
+            }
+        }
+
     def _to_avro_records(self, entries: List[ManifestEntry]) -> List[dict]:
-        records = []
-        for entry in entries:
-            records.append({
-                "_VERSION": 2,
-                "_KIND": entry.kind,
-                "_PARTITION": GenericRowSerializer.to_bytes(entry.partition),
-                "_BUCKET": entry.bucket,
-                "_TOTAL_BUCKETS": entry.total_buckets,
-                "_FILE": {
-                    "_FILE_NAME": entry.file.file_name,
-                    "_FILE_SIZE": entry.file.file_size,
-                    "_ROW_COUNT": entry.file.row_count,
-                    "_MIN_KEY": GenericRowSerializer.to_bytes(entry.file.min_key),
-                    "_MAX_KEY": GenericRowSerializer.to_bytes(entry.file.max_key),
-                    "_KEY_STATS": {
-                        "_MIN_VALUES": GenericRowSerializer.to_bytes(entry.file.key_stats.min_values),
-                        "_MAX_VALUES": GenericRowSerializer.to_bytes(entry.file.key_stats.max_values),
-                        "_NULL_COUNTS": entry.file.key_stats.null_counts,
-                    },
-                    "_VALUE_STATS": {
-                        "_MIN_VALUES": GenericRowSerializer.to_bytes(entry.file.value_stats.min_values),
-                        "_MAX_VALUES": GenericRowSerializer.to_bytes(entry.file.value_stats.max_values),
-                        "_NULL_COUNTS": entry.file.value_stats.null_counts,
-                    },
-                    "_MIN_SEQUENCE_NUMBER": entry.file.min_sequence_number,
-                    "_MAX_SEQUENCE_NUMBER": entry.file.max_sequence_number,
-                    "_SCHEMA_ID": entry.file.schema_id,
-                    "_LEVEL": entry.file.level,
-                    "_EXTRA_FILES": entry.file.extra_files,
-                    "_CREATION_TIME": entry.file.creation_time.get_millisecond() if entry.file.creation_time else None,
-                    "_DELETE_ROW_COUNT": entry.file.delete_row_count,
-                    "_EMBEDDED_FILE_INDEX": entry.file.embedded_index,
-                    "_FILE_SOURCE": entry.file.file_source,
-                    "_VALUE_STATS_COLS": entry.file.value_stats_cols,
-                    "_EXTERNAL_PATH": entry.file.external_path,
-                    "_FIRST_ROW_ID": entry.file.first_row_id,
-                    "_WRITE_COLS": entry.file.write_cols,
-                }
-            })
-        return records
+        return [self._to_avro_record(e) for e in entries]
 
     def _flush(self, file_name: str, avro_bytes: bytes):
         manifest_path = f"{self.manifest_path}/{file_name}"

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -212,8 +212,6 @@ class ManifestFileManager:
         fastavro.writer(buf, MANIFEST_ENTRY_SCHEMA, self._to_avro_records(entries))
         self._flush(file_name, buf.getvalue())
 
-    _CHECK_ROLLING_RECORD_CNT = 100
-
     def rolling_write(self, entries: List[ManifestEntry],
                       suggested_file_size: int,
                       name_prefix: str) -> List[ManifestFileMeta]:
@@ -222,26 +220,25 @@ class ManifestFileManager:
 
         from fastavro.write import Writer
 
+        sync_interval = min(16000, suggested_file_size)
         result = []
         chunk_start = 0
         buf = BytesIO()
-        writer = Writer(buf, MANIFEST_ENTRY_SCHEMA)
+        writer = Writer(buf, MANIFEST_ENTRY_SCHEMA, sync_interval=sync_interval)
         try:
             for i, entry in enumerate(entries):
                 writer.write(self._to_avro_record(entry))
-                if (i + 1) % self._CHECK_ROLLING_RECORD_CNT == 0:
+                if buf.tell() >= suggested_file_size:
                     writer.flush()
-                    if buf.tell() >= suggested_file_size:
-                        writer.dump()
-                        file_name = f"{name_prefix}-{len(result)}"
-                        self._flush(file_name, buf.getvalue())
-                        result.append(self._build_meta(file_name, entries[chunk_start:i + 1]))
-                        chunk_start = i + 1
-                        buf = BytesIO()
-                        writer = Writer(buf, MANIFEST_ENTRY_SCHEMA)
+                    file_name = f"{name_prefix}-{len(result)}"
+                    self._flush(file_name, buf.getvalue())
+                    result.append(self._build_meta(file_name, entries[chunk_start:i + 1]))
+                    chunk_start = i + 1
+                    buf = BytesIO()
+                    writer = Writer(buf, MANIFEST_ENTRY_SCHEMA, sync_interval=sync_interval)
 
             if chunk_start < len(entries):
-                writer.dump()
+                writer.flush()
                 file_name = f"{name_prefix}-{len(result)}"
                 self._flush(file_name, buf.getvalue())
                 result.append(self._build_meta(file_name, entries[chunk_start:]))

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -214,7 +214,7 @@ class ManifestFileManager:
 
     def rolling_write(self, entries: List[ManifestEntry],
                       suggested_file_size: int,
-                      base_name: str) -> List[ManifestFileMeta]:
+                      name_prefix: str) -> List[ManifestFileMeta]:
         if not entries:
             return []
 
@@ -224,10 +224,9 @@ class ManifestFileManager:
         total_size = buf.tell()
 
         if total_size <= suggested_file_size:
-            self._flush(base_name, buf.getvalue())
-            return [self._build_meta(base_name, entries)]
-
-        name_prefix = base_name.rsplit('-', 1)[0] if base_name[-1].isdigit() and '-' in base_name else base_name
+            file_name = f"{name_prefix}-0"
+            self._flush(file_name, buf.getvalue())
+            return [self._build_meta(file_name, entries)]
         entries_per_chunk = max(1, int(len(entries) * suggested_file_size / total_size))
         pos = 0
         result = []

--- a/paimon-python/pypaimon/manifest/manifest_file_merger.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_merger.py
@@ -68,7 +68,7 @@ class ManifestFileMerger:
     def _merge_candidates(self, candidates: List[ManifestFileMeta],
                           result: List[ManifestFileMeta],
                           new_files: List[ManifestFileMeta]):
-        if len(candidates) == 1 and candidates[0].file_size <= self.suggested_meta_size:
+        if len(candidates) == 1:
             result.append(candidates[0])
             return
 

--- a/paimon-python/pypaimon/manifest/manifest_file_merger.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_merger.py
@@ -86,12 +86,10 @@ class ManifestFileMerger:
             return
 
         manifest_file = "manifest-{}-0".format(str(uuid.uuid4()))
-        merged_meta = self.manifest_file_manager.write_with_meta(
-            manifest_file,
-            merged_entries,
-        )
-        result.append(merged_meta)
-        new_files.append(merged_meta)
+        merged_metas = self.manifest_file_manager.rolling_write(
+            merged_entries, self.suggested_meta_size, manifest_file)
+        result.extend(merged_metas)
+        new_files.extend(merged_metas)
 
     def _delete_manifests(self, manifests: List[ManifestFileMeta]):
         for manifest in manifests:

--- a/paimon-python/pypaimon/manifest/manifest_file_merger.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_merger.py
@@ -68,7 +68,7 @@ class ManifestFileMerger:
     def _merge_candidates(self, candidates: List[ManifestFileMeta],
                           result: List[ManifestFileMeta],
                           new_files: List[ManifestFileMeta]):
-        if len(candidates) == 1:
+        if len(candidates) == 1 and candidates[0].file_size <= self.suggested_meta_size:
             result.append(candidates[0])
             return
 

--- a/paimon-python/pypaimon/manifest/manifest_file_merger.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_merger.py
@@ -85,7 +85,7 @@ class ManifestFileMerger:
         if not merged_entries:
             return
 
-        manifest_file = "manifest-{}-0".format(str(uuid.uuid4()))
+        manifest_file = "manifest-{}".format(str(uuid.uuid4()))
         merged_metas = self.manifest_file_manager.rolling_write(
             merged_entries, self.suggested_meta_size, manifest_file)
         result.extend(merged_metas)

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -419,7 +419,7 @@ class TestFileStoreCommit(unittest.TestCase):
         snapshot_commit.commit.return_value = True
         file_store_commit.snapshot_commit = snapshot_commit
 
-        file_store_commit._write_manifest_file = Mock(return_value=Mock())
+        file_store_commit._write_manifest_files = Mock(return_value=[Mock()])
         file_store_commit._generate_partition_statistics = Mock(return_value=[])
         file_store_commit.manifest_list_manager.read_all.return_value = []
 
@@ -492,7 +492,7 @@ class TestFileStoreCommit(unittest.TestCase):
                           file=make_file("f2.parquet")),
         ]
 
-        result = file_store_commit._write_manifest_file(entries, "manifest-test")
+        result = file_store_commit._write_manifest_files(entries, "manifest-test")
         self.assertIsNotNone(result)
 
     @staticmethod

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -388,9 +388,7 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
         entries = [big if i % 5 == 0 else small for i in range(300)]
         metas = manager.rolling_write(entries, target_size, "manifest-skew")
 
-        # Streaming rolling checks size every N records after flush, so files
-        # may exceed target by up to one batch worth of large entries.
-        max_allowed = target_size * 5
+        max_allowed = target_size * 2
         oversized = [m for m in metas if m.file_size > max_allowed]
         self.assertEqual(
             len(oversized), 0,

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -397,24 +397,6 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
         total_entries = sum(m.num_added_files + m.num_deleted_files for m in metas)
         self.assertEqual(total_entries, 300)
 
-    def test_merge_splits_oversized_manifest(self):
-        from pypaimon.manifest.manifest_file_merger import ManifestFileMerger
-        target_size = 16 * 1024
-        manager = ManifestFileManager(self.table)
-        entries = [self._create_manifest_entry(f"data-{i}.parquet") for i in range(500)]
-        oversized_meta = manager.write_with_meta("manifest-oversized-0", entries)
-        self.assertGreater(oversized_meta.file_size, target_size)
-
-        merger = ManifestFileMerger(manager, target_size, 30)
-        result, new_files = merger.merge([oversized_meta])
-
-        self.assertGreater(len(result), 1,
-                           f"Expected merge to split oversized manifest into "
-                           f"multiple files, got {len(result)}")
-        self.assertTrue(
-            all(m.file_name != oversized_meta.file_name for m in result))
-        total = sum(m.num_added_files + m.num_deleted_files for m in result)
-        self.assertEqual(total, 500)
 
 
 class ManifestListManagerTest(_ManifestManagerSetup):

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -366,6 +366,14 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
             f"Expected multiple manifest files but got {len(metas)} "
             f"with total {sum(m.file_size for m in metas)} bytes")
 
+        mfm = ManifestFileManager(table)
+        all_entries = []
+        for meta in metas:
+            entries = mfm.read(meta.file_name)
+            self.assertEqual(len(entries), meta.num_added_files + meta.num_deleted_files)
+            all_entries.extend(entries)
+        self.assertEqual(len(all_entries), 200)
+
     def test_rolling_write_with_skewed_entries(self):
         target_size = 16 * 1024
         manager = ManifestFileManager(self.table)

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -388,7 +388,9 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
         entries = [big if i % 5 == 0 else small for i in range(300)]
         metas = manager.rolling_write(entries, target_size, "manifest-skew")
 
-        max_allowed = target_size * 2
+        # Streaming rolling checks size every N records after flush, so files
+        # may exceed target by up to one batch worth of large entries.
+        max_allowed = target_size * 5
         oversized = [m for m in metas if m.file_size > max_allowed]
         self.assertEqual(
             len(oversized), 0,

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -397,6 +397,25 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
         total_entries = sum(m.num_added_files + m.num_deleted_files for m in metas)
         self.assertEqual(total_entries, 300)
 
+    def test_merge_splits_oversized_manifest(self):
+        from pypaimon.manifest.manifest_file_merger import ManifestFileMerger
+        target_size = 16 * 1024
+        manager = ManifestFileManager(self.table)
+        entries = [self._create_manifest_entry(f"data-{i}.parquet") for i in range(500)]
+        oversized_meta = manager.write_with_meta("manifest-oversized-0", entries)
+        self.assertGreater(oversized_meta.file_size, target_size)
+
+        merger = ManifestFileMerger(manager, target_size, 30)
+        result, new_files = merger.merge([oversized_meta])
+
+        self.assertGreater(len(result), 1,
+                           f"Expected merge to split oversized manifest into "
+                           f"multiple files, got {len(result)}")
+        self.assertTrue(
+            all(m.file_name != oversized_meta.file_name for m in result))
+        total = sum(m.num_added_files + m.num_deleted_files for m in result)
+        self.assertEqual(total, 500)
+
 
 class ManifestListManagerTest(_ManifestManagerSetup):
     """Tests for ManifestListManager."""

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -385,7 +385,7 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
             ),
         )
         entries = [big if i % 5 == 0 else small for i in range(300)]
-        metas = manager.rolling_write(entries, target_size, "manifest-skew-0")
+        metas = manager.rolling_write(entries, target_size, "manifest-skew")
 
         max_allowed = target_size * 2
         oversized = [m for m in metas if m.file_size > max_allowed]

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -325,6 +325,46 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
         self.assertEqual(read_stats.max_values.get_field(0), 10)
         self.assertEqual(read_stats.null_counts, [2])
 
+    def test_commit_manifest_exceeds_target_size(self):
+        target_size = 16 * 1024
+        pa_schema = pa.schema([
+            ('pt', pa.string()),
+            ('pk', pa.int32()),
+            ('val', pa.string()),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            primary_keys=['pk'],
+            partition_keys=['pt'],
+            options={
+                'bucket': '1',
+                'manifest.target-file-size': '16 kb',
+            },
+        )
+        self.catalog.create_table('default.rolling_bug', schema, False)
+        table = self.catalog.get_table('default.rolling_bug')
+
+        wb = table.new_batch_write_builder()
+        w = wb.new_write()
+        for pt in range(200):
+            rows = [{'pt': f'p{pt}', 'pk': i, 'val': f'v{i}'} for i in range(5)]
+            w.write_arrow(pa.Table.from_pylist(rows, schema=pa_schema))
+        wb.new_commit().commit(w.prepare_commit())
+        w.close()
+
+        snap = table.snapshot_manager().get_latest_snapshot()
+        metas = ManifestListManager(table).read_all(snap)
+        max_allowed = target_size * 2
+        oversized = [m for m in metas if m.file_size > max_allowed]
+        self.assertEqual(
+            len(oversized), 0,
+            f"{len(oversized)} manifest file(s) exceed 2x target ({max_allowed} bytes): "
+            f"{[(m.file_name, m.file_size) for m in oversized]}. "
+            f"Java uses RollingFileWriter to split; Python writes one file.")
+        self.assertGreater(len(metas), 1,
+            f"Expected multiple manifest files but got {len(metas)} "
+            f"with total {sum(m.file_size for m in metas)} bytes")
+
 
 class ManifestListManagerTest(_ManifestManagerSetup):
     """Tests for ManifestListManager."""

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -361,7 +361,8 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
             f"{len(oversized)} manifest file(s) exceed 2x target ({max_allowed} bytes): "
             f"{[(m.file_name, m.file_size) for m in oversized]}. "
             f"Java uses RollingFileWriter to split; Python writes one file.")
-        self.assertGreater(len(metas), 1,
+        self.assertGreater(
+            len(metas), 1,
             f"Expected multiple manifest files but got {len(metas)} "
             f"with total {sum(m.file_size for m in metas)} bytes")
 
@@ -389,7 +390,8 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
 
         max_allowed = target_size * 2
         oversized = [m for m in metas if m.file_size > max_allowed]
-        self.assertEqual(len(oversized), 0,
+        self.assertEqual(
+            len(oversized), 0,
             f"Skewed entries: {len(oversized)} file(s) exceed 2x target: "
             f"{[(m.file_name, m.file_size) for m in oversized]}")
         total_entries = sum(m.num_added_files + m.num_deleted_files for m in metas)

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -406,7 +406,6 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
         self.assertEqual(total_entries, 300)
 
 
-
 class ManifestListManagerTest(_ManifestManagerSetup):
     """Tests for ManifestListManager."""
 

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -365,6 +365,36 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
             f"Expected multiple manifest files but got {len(metas)} "
             f"with total {sum(m.file_size for m in metas)} bytes")
 
+    def test_rolling_write_with_skewed_entries(self):
+        target_size = 16 * 1024
+        manager = ManifestFileManager(self.table)
+        small = self._create_manifest_entry("small.parquet")
+        big = ManifestEntry(
+            kind=0, partition=_EMPTY_ROW, bucket=0, total_buckets=1,
+            file=DataFileMeta(
+                file_name="big.parquet", file_size=1024, row_count=100,
+                min_key=_EMPTY_ROW, max_key=_EMPTY_ROW,
+                key_stats=_EMPTY_STATS, value_stats=_EMPTY_STATS,
+                min_sequence_number=1, max_sequence_number=100,
+                schema_id=0, level=0,
+                extra_files=[f"extra-{i}.idx" for i in range(50)],
+                creation_time=Timestamp.from_epoch_millis(0),
+                delete_row_count=0, embedded_index=b'\x00' * 2000,
+                file_source=None, value_stats_cols=None,
+                external_path=None, first_row_id=None, write_cols=None,
+            ),
+        )
+        entries = [big if i % 5 == 0 else small for i in range(300)]
+        metas = manager.rolling_write(entries, target_size, "manifest-skew-0")
+
+        max_allowed = target_size * 2
+        oversized = [m for m in metas if m.file_size > max_allowed]
+        self.assertEqual(len(oversized), 0,
+            f"Skewed entries: {len(oversized)} file(s) exceed 2x target: "
+            f"{[(m.file_name, m.file_size) for m in oversized]}")
+        total_entries = sum(m.num_added_files + m.num_deleted_files for m in metas)
+        self.assertEqual(total_entries, 300)
+
 
 class ManifestListManagerTest(_ManifestManagerSetup):
     """Tests for ManifestListManager."""

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -422,21 +422,19 @@ class FileStoreCommit:
         changelog_manifest_list_name = None
         changelog_manifest_list_size = None
         changelog_record_count = None
-        delta_known_metas = []
-        changelog_known_metas = []
         merge_new_files = []
         try:
-            delta_known_metas = self._write_manifest_files(commit_entries, new_manifest_file)
-            self.manifest_list_manager.write(delta_manifest_list, delta_known_metas)
+            new_manifest_file_metas = self._write_manifest_files(commit_entries, new_manifest_file)
+            self.manifest_list_manager.write(delta_manifest_list, new_manifest_file_metas)
 
             # Write changelog manifest if changelog entries exist
             if changelog_entries:
                 changelog_manifest_file = f"manifest-{str(uuid.uuid4())}-changelog"
-                changelog_known_metas = self._write_manifest_files(
+                changelog_manifest_file_metas = self._write_manifest_files(
                     changelog_entries, changelog_manifest_file)
                 changelog_manifest_list_name = f"manifest-list-{unique_id}-changelog"
                 self.manifest_list_manager.write(
-                    changelog_manifest_list_name, changelog_known_metas)
+                    changelog_manifest_list_name, changelog_manifest_file_metas)
                 manifest_path = self.manifest_list_manager.manifest_path
                 changelog_manifest_list_size = self.table.file_io.get_file_size(
                     f"{manifest_path}/{changelog_manifest_list_name}")
@@ -499,8 +497,7 @@ class FileStoreCommit:
         except Exception as e:
             try:
                 self._clean_up_reuse_tmp_manifests(
-                    delta_manifest_list, changelog_manifest_list_name, new_index_manifest,
-                    delta_known_metas, changelog_known_metas)
+                    delta_manifest_list, changelog_manifest_list_name, new_index_manifest)
                 self._clean_up_no_reuse_tmp_manifests(
                     base_manifest_list, merge_new_files)
             except Exception as cleanup_err:
@@ -653,25 +650,20 @@ class FileStoreCommit:
     def _clean_up_reuse_tmp_manifests(self,
                                      delta_manifest_list: Optional[str],
                                      changelog_manifest_list: Optional[str],
-                                     index_manifest: Optional[str] = None,
-                                     delta_known_metas: Optional[List[ManifestFileMeta]] = None,
-                                     changelog_known_metas: Optional[List[ManifestFileMeta]] = None):
+                                     index_manifest: Optional[str] = None):
         """Clean up delta/changelog manifests and index manifest.
 
-        Mirrors Java CommitCleaner.cleanUpReuseTmpManifests. Falls back to
-        known metas when manifest list is unreadable (e.g. write failed).
+        Mirrors Java CommitCleaner.cleanUpReuseTmpManifests.
         """
         manifest_path = self.manifest_list_manager.manifest_path
-        for ml_name, known in ((delta_manifest_list, delta_known_metas),
-                               (changelog_manifest_list, changelog_known_metas)):
+        for ml_name in (delta_manifest_list, changelog_manifest_list):
             if ml_name:
                 try:
-                    metas = self.manifest_list_manager.read(ml_name)
+                    for meta in self.manifest_list_manager.read(ml_name):
+                        self.table.file_io.delete_quietly(
+                            f"{self.manifest_file_manager.manifest_path}/{meta.file_name}")
                 except Exception:
-                    metas = known or []
-                for meta in metas:
-                    self.table.file_io.delete_quietly(
-                        f"{self.manifest_file_manager.manifest_path}/{meta.file_name}")
+                    pass
                 self.table.file_io.delete_quietly(f"{manifest_path}/{ml_name}")
         if index_manifest:
             self.table.file_io.delete_quietly(f"{manifest_path}/{index_manifest}")

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -647,10 +647,11 @@ class FileStoreCommit:
                 ))
         return changelog_entries
 
-    def _clean_up_reuse_tmp_manifests(self,
-                                     delta_manifest_list: Optional[str],
-                                     changelog_manifest_list: Optional[str],
-                                     index_manifest: Optional[str] = None):
+    def _clean_up_reuse_tmp_manifests(
+            self,
+            delta_manifest_list: Optional[str],
+            changelog_manifest_list: Optional[str],
+            index_manifest: Optional[str] = None):
         """Clean up delta/changelog manifests and index manifest.
 
         Mirrors Java CommitCleaner.cleanUpReuseTmpManifests.
@@ -668,9 +669,10 @@ class FileStoreCommit:
         if index_manifest:
             self.table.file_io.delete_quietly(f"{manifest_path}/{index_manifest}")
 
-    def _clean_up_no_reuse_tmp_manifests(self,
-                                         base_manifest_list: Optional[str],
-                                         merge_new_files: List[ManifestFileMeta]):
+    def _clean_up_no_reuse_tmp_manifests(
+            self,
+            base_manifest_list: Optional[str],
+            merge_new_files: List[ManifestFileMeta]):
         """Clean up base manifest list and newly created merge manifests.
 
         Mirrors Java CommitCleaner.cleanUpNoReuseTmpManifests.

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -498,9 +498,6 @@ class FileStoreCommit:
             # Generate partition statistics for the commit
             statistics = self._generate_partition_statistics(commit_entries)
         except Exception as e:
-            for meta in new_manifest_files_for_abort:
-                self.table.file_io.delete_quietly(
-                    f"{self.manifest_file_manager.manifest_path}/{meta.file_name}")
             self._cleanup_preparation_failure(delta_manifest_list, base_manifest_list,
                                               new_index_manifest, changelog_manifest_list_name,
                                               new_manifest_files_for_abort)

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -422,10 +422,10 @@ class FileStoreCommit:
         changelog_manifest_list_name = None
         changelog_manifest_list_size = None
         changelog_record_count = None
-        new_manifest_files_for_abort = []
+        merge_before_manifests = []
+        merge_after_manifests = []
         try:
             new_manifest_file_metas = self._write_manifest_files(commit_entries, new_manifest_file)
-            new_manifest_files_for_abort.extend(new_manifest_file_metas)
             self.manifest_list_manager.write(delta_manifest_list, new_manifest_file_metas)
 
             # Write changelog manifest if changelog entries exist
@@ -433,7 +433,6 @@ class FileStoreCommit:
                 changelog_manifest_file = f"manifest-{str(uuid.uuid4())}-changelog"
                 changelog_manifest_file_metas = self._write_manifest_files(
                     changelog_entries, changelog_manifest_file)
-                new_manifest_files_for_abort.extend(changelog_manifest_file_metas)
                 changelog_manifest_list_name = f"manifest-list-{unique_id}-changelog"
                 self.manifest_list_manager.write(
                     changelog_manifest_list_name, changelog_manifest_file_metas)
@@ -453,9 +452,10 @@ class FileStoreCommit:
                     total_record_count += previous_record_count
             else:
                 existing_manifest_files = []
-            merged_manifest_files, merge_new_files = self.manifest_file_merger.merge(
+            merge_before_manifests = existing_manifest_files
+            merged_manifest_files, _ = self.manifest_file_merger.merge(
                 existing_manifest_files)
-            new_manifest_files_for_abort.extend(merge_new_files)
+            merge_after_manifests = merged_manifest_files
             self.manifest_list_manager.write(base_manifest_list, merged_manifest_files)
 
             delta_record_count = 0
@@ -498,9 +498,10 @@ class FileStoreCommit:
             # Generate partition statistics for the commit
             statistics = self._generate_partition_statistics(commit_entries)
         except Exception as e:
-            self._cleanup_preparation_failure(delta_manifest_list, base_manifest_list,
-                                              new_index_manifest, changelog_manifest_list_name,
-                                              new_manifest_files_for_abort)
+            self._clean_up_reuse_tmp_manifests(
+                delta_manifest_list, changelog_manifest_list_name, new_index_manifest)
+            self._clean_up_no_reuse_tmp_manifests(
+                base_manifest_list, merge_before_manifests, merge_after_manifests)
             logger.warning(f"Exception occurs when preparing snapshot: {e}", exc_info=True)
             raise RuntimeError(f"Failed to prepare snapshot: {e}")
 
@@ -645,51 +646,45 @@ class FileStoreCommit:
                 ))
         return changelog_entries
 
-    def _cleanup_preparation_failure(self,
+    def _clean_up_reuse_tmp_manifests(self,
                                      delta_manifest_list: Optional[str],
-                                     base_manifest_list: Optional[str],
-                                     index_manifest: Optional[str] = None,
-                                     changelog_manifest_list: Optional[str] = None,
-                                     base_manifest_files_to_delete: Optional[List[ManifestFileMeta]] = None):
-        try:
-            manifest_path = self.manifest_list_manager.manifest_path
+                                     changelog_manifest_list: Optional[str],
+                                     index_manifest: Optional[str] = None):
+        """Clean up delta/changelog manifests and index manifest.
 
-            if index_manifest:
-                self.table.file_io.delete_quietly(f"{manifest_path}/{index_manifest}")
-
-            if delta_manifest_list:
+        Mirrors Java CommitCleaner.cleanUpReuseTmpManifests.
+        """
+        manifest_path = self.manifest_list_manager.manifest_path
+        for ml_name in (delta_manifest_list, changelog_manifest_list):
+            if ml_name:
                 try:
-                    manifest_files = self.manifest_list_manager.read(delta_manifest_list)
-                    for manifest_meta in manifest_files:
-                        manifest_file_path = f"{self.manifest_file_manager.manifest_path}/{manifest_meta.file_name}"
-                        self.table.file_io.delete_quietly(manifest_file_path)
+                    for meta in self.manifest_list_manager.read(ml_name):
+                        self.table.file_io.delete_quietly(
+                            f"{self.manifest_file_manager.manifest_path}/{meta.file_name}")
                 except Exception:
                     pass
-                delta_path = f"{manifest_path}/{delta_manifest_list}"
-                self.table.file_io.delete_quietly(delta_path)
+                self.table.file_io.delete_quietly(f"{manifest_path}/{ml_name}")
+        if index_manifest:
+            self.table.file_io.delete_quietly(f"{manifest_path}/{index_manifest}")
 
-            if base_manifest_list:
-                if base_manifest_files_to_delete:
-                    for manifest_meta in base_manifest_files_to_delete:
-                        manifest_file_path = (
-                            f"{self.manifest_file_manager.manifest_path}/{manifest_meta.file_name}")
-                        self.table.file_io.delete_quietly(manifest_file_path)
-                base_path = f"{manifest_path}/{base_manifest_list}"
-                self.table.file_io.delete_quietly(base_path)
+    def _clean_up_no_reuse_tmp_manifests(self,
+                                         base_manifest_list: Optional[str],
+                                         merge_before: List[ManifestFileMeta],
+                                         merge_after: List[ManifestFileMeta]):
+        """Clean up base manifest list and only the newly created merge manifests.
 
-            if changelog_manifest_list:
-                try:
-                    changelog_manifests = self.manifest_list_manager.read(changelog_manifest_list)
-                    for manifest_meta in changelog_manifests:
-                        manifest_file_path = (
-                            f"{self.manifest_file_manager.manifest_path}/{manifest_meta.file_name}")
-                        self.table.file_io.delete_quietly(manifest_file_path)
-                except Exception:
-                    pass
-                changelog_path = f"{manifest_path}/{changelog_manifest_list}"
-                self.table.file_io.delete_quietly(changelog_path)
-        except Exception as e:
-            logger.warning(f"Failed to clean up temporary files during preparation failure: {e}", exc_info=True)
+        Mirrors Java CommitCleaner.cleanUpNoReuseTmpManifests: only deletes
+        manifests in merge_after that are not in merge_before (i.e. newly
+        created by the merger, not pre-existing).
+        """
+        manifest_path = self.manifest_list_manager.manifest_path
+        if base_manifest_list:
+            self.table.file_io.delete_quietly(f"{manifest_path}/{base_manifest_list}")
+        old_names = {m.file_name for m in merge_before}
+        for meta in merge_after:
+            if meta.file_name not in old_names:
+                self.table.file_io.delete_quietly(
+                    f"{self.manifest_file_manager.manifest_path}/{meta.file_name}")
 
     def abort(self, commit_messages: List[CommitMessage]):
         """Abort commit and delete files. Uses external_path if available to ensure proper scheme handling."""

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -498,6 +498,9 @@ class FileStoreCommit:
             # Generate partition statistics for the commit
             statistics = self._generate_partition_statistics(commit_entries)
         except Exception as e:
+            for meta in new_manifest_files_for_abort:
+                self.table.file_io.delete_quietly(
+                    f"{self.manifest_file_manager.manifest_path}/{meta.file_name}")
             self._cleanup_preparation_failure(delta_manifest_list, base_manifest_list,
                                               new_index_manifest, changelog_manifest_list_name,
                                               new_manifest_files_for_abort)

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -425,6 +425,7 @@ class FileStoreCommit:
         new_manifest_files_for_abort = []
         try:
             new_manifest_file_metas = self._write_manifest_files(commit_entries, new_manifest_file)
+            new_manifest_files_for_abort.extend(new_manifest_file_metas)
             self.manifest_list_manager.write(delta_manifest_list, new_manifest_file_metas)
 
             # Write changelog manifest if changelog entries exist
@@ -432,6 +433,7 @@ class FileStoreCommit:
                 changelog_manifest_file = f"manifest-{str(uuid.uuid4())}-changelog"
                 changelog_manifest_file_metas = self._write_manifest_files(
                     changelog_entries, changelog_manifest_file)
+                new_manifest_files_for_abort.extend(changelog_manifest_file_metas)
                 changelog_manifest_list_name = f"manifest-list-{unique_id}-changelog"
                 self.manifest_list_manager.write(
                     changelog_manifest_list_name, changelog_manifest_file_metas)
@@ -451,8 +453,9 @@ class FileStoreCommit:
                     total_record_count += previous_record_count
             else:
                 existing_manifest_files = []
-            merged_manifest_files, new_manifest_files_for_abort = self.manifest_file_merger.merge(
+            merged_manifest_files, merge_new_files = self.manifest_file_merger.merge(
                 existing_manifest_files)
+            new_manifest_files_for_abort.extend(merge_new_files)
             self.manifest_list_manager.write(base_manifest_list, merged_manifest_files)
 
             delta_record_count = 0

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -374,7 +374,7 @@ class FileStoreCommit:
         delta_manifest_list = f"manifest-list-{unique_id}-1"
 
         # process new_manifest
-        new_manifest_file = f"manifest-{str(uuid.uuid4())}-0"
+        new_manifest_file = f"manifest-{str(uuid.uuid4())}"
         new_index_manifest = None
         # process snapshot
         new_snapshot_id = latest_snapshot.id + 1 if latest_snapshot else 1
@@ -429,7 +429,7 @@ class FileStoreCommit:
 
             # Write changelog manifest if changelog entries exist
             if changelog_entries:
-                changelog_manifest_file = f"manifest-{str(uuid.uuid4())}-changelog-0"
+                changelog_manifest_file = f"manifest-{str(uuid.uuid4())}-changelog"
                 changelog_manifest_file_metas = self._write_manifest_files(
                     changelog_entries, changelog_manifest_file)
                 changelog_manifest_list_name = f"manifest-list-{unique_id}-changelog"

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -422,20 +422,22 @@ class FileStoreCommit:
         changelog_manifest_list_name = None
         changelog_manifest_list_size = None
         changelog_record_count = None
+        delta_known_metas = []
+        changelog_known_metas = []
         merge_before_manifests = []
         merge_after_manifests = []
         try:
-            new_manifest_file_metas = self._write_manifest_files(commit_entries, new_manifest_file)
-            self.manifest_list_manager.write(delta_manifest_list, new_manifest_file_metas)
+            delta_known_metas = self._write_manifest_files(commit_entries, new_manifest_file)
+            self.manifest_list_manager.write(delta_manifest_list, delta_known_metas)
 
             # Write changelog manifest if changelog entries exist
             if changelog_entries:
                 changelog_manifest_file = f"manifest-{str(uuid.uuid4())}-changelog"
-                changelog_manifest_file_metas = self._write_manifest_files(
+                changelog_known_metas = self._write_manifest_files(
                     changelog_entries, changelog_manifest_file)
                 changelog_manifest_list_name = f"manifest-list-{unique_id}-changelog"
                 self.manifest_list_manager.write(
-                    changelog_manifest_list_name, changelog_manifest_file_metas)
+                    changelog_manifest_list_name, changelog_known_metas)
                 manifest_path = self.manifest_list_manager.manifest_path
                 changelog_manifest_list_size = self.table.file_io.get_file_size(
                     f"{manifest_path}/{changelog_manifest_list_name}")
@@ -499,7 +501,8 @@ class FileStoreCommit:
             statistics = self._generate_partition_statistics(commit_entries)
         except Exception as e:
             self._clean_up_reuse_tmp_manifests(
-                delta_manifest_list, changelog_manifest_list_name, new_index_manifest)
+                delta_manifest_list, changelog_manifest_list_name, new_index_manifest,
+                delta_known_metas, changelog_known_metas)
             self._clean_up_no_reuse_tmp_manifests(
                 base_manifest_list, merge_before_manifests, merge_after_manifests)
             logger.warning(f"Exception occurs when preparing snapshot: {e}", exc_info=True)
@@ -649,20 +652,25 @@ class FileStoreCommit:
     def _clean_up_reuse_tmp_manifests(self,
                                      delta_manifest_list: Optional[str],
                                      changelog_manifest_list: Optional[str],
-                                     index_manifest: Optional[str] = None):
+                                     index_manifest: Optional[str] = None,
+                                     delta_known_metas: Optional[List[ManifestFileMeta]] = None,
+                                     changelog_known_metas: Optional[List[ManifestFileMeta]] = None):
         """Clean up delta/changelog manifests and index manifest.
 
-        Mirrors Java CommitCleaner.cleanUpReuseTmpManifests.
+        Mirrors Java CommitCleaner.cleanUpReuseTmpManifests. Falls back to
+        known metas when manifest list is unreadable (e.g. write failed).
         """
         manifest_path = self.manifest_list_manager.manifest_path
-        for ml_name in (delta_manifest_list, changelog_manifest_list):
+        for ml_name, known in ((delta_manifest_list, delta_known_metas),
+                               (changelog_manifest_list, changelog_known_metas)):
             if ml_name:
                 try:
-                    for meta in self.manifest_list_manager.read(ml_name):
-                        self.table.file_io.delete_quietly(
-                            f"{self.manifest_file_manager.manifest_path}/{meta.file_name}")
+                    metas = self.manifest_list_manager.read(ml_name)
                 except Exception:
-                    pass
+                    metas = known or []
+                for meta in metas:
+                    self.table.file_io.delete_quietly(
+                        f"{self.manifest_file_manager.manifest_path}/{meta.file_name}")
                 self.table.file_io.delete_quietly(f"{manifest_path}/{ml_name}")
         if index_manifest:
             self.table.file_io.delete_quietly(f"{manifest_path}/{index_manifest}")

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -424,8 +424,7 @@ class FileStoreCommit:
         changelog_record_count = None
         delta_known_metas = []
         changelog_known_metas = []
-        merge_before_manifests = []
-        merge_after_manifests = []
+        merge_new_files = []
         try:
             delta_known_metas = self._write_manifest_files(commit_entries, new_manifest_file)
             self.manifest_list_manager.write(delta_manifest_list, delta_known_metas)
@@ -454,10 +453,8 @@ class FileStoreCommit:
                     total_record_count += previous_record_count
             else:
                 existing_manifest_files = []
-            merge_before_manifests = existing_manifest_files
             merged_manifest_files, merge_new_files = self.manifest_file_merger.merge(
                 existing_manifest_files)
-            merge_after_manifests = merged_manifest_files
             self.manifest_list_manager.write(base_manifest_list, merged_manifest_files)
 
             delta_record_count = 0

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -455,7 +455,7 @@ class FileStoreCommit:
             else:
                 existing_manifest_files = []
             merge_before_manifests = existing_manifest_files
-            merged_manifest_files, _ = self.manifest_file_merger.merge(
+            merged_manifest_files, merge_new_files = self.manifest_file_merger.merge(
                 existing_manifest_files)
             merge_after_manifests = merged_manifest_files
             self.manifest_list_manager.write(base_manifest_list, merged_manifest_files)
@@ -500,11 +500,15 @@ class FileStoreCommit:
             # Generate partition statistics for the commit
             statistics = self._generate_partition_statistics(commit_entries)
         except Exception as e:
-            self._clean_up_reuse_tmp_manifests(
-                delta_manifest_list, changelog_manifest_list_name, new_index_manifest,
-                delta_known_metas, changelog_known_metas)
-            self._clean_up_no_reuse_tmp_manifests(
-                base_manifest_list, merge_before_manifests, merge_after_manifests)
+            try:
+                self._clean_up_reuse_tmp_manifests(
+                    delta_manifest_list, changelog_manifest_list_name, new_index_manifest,
+                    delta_known_metas, changelog_known_metas)
+                self._clean_up_no_reuse_tmp_manifests(
+                    base_manifest_list, merge_new_files)
+            except Exception as cleanup_err:
+                logger.warning(f"Failed to clean up temporary files: {cleanup_err}",
+                               exc_info=True)
             logger.warning(f"Exception occurs when preparing snapshot: {e}", exc_info=True)
             raise RuntimeError(f"Failed to prepare snapshot: {e}")
 
@@ -677,22 +681,17 @@ class FileStoreCommit:
 
     def _clean_up_no_reuse_tmp_manifests(self,
                                          base_manifest_list: Optional[str],
-                                         merge_before: List[ManifestFileMeta],
-                                         merge_after: List[ManifestFileMeta]):
-        """Clean up base manifest list and only the newly created merge manifests.
+                                         merge_new_files: List[ManifestFileMeta]):
+        """Clean up base manifest list and newly created merge manifests.
 
-        Mirrors Java CommitCleaner.cleanUpNoReuseTmpManifests: only deletes
-        manifests in merge_after that are not in merge_before (i.e. newly
-        created by the merger, not pre-existing).
+        Mirrors Java CommitCleaner.cleanUpNoReuseTmpManifests.
         """
         manifest_path = self.manifest_list_manager.manifest_path
         if base_manifest_list:
             self.table.file_io.delete_quietly(f"{manifest_path}/{base_manifest_list}")
-        old_names = {m.file_name for m in merge_before}
-        for meta in merge_after:
-            if meta.file_name not in old_names:
-                self.table.file_io.delete_quietly(
-                    f"{self.manifest_file_manager.manifest_path}/{meta.file_name}")
+        for meta in merge_new_files:
+            self.table.file_io.delete_quietly(
+                f"{self.manifest_file_manager.manifest_path}/{meta.file_name}")
 
     def abort(self, commit_messages: List[CommitMessage]):
         """Abort commit and delete files. Uses external_path if available to ensure proper scheme handling."""

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -424,17 +424,17 @@ class FileStoreCommit:
         changelog_record_count = None
         new_manifest_files_for_abort = []
         try:
-            new_manifest_file_meta = self._write_manifest_file(commit_entries, new_manifest_file)
-            self.manifest_list_manager.write(delta_manifest_list, [new_manifest_file_meta])
+            new_manifest_file_metas = self._write_manifest_files(commit_entries, new_manifest_file)
+            self.manifest_list_manager.write(delta_manifest_list, new_manifest_file_metas)
 
             # Write changelog manifest if changelog entries exist
             if changelog_entries:
                 changelog_manifest_file = f"manifest-{str(uuid.uuid4())}-changelog-0"
-                changelog_manifest_file_meta = self._write_manifest_file(
+                changelog_manifest_file_metas = self._write_manifest_files(
                     changelog_entries, changelog_manifest_file)
                 changelog_manifest_list_name = f"manifest-list-{unique_id}-changelog"
                 self.manifest_list_manager.write(
-                    changelog_manifest_list_name, [changelog_manifest_file_meta])
+                    changelog_manifest_list_name, changelog_manifest_file_metas)
                 manifest_path = self.manifest_list_manager.manifest_path
                 changelog_manifest_list_size = self.table.file_io.get_file_size(
                     f"{manifest_path}/{changelog_manifest_list_name}")
@@ -543,8 +543,9 @@ class FileStoreCommit:
 
         return SuccessResult()
 
-    def _write_manifest_file(self, commit_entries, new_manifest_file):
-        return self.manifest_file_manager.write_with_meta(new_manifest_file, commit_entries)
+    def _write_manifest_files(self, commit_entries, base_name):
+        return self.manifest_file_manager.rolling_write(
+            commit_entries, self.manifest_target_size, base_name)
 
     def _is_duplicate_commit(self, retry_result, latest_snapshot, commit_identifier, commit_kind) -> bool:
         if retry_result is not None and latest_snapshot is not None:


### PR DESCRIPTION
…tion

Manifest files written by pypaimon commit and minor compaction were not split by manifest-target-file-size. A single OVERWRITE commit writing 400 partitions produced a 138 MiB manifest (17x the 8 MiB default target), slowing every subsequent commit that reads it.

Add ManifestFileManager.rolling_write() that estimates the total serialized size, then splits entries across multiple files so each stays near the target. Apply it in FileStoreCommit delta/changelog manifest writing and ManifestFileMerger minor compaction.

### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the commit preparation path (manifest layout and failure cleanup); incorrect rolling or cleanup could leave orphan files or oversized manifests, though behavior mirrors Java and is covered by new integration tests.
> 
> **Overview**
> **pypaimon** no longer writes one monolithic Avro manifest per delta/changelog commit or minor merge when entry volume exceeds **`manifest.target-file-size`**. **`ManifestFileManager.rolling_write()`** streams entries with fastavro’s **`Writer`**, rolls to new files when buffered size crosses the suggested limit (with Avro sync interval capped), returns multiple **`ManifestFileMeta`**, and deletes partial outputs on failure.
> 
> **`FileStoreCommit`** routes delta and changelog manifests through **`_write_manifest_files`** → **`rolling_write`**, writes **lists** of metas to manifest lists, and replaces the old single-file cleanup with Java-aligned **`_clean_up_reuse_tmp_manifests`** / **`_clean_up_no_reuse_tmp_manifests`** (including merge outputs from compaction). **`ManifestFileMerger`** minor compaction uses **`rolling_write`** instead of a single **`write_with_meta`**.
> 
> Avro serialization is centralized in **`_to_avro_record`** / **`_flush`** / **`_build_meta`** (optional known **`file_size`**). Tests cover large multi-partition commits and skewed entry sizes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6790c9f9aa442574082ef3caa841aaa82aa3544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->