### PR TITLE
[flink][spark] Support dry_run in compact_manifest procedure

### DIFF
--- a/docs/docs/flink/procedures.md
+++ b/docs/docs/flink/procedures.md
@@ -871,15 +871,18 @@ All available procedures are listed below.
       <td>compact_manifest</td>
       <td>
          CALL [catalog.]sys.compact_manifest(`table` => 'identifier')<br/>
-         CALL [catalog.]sys.compact_manifest(`table` => 'identifier', 'options' => 'key1=value1,key2=value2')
+         CALL [catalog.]sys.compact_manifest(`table` => 'identifier', 'options' => 'key1=value1,key2=value2')<br/>
+         CALL [catalog.]sys.compact_manifest(`table` => 'identifier', `dry_run` => true)
       </td>
       <td>
          To compact_manifest the manifests. Arguments:
             <li>table: the target table identifier. Cannot be empty.</li>
             <li>options: the additional dynamic options of the table. It prioritizes higher than original `tableProp` and lower than `procedureArg`.</li>
+            <li>dry_run (Boolean, optional): when true, returns manifest metadata statistics without actually compacting.</li>
       </td>
       <td>
-         CALL sys.compact_manifest(`table` => 'default.T')
+         CALL sys.compact_manifest(`table` => 'default.T')<br/>
+         CALL sys.compact_manifest(`table` => 'default.T', `dry_run` => true)
       </td>
    </tr>
    <tr>

--- a/docs/docs/spark/procedures.md
+++ b/docs/docs/spark/procedures.md
@@ -441,9 +441,11 @@ This section introduce all available spark procedures about paimon.
          To compact_manifest the manifests. Arguments:
             <li>table: the target table identifier. Cannot be empty.</li>
             <li>options: the additional dynamic options of the table. It prioritizes higher than original `tableProp` and lower than `procedureArg`.</li>
+            <li>dry_run (Boolean, optional): when true, logs manifest metadata statistics without actually compacting. The result is printed to the application log; the SQL return value is still `true`.</li>
       </td>
       <td>
-         CALL sys.compact_manifest(`table` => 'default.T')
+         CALL sys.compact_manifest(`table` => 'default.T')<br/>
+         CALL sys.compact_manifest(`table` => 'default.T', dry_run => true)
       </td>
    </tr>
    <tr>

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestCompactDryRun.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestCompactDryRun.java
@@ -18,17 +18,15 @@
 
 package org.apache.paimon.operation;
 
-import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.options.MemorySize;
-import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 
 import java.util.List;
 
-/** Dry run for manifest compaction, computing before/after statistics without committing. */
+/** Dry run for manifest compaction. Reads only existing metadata, never writes files. */
 public class ManifestCompactDryRun {
 
     public static String execute(FileStoreTable table) {
@@ -38,38 +36,27 @@ public class ManifestCompactDryRun {
         }
 
         ManifestList manifestList = table.store().manifestListFactory().create();
-        List<ManifestFileMeta> beforeManifests = manifestList.readDataManifests(latestSnapshot);
+        List<ManifestFileMeta> manifests = manifestList.readDataManifests(latestSnapshot);
 
-        Options compactOptions = Options.fromMap(table.options());
-        compactOptions.set(CoreOptions.MANIFEST_MERGE_MIN_COUNT, 1);
-        compactOptions.set(CoreOptions.MANIFEST_FULL_COMPACTION_FILE_SIZE, MemorySize.ofBytes(1));
+        long manifestFileCount = manifests.size();
+        long totalSize = manifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
+        long totalAddedEntries =
+                manifests.stream().mapToLong(ManifestFileMeta::numAddedFiles).sum();
+        long totalDeletedEntries =
+                manifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
 
-        List<ManifestFileMeta> afterManifests =
-                ManifestFileMerger.merge(
-                        beforeManifests,
-                        table.store().manifestFileFactory().create(),
-                        table.schema().logicalPartitionType(),
-                        new CoreOptions(compactOptions),
-                        null);
-
-        long beforeFileCount = beforeManifests.size();
-        long afterFileCount = afterManifests.size();
-        long beforeTotalSize = beforeManifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
-        long afterTotalSize = afterManifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
-        long beforeDeletedEntries =
-                beforeManifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
-        long afterDeletedEntries =
-                afterManifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
-        long eliminatedDeletedEntries = beforeDeletedEntries - afterDeletedEntries;
+        if (totalDeletedEntries == 0) {
+            return String.format(
+                    "Dry run: %d manifest files (%s), 0 deleted entries. Nothing to compact.",
+                    manifestFileCount, MemorySize.ofBytes(totalSize));
+        }
 
         return String.format(
-                "Dry run: manifest compaction would reduce %d manifest files to %d, "
-                        + "total file size from %s to %s, "
-                        + "eliminating %d deleted entries.",
-                beforeFileCount,
-                afterFileCount,
-                MemorySize.ofBytes(beforeTotalSize),
-                MemorySize.ofBytes(afterTotalSize),
-                eliminatedDeletedEntries);
+                "Dry run: %d manifest files (%s), "
+                        + "%d added entries, %d deleted entries to eliminate.",
+                manifestFileCount,
+                MemorySize.ofBytes(totalSize),
+                totalAddedEntries,
+                totalDeletedEntries);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestCompactDryRun.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestCompactDryRun.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.manifest.ManifestFileMeta;
+import org.apache.paimon.manifest.ManifestList;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
+
+import java.util.List;
+
+/** Dry run for manifest compaction, computing before/after statistics without committing. */
+public class ManifestCompactDryRun {
+
+    public static String execute(FileStoreTable table) {
+        Snapshot latestSnapshot = table.store().snapshotManager().latestSnapshot();
+        if (latestSnapshot == null) {
+            return "Dry run: no snapshot exists, nothing to compact.";
+        }
+
+        ManifestList manifestList = table.store().manifestListFactory().create();
+        List<ManifestFileMeta> beforeManifests = manifestList.readDataManifests(latestSnapshot);
+
+        Options compactOptions = Options.fromMap(table.options());
+        compactOptions.set(CoreOptions.MANIFEST_MERGE_MIN_COUNT, 1);
+        compactOptions.set(CoreOptions.MANIFEST_FULL_COMPACTION_FILE_SIZE, MemorySize.ofBytes(1));
+
+        List<ManifestFileMeta> afterManifests =
+                ManifestFileMerger.merge(
+                        beforeManifests,
+                        table.store().manifestFileFactory().create(),
+                        table.schema().logicalPartitionType(),
+                        new CoreOptions(compactOptions),
+                        null);
+
+        long beforeFileCount = beforeManifests.size();
+        long afterFileCount = afterManifests.size();
+        long beforeTotalSize = beforeManifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
+        long afterTotalSize = afterManifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
+        long beforeDeletedEntries =
+                beforeManifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
+        long afterDeletedEntries =
+                afterManifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
+        long eliminatedDeletedEntries = beforeDeletedEntries - afterDeletedEntries;
+
+        return String.format(
+                "Dry run: manifest compaction would reduce %d manifest files to %d, "
+                        + "total file size from %s to %s, "
+                        + "eliminating %d deleted entries.",
+                beforeFileCount,
+                afterFileCount,
+                MemorySize.ofBytes(beforeTotalSize),
+                MemorySize.ofBytes(afterTotalSize),
+                eliminatedDeletedEntries);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestCompactDryRun.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestCompactDryRun.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.operation;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.manifest.ManifestList;
@@ -26,37 +27,72 @@ import org.apache.paimon.table.FileStoreTable;
 
 import java.util.List;
 
-/** Dry run for manifest compaction. Reads only existing metadata, never writes files. */
+/**
+ * Dry run for manifest compaction. Reads only existing metadata, never writes files. Replicates the
+ * trigger logic from {@link ManifestFileMerger#tryFullCompaction} to predict whether compaction
+ * would actually fire.
+ */
 public class ManifestCompactDryRun {
 
     public static String execute(FileStoreTable table) {
         Snapshot latestSnapshot = table.store().snapshotManager().latestSnapshot();
         if (latestSnapshot == null) {
-            return "Dry run: no snapshot exists, nothing to compact.";
+            return "Dry run: no snapshot exists.";
         }
 
         ManifestList manifestList = table.store().manifestListFactory().create();
         List<ManifestFileMeta> manifests = manifestList.readDataManifests(latestSnapshot);
 
-        long manifestFileCount = manifests.size();
-        long totalSize = manifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
-        long totalAddedEntries =
-                manifests.stream().mapToLong(ManifestFileMeta::numAddedFiles).sum();
-        long totalDeletedEntries =
-                manifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
-
-        if (totalDeletedEntries == 0) {
-            return String.format(
-                    "Dry run: %d manifest files (%s), 0 deleted entries. Nothing to compact.",
-                    manifestFileCount, MemorySize.ofBytes(totalSize));
+        if (manifests.isEmpty()) {
+            return "Dry run: 0 manifest files.";
         }
+
+        CoreOptions options = new CoreOptions(table.options());
+        long suggestedMetaSize = options.manifestTargetSize().getBytes();
+
+        long totalFiles = manifests.size();
+        long totalSize = 0;
+        long totalDeletedEntries = 0;
+        long filesWithDeletedEntries = 0;
+        long smallFiles = 0;
+        long filesToCompact = 0;
+        long totalDeltaFileSize = 0;
+
+        for (ManifestFileMeta file : manifests) {
+            totalSize += file.fileSize();
+            totalDeletedEntries += file.numDeletedFiles();
+
+            boolean hasDeleted = file.numDeletedFiles() > 0;
+            boolean isSmall = file.fileSize() < suggestedMetaSize;
+
+            if (hasDeleted) {
+                filesWithDeletedEntries++;
+            }
+            if (isSmall) {
+                smallFiles++;
+            }
+            if (hasDeleted || isSmall) {
+                filesToCompact++;
+                totalDeltaFileSize += file.fileSize();
+            }
+        }
+
+        // compactManifestOnce forces sizeTrigger = 1 byte
+        boolean wouldTrigger = totalDeltaFileSize >= 1;
 
         return String.format(
                 "Dry run: %d manifest files (%s), "
-                        + "%d added entries, %d deleted entries to eliminate.",
-                manifestFileCount,
+                        + "%d deleted entries in %d files, "
+                        + "%d undersized files (< %s), "
+                        + "%d files to compact, "
+                        + "would trigger: %s.",
+                totalFiles,
                 MemorySize.ofBytes(totalSize),
-                totalAddedEntries,
-                totalDeletedEntries);
+                totalDeletedEntries,
+                filesWithDeletedEntries,
+                smallFiles,
+                MemorySize.ofBytes(suggestedMetaSize),
+                filesToCompact,
+                wouldTrigger);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestCompactDryRun.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestCompactDryRun.java
@@ -27,11 +27,7 @@ import org.apache.paimon.table.FileStoreTable;
 
 import java.util.List;
 
-/**
- * Dry run for manifest compaction. Reads only existing metadata, never writes files. Replicates the
- * trigger logic from {@link ManifestFileMerger#tryFullCompaction} to predict whether compaction
- * would actually fire.
- */
+/** Dry run for manifest compaction. Reads only existing metadata, never writes files. */
 public class ManifestCompactDryRun {
 
     public static String execute(FileStoreTable table) {
@@ -55,44 +51,27 @@ public class ManifestCompactDryRun {
         long totalDeletedEntries = 0;
         long filesWithDeletedEntries = 0;
         long smallFiles = 0;
-        long filesToCompact = 0;
-        long totalDeltaFileSize = 0;
 
         for (ManifestFileMeta file : manifests) {
             totalSize += file.fileSize();
             totalDeletedEntries += file.numDeletedFiles();
-
-            boolean hasDeleted = file.numDeletedFiles() > 0;
-            boolean isSmall = file.fileSize() < suggestedMetaSize;
-
-            if (hasDeleted) {
+            if (file.numDeletedFiles() > 0) {
                 filesWithDeletedEntries++;
             }
-            if (isSmall) {
+            if (file.fileSize() < suggestedMetaSize) {
                 smallFiles++;
             }
-            if (hasDeleted || isSmall) {
-                filesToCompact++;
-                totalDeltaFileSize += file.fileSize();
-            }
         }
-
-        // compactManifestOnce forces sizeTrigger = 1 byte
-        boolean wouldTrigger = totalDeltaFileSize >= 1;
 
         return String.format(
                 "Dry run: %d manifest files (%s), "
                         + "%d deleted entries in %d files, "
-                        + "%d undersized files (< %s), "
-                        + "%d files to compact, "
-                        + "would trigger: %s.",
+                        + "%d undersized files (< %s).",
                 totalFiles,
                 MemorySize.ofBytes(totalSize),
                 totalDeletedEntries,
                 filesWithDeletedEntries,
                 smallFiles,
-                MemorySize.ofBytes(suggestedMetaSize),
-                filesToCompact,
-                wouldTrigger);
+                MemorySize.ofBytes(suggestedMetaSize));
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
@@ -195,10 +195,7 @@ public class ManifestFileMerger {
         // 1. should trigger full compaction
 
         Filter<ManifestFileMeta> mustChange =
-                file ->
-                        file.numDeletedFiles() > 0
-                                || file.fileSize() < suggestedMetaSize
-                                || file.fileSize() > suggestedMetaSize;
+                file -> file.numDeletedFiles() > 0 || file.fileSize() < suggestedMetaSize;
         long totalManifestSize = 0;
         long deltaDeleteFileNum = 0;
         long totalDeltaFileSize = 0;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
@@ -194,12 +194,11 @@ public class ManifestFileMerger {
 
         // 1. should trigger full compaction
 
-        long oversizedThreshold = Math.max(2 * suggestedMetaSize, 16 * 1024 * 1024);
         Filter<ManifestFileMeta> mustChange =
                 file ->
                         file.numDeletedFiles() > 0
                                 || file.fileSize() < suggestedMetaSize
-                                || file.fileSize() > oversizedThreshold;
+                                || file.fileSize() > suggestedMetaSize;
         long totalManifestSize = 0;
         long deltaDeleteFileNum = 0;
         long totalDeltaFileSize = 0;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
@@ -195,7 +195,10 @@ public class ManifestFileMerger {
         // 1. should trigger full compaction
 
         Filter<ManifestFileMeta> mustChange =
-                file -> file.numDeletedFiles() > 0 || file.fileSize() < suggestedMetaSize;
+                file ->
+                        file.numDeletedFiles() > 0
+                                || file.fileSize() < suggestedMetaSize
+                                || file.fileSize() > suggestedMetaSize;
         long totalManifestSize = 0;
         long deltaDeleteFileNum = 0;
         long totalDeltaFileSize = 0;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
@@ -194,11 +194,12 @@ public class ManifestFileMerger {
 
         // 1. should trigger full compaction
 
+        long oversizedThreshold = Math.max(2 * suggestedMetaSize, 16 * 1024 * 1024);
         Filter<ManifestFileMeta> mustChange =
                 file ->
                         file.numDeletedFiles() > 0
                                 || file.fileSize() < suggestedMetaSize
-                                || file.fileSize() > suggestedMetaSize;
+                                || file.fileSize() > oversizedThreshold;
         long totalManifestSize = 0;
         long deltaDeleteFileNum = 0;
         long totalDeltaFileSize = 0;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactManifestProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactManifestProcedure.java
@@ -19,6 +19,12 @@
 package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.manifest.ManifestFileMeta;
+import org.apache.paimon.manifest.ManifestList;
+import org.apache.paimon.operation.ManifestFileMerger;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.utils.ProcedureUtils;
@@ -28,7 +34,10 @@ import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.ProcedureHint;
 import org.apache.flink.table.procedure.ProcedureContext;
 
+import javax.annotation.Nullable;
+
 import java.util.HashMap;
+import java.util.List;
 
 /** Compact manifest file to reduce deleted manifest entries. */
 public class CompactManifestProcedure extends ProcedureBase {
@@ -43,9 +52,14 @@ public class CompactManifestProcedure extends ProcedureBase {
     @ProcedureHint(
             argument = {
                 @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
-                @ArgumentHint(name = "options", type = @DataTypeHint("STRING"), isOptional = true)
+                @ArgumentHint(name = "options", type = @DataTypeHint("STRING"), isOptional = true),
+                @ArgumentHint(name = "dry_run", type = @DataTypeHint("BOOLEAN"), isOptional = true)
             })
-    public String[] call(ProcedureContext procedureContext, String tableId, String options)
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            @Nullable String options,
+            @Nullable Boolean dryRun)
             throws Exception {
 
         FileStoreTable table = (FileStoreTable) table(tableId);
@@ -56,9 +70,57 @@ public class CompactManifestProcedure extends ProcedureBase {
 
         table = table.copy(dynamicOptions);
 
+        if (dryRun != null && dryRun) {
+            return dryRunCompactManifest(table);
+        }
+
         try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
             commit.compactManifests();
         }
         return new String[] {"success"};
+    }
+
+    private String[] dryRunCompactManifest(FileStoreTable table) {
+        Snapshot latestSnapshot = table.store().snapshotManager().latestSnapshot();
+        if (latestSnapshot == null) {
+            return new String[] {"Dry run: no snapshot exists, nothing to compact."};
+        }
+
+        ManifestList manifestList = table.store().manifestListFactory().create();
+        List<ManifestFileMeta> beforeManifests = manifestList.readDataManifests(latestSnapshot);
+
+        Options compactOptions = Options.fromMap(table.options());
+        compactOptions.set(CoreOptions.MANIFEST_MERGE_MIN_COUNT, 1);
+        compactOptions.set(CoreOptions.MANIFEST_FULL_COMPACTION_FILE_SIZE, MemorySize.ofBytes(1));
+
+        List<ManifestFileMeta> afterManifests =
+                ManifestFileMerger.merge(
+                        beforeManifests,
+                        table.store().manifestFileFactory().create(),
+                        table.schema().logicalPartitionType(),
+                        new CoreOptions(compactOptions),
+                        null);
+
+        long beforeFileCount = beforeManifests.size();
+        long afterFileCount = afterManifests.size();
+        long beforeTotalSize = beforeManifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
+        long afterTotalSize = afterManifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
+        long beforeDeletedEntries =
+                beforeManifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
+        long afterDeletedEntries =
+                afterManifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
+        long eliminatedDeletedEntries = beforeDeletedEntries - afterDeletedEntries;
+
+        String result =
+                String.format(
+                        "Dry run: manifest compaction would reduce %d manifest files to %d, "
+                                + "total file size from %s to %s, "
+                                + "eliminating %d deleted entries.",
+                        beforeFileCount,
+                        afterFileCount,
+                        MemorySize.ofBytes(beforeTotalSize),
+                        MemorySize.ofBytes(afterTotalSize),
+                        eliminatedDeletedEntries);
+        return new String[] {result};
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactManifestProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactManifestProcedure.java
@@ -19,12 +19,7 @@
 package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.Snapshot;
-import org.apache.paimon.manifest.ManifestFileMeta;
-import org.apache.paimon.manifest.ManifestList;
-import org.apache.paimon.operation.ManifestFileMerger;
-import org.apache.paimon.options.MemorySize;
-import org.apache.paimon.options.Options;
+import org.apache.paimon.operation.ManifestCompactDryRun;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.utils.ProcedureUtils;
@@ -37,7 +32,6 @@ import org.apache.flink.table.procedure.ProcedureContext;
 import javax.annotation.Nullable;
 
 import java.util.HashMap;
-import java.util.List;
 
 /** Compact manifest file to reduce deleted manifest entries. */
 public class CompactManifestProcedure extends ProcedureBase {
@@ -71,56 +65,12 @@ public class CompactManifestProcedure extends ProcedureBase {
         table = table.copy(dynamicOptions);
 
         if (dryRun != null && dryRun) {
-            return dryRunCompactManifest(table);
+            return new String[] {ManifestCompactDryRun.execute(table)};
         }
 
         try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
             commit.compactManifests();
         }
         return new String[] {"success"};
-    }
-
-    private String[] dryRunCompactManifest(FileStoreTable table) {
-        Snapshot latestSnapshot = table.store().snapshotManager().latestSnapshot();
-        if (latestSnapshot == null) {
-            return new String[] {"Dry run: no snapshot exists, nothing to compact."};
-        }
-
-        ManifestList manifestList = table.store().manifestListFactory().create();
-        List<ManifestFileMeta> beforeManifests = manifestList.readDataManifests(latestSnapshot);
-
-        Options compactOptions = Options.fromMap(table.options());
-        compactOptions.set(CoreOptions.MANIFEST_MERGE_MIN_COUNT, 1);
-        compactOptions.set(CoreOptions.MANIFEST_FULL_COMPACTION_FILE_SIZE, MemorySize.ofBytes(1));
-
-        List<ManifestFileMeta> afterManifests =
-                ManifestFileMerger.merge(
-                        beforeManifests,
-                        table.store().manifestFileFactory().create(),
-                        table.schema().logicalPartitionType(),
-                        new CoreOptions(compactOptions),
-                        null);
-
-        long beforeFileCount = beforeManifests.size();
-        long afterFileCount = afterManifests.size();
-        long beforeTotalSize = beforeManifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
-        long afterTotalSize = afterManifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
-        long beforeDeletedEntries =
-                beforeManifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
-        long afterDeletedEntries =
-                afterManifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
-        long eliminatedDeletedEntries = beforeDeletedEntries - afterDeletedEntries;
-
-        String result =
-                String.format(
-                        "Dry run: manifest compaction would reduce %d manifest files to %d, "
-                                + "total file size from %s to %s, "
-                                + "eliminating %d deleted entries.",
-                        beforeFileCount,
-                        afterFileCount,
-                        MemorySize.ofBytes(beforeTotalSize),
-                        MemorySize.ofBytes(afterTotalSize),
-                        eliminatedDeletedEntries);
-        return new String[] {result};
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactManifestProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactManifestProcedureITCase.java
@@ -166,7 +166,8 @@ public class CompactManifestProcedureITCase extends CatalogITCaseBase {
                         .toString();
 
         Assertions.assertThat(dryRunResult).startsWith("Dry run:");
-        Assertions.assertThat(dryRunResult).contains("deleted entries to eliminate");
+        Assertions.assertThat(dryRunResult).contains("deleted entries in");
+        Assertions.assertThat(dryRunResult).contains("would trigger: true");
 
         // verify dry run did not actually compact
         Assertions.assertThat(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactManifestProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactManifestProcedureITCase.java
@@ -167,7 +167,6 @@ public class CompactManifestProcedureITCase extends CatalogITCaseBase {
 
         Assertions.assertThat(dryRunResult).startsWith("Dry run:");
         Assertions.assertThat(dryRunResult).contains("deleted entries in");
-        Assertions.assertThat(dryRunResult).contains("would trigger: true");
 
         // verify dry run did not actually compact
         Assertions.assertThat(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactManifestProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactManifestProcedureITCase.java
@@ -166,7 +166,7 @@ public class CompactManifestProcedureITCase extends CatalogITCaseBase {
                         .toString();
 
         Assertions.assertThat(dryRunResult).startsWith("Dry run:");
-        Assertions.assertThat(dryRunResult).contains("eliminating");
+        Assertions.assertThat(dryRunResult).contains("deleted entries to eliminate");
 
         // verify dry run did not actually compact
         Assertions.assertThat(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactManifestProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactManifestProcedureITCase.java
@@ -130,4 +130,47 @@ public class CompactManifestProcedureITCase extends CatalogITCaseBase {
                 .isEqualTo(
                         "[+I[1, 101, 15, 20221208], +I[4, 1001, 16, 20221208], +I[5, 10001, 15, 20221209]]");
     }
+
+    @Test
+    public void testManifestCompactDryRun() {
+        sql(
+                "CREATE TABLE T ("
+                        + " k INT,"
+                        + " v STRING,"
+                        + " hh INT,"
+                        + " dt STRING"
+                        + ") PARTITIONED BY (dt, hh) WITH ("
+                        + " 'write-only' = 'true',"
+                        + " 'manifest.full-compaction-threshold-size' = '10000 T',"
+                        + " 'bucket' = '-1'"
+                        + ")");
+
+        sql(
+                "INSERT INTO T VALUES (1, '10', 15, '20221208'), (4, '100', 16, '20221208'), (5, '1000', 15, '20221209')");
+
+        sql(
+                "INSERT OVERWRITE T VALUES (1, '10', 15, '20221208'), (4, '100', 16, '20221208'), (5, '1000', 15, '20221209')");
+
+        sql(
+                "INSERT OVERWRITE T VALUES (1, '10', 15, '20221208'), (4, '100', 16, '20221208'), (5, '1000', 15, '20221209')");
+
+        Assertions.assertThat(
+                        sql("SELECT sum(num_deleted_files) FROM T$manifests").get(0).getField(0))
+                .isEqualTo(6L);
+
+        String dryRunResult =
+                Objects.requireNonNull(
+                                sql("CALL sys.compact_manifest(`table` => 'default.T', `dry_run` => true)")
+                                        .get(0)
+                                        .getField(0))
+                        .toString();
+
+        Assertions.assertThat(dryRunResult).startsWith("Dry run:");
+        Assertions.assertThat(dryRunResult).contains("eliminating");
+
+        // verify dry run did not actually compact
+        Assertions.assertThat(
+                        sql("SELECT sum(num_deleted_files) FROM T$manifests").get(0).getField(0))
+                .isEqualTo(6L);
+    }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactManifestProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactManifestProcedure.java
@@ -18,13 +18,7 @@
 
 package org.apache.paimon.spark.procedure;
 
-import org.apache.paimon.CoreOptions;
-import org.apache.paimon.Snapshot;
-import org.apache.paimon.manifest.ManifestFileMeta;
-import org.apache.paimon.manifest.ManifestList;
-import org.apache.paimon.operation.ManifestFileMerger;
-import org.apache.paimon.options.MemorySize;
-import org.apache.paimon.options.Options;
+import org.apache.paimon.operation.ManifestCompactDryRun;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.BatchTableCommit;
@@ -40,7 +34,6 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
 
 import java.util.HashMap;
-import java.util.List;
 
 import static org.apache.spark.sql.types.DataTypes.BooleanType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
@@ -65,7 +58,8 @@ public class CompactManifestProcedure extends BaseProcedure {
     private static final StructType OUTPUT_TYPE =
             new StructType(
                     new StructField[] {
-                        new StructField("result", DataTypes.StringType, true, Metadata.empty())
+                        new StructField("result", DataTypes.BooleanType, true, Metadata.empty()),
+                        new StructField("message", DataTypes.StringType, true, Metadata.empty())
                     });
 
     protected CompactManifestProcedure(TableCatalog tableCatalog) {
@@ -95,8 +89,8 @@ public class CompactManifestProcedure extends BaseProcedure {
         table = table.copy(dynamicOptions);
 
         if (dryRun) {
-            String result = dryRunCompactManifest((FileStoreTable) table);
-            return new InternalRow[] {newInternalRow(UTF8String.fromString(result))};
+            String message = ManifestCompactDryRun.execute((FileStoreTable) table);
+            return new InternalRow[] {newInternalRow(true, UTF8String.fromString(message))};
         }
 
         try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
@@ -105,49 +99,7 @@ public class CompactManifestProcedure extends BaseProcedure {
             throw new RuntimeException(e);
         }
 
-        return new InternalRow[] {newInternalRow(UTF8String.fromString("success"))};
-    }
-
-    private String dryRunCompactManifest(FileStoreTable table) {
-        Snapshot latestSnapshot = table.store().snapshotManager().latestSnapshot();
-        if (latestSnapshot == null) {
-            return "Dry run: no snapshot exists, nothing to compact.";
-        }
-
-        ManifestList manifestList = table.store().manifestListFactory().create();
-        List<ManifestFileMeta> beforeManifests = manifestList.readDataManifests(latestSnapshot);
-
-        Options compactOptions = Options.fromMap(table.options());
-        compactOptions.set(CoreOptions.MANIFEST_MERGE_MIN_COUNT, 1);
-        compactOptions.set(CoreOptions.MANIFEST_FULL_COMPACTION_FILE_SIZE, MemorySize.ofBytes(1));
-
-        List<ManifestFileMeta> afterManifests =
-                ManifestFileMerger.merge(
-                        beforeManifests,
-                        table.store().manifestFileFactory().create(),
-                        table.schema().logicalPartitionType(),
-                        new CoreOptions(compactOptions),
-                        null);
-
-        long beforeFileCount = beforeManifests.size();
-        long afterFileCount = afterManifests.size();
-        long beforeTotalSize = beforeManifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
-        long afterTotalSize = afterManifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
-        long beforeDeletedEntries =
-                beforeManifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
-        long afterDeletedEntries =
-                afterManifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
-        long eliminatedDeletedEntries = beforeDeletedEntries - afterDeletedEntries;
-
-        return String.format(
-                "Dry run: manifest compaction would reduce %d manifest files to %d, "
-                        + "total file size from %s to %s, "
-                        + "eliminating %d deleted entries.",
-                beforeFileCount,
-                afterFileCount,
-                MemorySize.ofBytes(beforeTotalSize),
-                MemorySize.ofBytes(afterTotalSize),
-                eliminatedDeletedEntries);
+        return new InternalRow[] {newInternalRow(true, null)};
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactManifestProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactManifestProcedure.java
@@ -31,7 +31,8 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.unsafe.types.UTF8String;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 
@@ -48,6 +49,8 @@ import static org.apache.spark.sql.types.DataTypes.StringType;
  */
 public class CompactManifestProcedure extends BaseProcedure {
 
+    private static final Logger LOG = LoggerFactory.getLogger(CompactManifestProcedure.class);
+
     private static final ProcedureParameter[] PARAMETERS =
             new ProcedureParameter[] {
                 ProcedureParameter.required("table", StringType),
@@ -58,8 +61,7 @@ public class CompactManifestProcedure extends BaseProcedure {
     private static final StructType OUTPUT_TYPE =
             new StructType(
                     new StructField[] {
-                        new StructField("result", DataTypes.BooleanType, true, Metadata.empty()),
-                        new StructField("message", DataTypes.StringType, true, Metadata.empty())
+                        new StructField("result", DataTypes.BooleanType, true, Metadata.empty())
                     });
 
     protected CompactManifestProcedure(TableCatalog tableCatalog) {
@@ -90,7 +92,8 @@ public class CompactManifestProcedure extends BaseProcedure {
 
         if (dryRun) {
             String message = ManifestCompactDryRun.execute((FileStoreTable) table);
-            return new InternalRow[] {newInternalRow(true, UTF8String.fromString(message))};
+            LOG.info(message);
+            return new InternalRow[] {newInternalRow(true)};
         }
 
         try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
@@ -99,7 +102,7 @@ public class CompactManifestProcedure extends BaseProcedure {
             throw new RuntimeException(e);
         }
 
-        return new InternalRow[] {newInternalRow(true, null)};
+        return new InternalRow[] {newInternalRow(true)};
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactManifestProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactManifestProcedure.java
@@ -18,6 +18,14 @@
 
 package org.apache.paimon.spark.procedure;
 
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.manifest.ManifestFileMeta;
+import org.apache.paimon.manifest.ManifestList;
+import org.apache.paimon.operation.ManifestFileMerger;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.utils.ProcedureUtils;
@@ -29,9 +37,12 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 
 import java.util.HashMap;
+import java.util.List;
 
+import static org.apache.spark.sql.types.DataTypes.BooleanType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
 /**
@@ -39,6 +50,7 @@ import static org.apache.spark.sql.types.DataTypes.StringType;
  *
  * <pre><code>
  *  CALL sys.compact_manifest(table => 'tableId')
+ *  CALL sys.compact_manifest(table => 'tableId', dry_run => true)
  * </code></pre>
  */
 public class CompactManifestProcedure extends BaseProcedure {
@@ -46,13 +58,14 @@ public class CompactManifestProcedure extends BaseProcedure {
     private static final ProcedureParameter[] PARAMETERS =
             new ProcedureParameter[] {
                 ProcedureParameter.required("table", StringType),
-                ProcedureParameter.optional("options", StringType)
+                ProcedureParameter.optional("options", StringType),
+                ProcedureParameter.optional("dry_run", BooleanType)
             };
 
     private static final StructType OUTPUT_TYPE =
             new StructType(
                     new StructField[] {
-                        new StructField("result", DataTypes.BooleanType, true, Metadata.empty())
+                        new StructField("result", DataTypes.StringType, true, Metadata.empty())
                     });
 
     protected CompactManifestProcedure(TableCatalog tableCatalog) {
@@ -74,11 +87,17 @@ public class CompactManifestProcedure extends BaseProcedure {
 
         Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
         String options = args.isNullAt(1) ? null : args.getString(1);
+        boolean dryRun = !args.isNullAt(2) && args.getBoolean(2);
 
         Table table = loadSparkTable(tableIdent).getTable();
         HashMap<String, String> dynamicOptions = new HashMap<>();
         ProcedureUtils.putAllOptions(dynamicOptions, options);
         table = table.copy(dynamicOptions);
+
+        if (dryRun) {
+            String result = dryRunCompactManifest((FileStoreTable) table);
+            return new InternalRow[] {newInternalRow(UTF8String.fromString(result))};
+        }
 
         try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
             commit.compactManifests();
@@ -86,7 +105,49 @@ public class CompactManifestProcedure extends BaseProcedure {
             throw new RuntimeException(e);
         }
 
-        return new InternalRow[] {newInternalRow(true)};
+        return new InternalRow[] {newInternalRow(UTF8String.fromString("success"))};
+    }
+
+    private String dryRunCompactManifest(FileStoreTable table) {
+        Snapshot latestSnapshot = table.store().snapshotManager().latestSnapshot();
+        if (latestSnapshot == null) {
+            return "Dry run: no snapshot exists, nothing to compact.";
+        }
+
+        ManifestList manifestList = table.store().manifestListFactory().create();
+        List<ManifestFileMeta> beforeManifests = manifestList.readDataManifests(latestSnapshot);
+
+        Options compactOptions = Options.fromMap(table.options());
+        compactOptions.set(CoreOptions.MANIFEST_MERGE_MIN_COUNT, 1);
+        compactOptions.set(CoreOptions.MANIFEST_FULL_COMPACTION_FILE_SIZE, MemorySize.ofBytes(1));
+
+        List<ManifestFileMeta> afterManifests =
+                ManifestFileMerger.merge(
+                        beforeManifests,
+                        table.store().manifestFileFactory().create(),
+                        table.schema().logicalPartitionType(),
+                        new CoreOptions(compactOptions),
+                        null);
+
+        long beforeFileCount = beforeManifests.size();
+        long afterFileCount = afterManifests.size();
+        long beforeTotalSize = beforeManifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
+        long afterTotalSize = afterManifests.stream().mapToLong(ManifestFileMeta::fileSize).sum();
+        long beforeDeletedEntries =
+                beforeManifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
+        long afterDeletedEntries =
+                afterManifests.stream().mapToLong(ManifestFileMeta::numDeletedFiles).sum();
+        long eliminatedDeletedEntries = beforeDeletedEntries - afterDeletedEntries;
+
+        return String.format(
+                "Dry run: manifest compaction would reduce %d manifest files to %d, "
+                        + "total file size from %s to %s, "
+                        + "eliminating %d deleted entries.",
+                beforeFileCount,
+                afterFileCount,
+                MemorySize.ofBytes(beforeTotalSize),
+                MemorySize.ofBytes(afterTotalSize),
+                eliminatedDeletedEntries);
     }
 
     @Override

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactManifestProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactManifestProcedureTest.scala
@@ -46,4 +46,31 @@ class CompactManifestProcedureTest extends PaimonSparkTestBase with StreamTest {
     rows = spark.sql("SELECT sum(num_deleted_files) FROM `T$manifests`").collectAsList()
     Assertions.assertThat(rows.get(0).getLong(0)).isEqualTo(0L)
   }
+
+  test("Paimon Procedure: compact manifest dry run") {
+    spark.sql(s"""
+                 |CREATE TABLE T2 (id INT, value STRING, dt STRING, hh INT)
+                 |TBLPROPERTIES ('bucket'='-1', 'write-only'='true', 'compaction.min.file-num'='2')
+                 |PARTITIONED BY (dt, hh)
+                 |""".stripMargin)
+
+    spark.sql(s"INSERT INTO T2 VALUES (5, '5', '2024-01-02', 0), (6, '6', '2024-01-02', 1)")
+    spark.sql(s"INSERT OVERWRITE T2 VALUES (5, '5', '2024-01-02', 0), (6, '6', '2024-01-02', 1)")
+    spark.sql(s"INSERT OVERWRITE T2 VALUES (5, '5', '2024-01-02', 0), (6, '6', '2024-01-02', 1)")
+
+    Thread.sleep(10000)
+
+    var rows = spark.sql("SELECT sum(num_deleted_files) FROM `T2$manifests`").collectAsList()
+    val deletedBefore = rows.get(0).getLong(0)
+    Assertions.assertThat(deletedBefore).isGreaterThan(0L)
+
+    val dryRunRows = spark.sql("CALL sys.compact_manifest(table => 'T2', dry_run => true)")
+      .collectAsList()
+    Assertions.assertThat(dryRunRows.get(0).getBoolean(0)).isTrue
+    Assertions.assertThat(dryRunRows.get(0).getString(1)).startsWith("Dry run:")
+
+    // verify dry run did not actually compact
+    rows = spark.sql("SELECT sum(num_deleted_files) FROM `T2$manifests`").collectAsList()
+    Assertions.assertThat(rows.get(0).getLong(0)).isEqualTo(deletedBefore)
+  }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactManifestProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactManifestProcedureTest.scala
@@ -62,10 +62,10 @@ class CompactManifestProcedureTest extends PaimonSparkTestBase with StreamTest {
     val deletedBefore = rows.get(0).getLong(0)
     Assertions.assertThat(deletedBefore).isGreaterThan(0L)
 
-    val dryRunRows = spark.sql("CALL sys.compact_manifest(table => 'T2', dry_run => true)")
+    val dryRunRows = spark
+      .sql("CALL sys.compact_manifest(table => 'T2', dry_run => true)")
       .collectAsList()
     Assertions.assertThat(dryRunRows.get(0).getBoolean(0)).isTrue
-    Assertions.assertThat(dryRunRows.get(0).getString(1)).startsWith("Dry run:")
 
     // verify dry run did not actually compact
     rows = spark.sql("SELECT sum(num_deleted_files) FROM `T2$manifests`").collectAsList()

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactManifestProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactManifestProcedureTest.scala
@@ -58,8 +58,6 @@ class CompactManifestProcedureTest extends PaimonSparkTestBase with StreamTest {
     spark.sql(s"INSERT OVERWRITE T2 VALUES (5, '5', '2024-01-02', 0), (6, '6', '2024-01-02', 1)")
     spark.sql(s"INSERT OVERWRITE T2 VALUES (5, '5', '2024-01-02', 0), (6, '6', '2024-01-02', 1)")
 
-    Thread.sleep(10000)
-
     var rows = spark.sql("SELECT sum(num_deleted_files) FROM `T2$manifests`").collectAsList()
     val deletedBefore = rows.get(0).getLong(0)
     Assertions.assertThat(deletedBefore).isGreaterThan(0L)


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in read-only metadata path; default compaction behavior is unchanged. Spark surfaces stats via logs rather than SQL output.
> 
> **Overview**
> Adds an optional **`dry_run`** argument to **`sys.compact_manifest`** on Flink and Spark so operators can inspect manifest compaction impact without committing changes.
> 
> Shared logic lives in **`ManifestCompactDryRun`**, which reads the latest snapshot’s data manifests only (no writes) and reports counts such as manifest files, total size, deleted entries, and undersized files vs **`manifest-target-size`**.
> 
> With **`dry_run => true`**, Flink returns that summary string from the procedure; Spark logs the same text-smoke and still returns **`true`**. Normal compaction is unchanged when **`dry_run`** is omitted or false. Flink and Spark procedure docs and integration tests cover the dry-run path and assert deleted manifest entries are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29e0275974cc418d17c7a630d7af369935456267. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->