### PR TITLE
[python] Embed IOConfig in Daft blob File columns so native File ops …

### DIFF
--- a/paimon-python/pypaimon/daft/daft_blob.py
+++ b/paimon-python/pypaimon/daft/daft_blob.py
@@ -60,11 +60,10 @@ def _deserialize_one(data: bytes) -> tuple[str, int, int]:
 
 
 def blob_column_to_file_array(column: pa.Array, io_config_bytes: bytes | None = None) -> pa.Array:
-    """Convert a large_binary column of serialized BlobDescriptors to a FileReference-compatible struct.
+    """Convert a large_binary column of serialized BlobDescriptors to a File-compatible struct.
 
-    ``io_config_bytes`` is a serialized Daft IOConfig (see ``serialize_io_config``) embedded into
-    each File so native Daft File ops (open/read/as_image) carry object-store credentials. When None
-    the io_config is left null and native File ops fall back to Daft's global IOConfig.
+    ``io_config_bytes`` (serialized IOConfig) is embedded into each File so native File ops carry
+    credentials; when None the io_config is left null and ops fall back to Daft's global IOConfig.
     """
     urls: list[str | None] = []
     offsets: list[int | None] = []

--- a/paimon-python/pypaimon/daft/daft_blob.py
+++ b/paimon-python/pypaimon/daft/daft_blob.py
@@ -59,8 +59,13 @@ def _deserialize_one(data: bytes) -> tuple[str, int, int]:
     return uri, offset, length
 
 
-def blob_column_to_file_array(column: pa.Array) -> pa.Array:
-    """Convert a large_binary column of serialized BlobDescriptors to a FileReference-compatible struct."""
+def blob_column_to_file_array(column: pa.Array, io_config_bytes: bytes | None = None) -> pa.Array:
+    """Convert a large_binary column of serialized BlobDescriptors to a FileReference-compatible struct.
+
+    ``io_config_bytes`` is a serialized Daft IOConfig (see ``serialize_io_config``) embedded into
+    each File so native Daft File ops (open/read/as_image) carry object-store credentials. When None
+    the io_config is left null and native File ops fall back to Daft's global IOConfig.
+    """
     urls: list[str | None] = []
     offsets: list[int | None] = []
     lengths: list[int | None] = []
@@ -78,10 +83,18 @@ def blob_column_to_file_array(column: pa.Array) -> pa.Array:
             lengths.append(length)
 
     n = len(urls)
+    if io_config_bytes is None:
+        io_configs: pa.Array = pa.nulls(n, type=pa.large_binary())
+    else:
+        # Only populate io_config for valid rows; keep null rows null.
+        io_configs = pa.array(
+            [io_config_bytes if u is not None else None for u in urls],
+            type=pa.large_binary(),
+        )
     return pa.StructArray.from_arrays(
         [
             pa.array(urls, type=pa.large_utf8()),
-            pa.nulls(n, type=pa.large_binary()),
+            io_configs,
             pa.array(offsets, type=pa.int64()),
             pa.array(lengths, type=pa.int64()),
         ],

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -212,19 +212,38 @@ class _PaimonPKSplitTask(DataSourceTask):
         if self._predicate is not None:
             read_builder = read_builder.with_filter(self._predicate)
 
+        blob_io_config = self._blob_io_config_bytes(table) if self._blob_column_names else None
         reader = read_builder.new_read().to_arrow_batch_reader([self._split])
         for batch in iter(reader.read_next_batch, None):
             if self._output_columns is not None:
                 batch = batch.select(self._output_columns)
             if self._blob_column_names:
-                batch = _convert_blob_columns(batch, self._blob_column_names)
+                batch = _convert_blob_columns(batch, self._blob_column_names, blob_io_config)
             rb = RecordBatch.from_arrow_record_batches([batch], batch.schema)
             if self._blob_column_names:
                 rb = _cast_blob_columns_to_file(rb, self._blob_column_names)
             yield rb
 
+    def _blob_io_config_bytes(self, table: FileStoreTable) -> bytes | None:
+        """Serialized IOConfig embedded into blob File columns so native Daft File ops
+        carry object-store credentials. Built from the just-loaded table so REST/DLF STS
+        tokens are refreshed at read time rather than frozen at plan time."""
+        from pypaimon.daft.daft_io_config import (
+            _convert_paimon_catalog_options_to_io_config,
+            serialize_io_config,
+        )
+        from pypaimon.daft.daft_paimon import _enrich_options_with_rest_token
 
-def _convert_blob_columns(batch: pa.RecordBatch, blob_column_names: set[str]) -> pa.RecordBatch:
+        enriched = _enrich_options_with_rest_token(self._table_catalog_options, table)
+        io_config = _convert_paimon_catalog_options_to_io_config(enriched)
+        return serialize_io_config(io_config) if io_config is not None else None
+
+
+def _convert_blob_columns(
+    batch: pa.RecordBatch,
+    blob_column_names: set[str],
+    io_config_bytes: bytes | None = None,
+) -> pa.RecordBatch:
     """Replace serialized BlobDescriptor columns with the File physical struct layout."""
     from pypaimon.daft.daft_blob import FILE_PHYSICAL_TYPE, blob_column_to_file_array
 
@@ -233,7 +252,7 @@ def _convert_blob_columns(batch: pa.RecordBatch, blob_column_names: set[str]) ->
     for i, field in enumerate(batch.schema):
         col = batch.column(i)
         if field.name in blob_column_names and (pa.types.is_large_binary(field.type) or pa.types.is_binary(field.type)):
-            arrays.append(blob_column_to_file_array(col))
+            arrays.append(blob_column_to_file_array(col, io_config_bytes))
             fields.append(pa.field(field.name, FILE_PHYSICAL_TYPE, nullable=field.nullable))
         else:
             arrays.append(col)

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -228,9 +228,14 @@ class _PaimonPKSplitTask(DataSourceTask):
 
     def _blob_io_config_bytes(self, table: FileStoreTable) -> bytes | None:
         """Serialized IOConfig embedded into blob File columns so native Daft File ops
-        carry object-store credentials. Prefer the just-loaded table's REST/DLF token so
-        STS credentials are refreshed at read time; otherwise fall back to the io_config
-        the caller passed to read_paimon. OSS is routed through Daft's S3 client (see
+        carry object-store credentials, in priority order:
+        1. catalog options / refreshed REST-DLF token (STS refreshed at read time);
+        2. the explicit io_config passed to read_paimon;
+        3. for OSS, the oss->s3 alias alone, so Daft's S3 client can use env credentials.
+
+        Note: unlike the table-scan StorageConfig (where an explicit io_config wins), the
+        refreshed token takes precedence here so long reads don't freeze a short-lived STS
+        token. OSS is routed through Daft's S3 client (see
         _convert_paimon_catalog_options_to_file_io_config)."""
         from pypaimon.daft.daft_io_config import (
             _convert_paimon_catalog_options_to_file_io_config,
@@ -242,7 +247,10 @@ class _PaimonPKSplitTask(DataSourceTask):
         io_config = _convert_paimon_catalog_options_to_file_io_config(enriched)
         if io_config is not None:
             return serialize_io_config(io_config)
-        return self._explicit_io_config_bytes
+        if self._explicit_io_config_bytes is not None:
+            return self._explicit_io_config_bytes
+        io_config = _convert_paimon_catalog_options_to_file_io_config(enriched, require_credentials=False)
+        return serialize_io_config(io_config) if io_config is not None else None
 
 
 def _convert_blob_columns(

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -239,6 +239,7 @@ class _PaimonPKSplitTask(DataSourceTask):
         _convert_paimon_catalog_options_to_file_io_config)."""
         from pypaimon.daft.daft_io_config import (
             _convert_paimon_catalog_options_to_file_io_config,
+            _with_oss_alias,
             serialize_io_config,
         )
         from pypaimon.daft.daft_paimon import _enrich_options_with_rest_token
@@ -248,6 +249,10 @@ class _PaimonPKSplitTask(DataSourceTask):
         if io_config is not None:
             return serialize_io_config(io_config)
         if self._explicit_io_config_bytes is not None:
+            # oss:// blobs need the s3 alias even from an explicit io_config (opendal File.open is broken).
+            if urlparse(str(getattr(table, "table_path", "") or "")).scheme == "oss":
+                from daft.io import IOConfig
+                return serialize_io_config(_with_oss_alias(IOConfig._from_serialized(self._explicit_io_config_bytes)))
             return self._explicit_io_config_bytes
         io_config = _convert_paimon_catalog_options_to_file_io_config(enriched, require_credentials=False)
         return serialize_io_config(io_config) if io_config is not None else None

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -180,6 +180,7 @@ class _PaimonPKSplitTask(DataSourceTask):
         predicate: Predicate | None = None,
         output_columns: list[str] | None = None,
         blob_column_names: set[str] | None = None,
+        explicit_io_config_bytes: bytes | None = None,
     ) -> None:
         self._table_catalog_options = table_catalog_options
         self._table_identifier = table_identifier
@@ -192,6 +193,7 @@ class _PaimonPKSplitTask(DataSourceTask):
         self._predicate = predicate
         self._output_columns = output_columns
         self._blob_column_names = blob_column_names or set()
+        self._explicit_io_config_bytes = explicit_io_config_bytes
 
     @property
     def schema(self) -> Schema:
@@ -212,13 +214,13 @@ class _PaimonPKSplitTask(DataSourceTask):
         if self._predicate is not None:
             read_builder = read_builder.with_filter(self._predicate)
 
-        blob_io_config = self._blob_io_config_bytes(table) if self._blob_column_names else None
+        blob_io_config_bytes = self._blob_io_config_bytes(table) if self._blob_column_names else None
         reader = read_builder.new_read().to_arrow_batch_reader([self._split])
         for batch in iter(reader.read_next_batch, None):
             if self._output_columns is not None:
                 batch = batch.select(self._output_columns)
             if self._blob_column_names:
-                batch = _convert_blob_columns(batch, self._blob_column_names, blob_io_config)
+                batch = _convert_blob_columns(batch, self._blob_column_names, blob_io_config_bytes)
             rb = RecordBatch.from_arrow_record_batches([batch], batch.schema)
             if self._blob_column_names:
                 rb = _cast_blob_columns_to_file(rb, self._blob_column_names)
@@ -226,17 +228,21 @@ class _PaimonPKSplitTask(DataSourceTask):
 
     def _blob_io_config_bytes(self, table: FileStoreTable) -> bytes | None:
         """Serialized IOConfig embedded into blob File columns so native Daft File ops
-        carry object-store credentials. Built from the just-loaded table so REST/DLF STS
-        tokens are refreshed at read time rather than frozen at plan time."""
+        carry object-store credentials. Prefer the just-loaded table's REST/DLF token so
+        STS credentials are refreshed at read time; otherwise fall back to the io_config
+        the caller passed to read_paimon. OSS is routed through Daft's S3 client (see
+        _convert_paimon_catalog_options_to_file_io_config)."""
         from pypaimon.daft.daft_io_config import (
-            _convert_paimon_catalog_options_to_io_config,
+            _convert_paimon_catalog_options_to_file_io_config,
             serialize_io_config,
         )
         from pypaimon.daft.daft_paimon import _enrich_options_with_rest_token
 
         enriched = _enrich_options_with_rest_token(self._table_catalog_options, table)
-        io_config = _convert_paimon_catalog_options_to_io_config(enriched)
-        return serialize_io_config(io_config) if io_config is not None else None
+        io_config = _convert_paimon_catalog_options_to_file_io_config(enriched)
+        if io_config is not None:
+            return serialize_io_config(io_config)
+        return self._explicit_io_config_bytes
 
 
 def _convert_blob_columns(
@@ -291,8 +297,10 @@ class PaimonDataSource(DataSource):
         table: FileStoreTable,
         storage_config: StorageConfig,
         catalog_options: dict[str, str],
+        explicit_io_config_bytes: bytes | None = None,
     ) -> None:
         self._storage_config = storage_config
+        self._explicit_io_config_bytes = explicit_io_config_bytes
         self._catalog_options = dict(catalog_options or {})
         self._table_catalog_options = {
             **_extract_catalog_options(table),
@@ -310,6 +318,7 @@ class PaimonDataSource(DataSource):
     def __getstate__(self) -> dict[str, Any]:
         return {
             "_multithreaded_io": self._storage_config.multithreaded_io,
+            "_explicit_io_config_bytes": self._explicit_io_config_bytes,
             "_catalog_options": self._catalog_options,
             "_table_catalog_options": self._table_catalog_options,
             "_table_identifier": self._table_identifier,
@@ -321,6 +330,7 @@ class PaimonDataSource(DataSource):
         }
 
     def __setstate__(self, state: dict[str, Any]) -> None:
+        self._explicit_io_config_bytes = state.get("_explicit_io_config_bytes")
         self._catalog_options = state["_catalog_options"]
         self._table_catalog_options = state["_table_catalog_options"]
         self._table_identifier = state["_table_identifier"]
@@ -504,6 +514,7 @@ class PaimonDataSource(DataSource):
                     read_pushdowns.reader_predicate,
                     read_pushdowns.task_columns,
                     self._blob_column_names,
+                    self._explicit_io_config_bytes,
                 )
 
     def explain_scan(self, pushdowns: Pushdowns, verbose: bool = False) -> PaimonScanExplain:

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -227,16 +227,9 @@ class _PaimonPKSplitTask(DataSourceTask):
             yield rb
 
     def _blob_io_config_bytes(self, table: FileStoreTable) -> bytes | None:
-        """Serialized IOConfig embedded into blob File columns so native Daft File ops
-        carry object-store credentials, in priority order:
-        1. catalog options / refreshed REST-DLF token (STS refreshed at read time);
-        2. the explicit io_config passed to read_paimon;
-        3. for OSS, the oss->s3 alias alone, so Daft's S3 client can use env credentials.
-
-        Note: unlike the table-scan StorageConfig (where an explicit io_config wins), the
-        refreshed token takes precedence here so long reads don't freeze a short-lived STS
-        token. OSS is routed through Daft's S3 client (see
-        _convert_paimon_catalog_options_to_file_io_config)."""
+        """Serialized IOConfig embedded into blob File columns, in priority order: refreshed
+        REST-DLF token / catalog creds (refreshed at read time, so long reads don't freeze a
+        short STS token), then the explicit read_paimon io_config, then the OSS env alias."""
         from pypaimon.daft.daft_io_config import (
             _convert_paimon_catalog_options_to_file_io_config,
             _with_oss_alias,

--- a/paimon-python/pypaimon/daft/daft_io_config.py
+++ b/paimon-python/pypaimon/daft/daft_io_config.py
@@ -124,11 +124,10 @@ def _convert_paimon_catalog_options_to_file_io_config(
     """
     warehouse = catalog_options.get("warehouse", "")
     if (urlparse(warehouse).scheme if warehouse else "") != "oss":
-        # Non-OSS (s3://, s3a://, local): an endpoint alone is not credentials, so fall
-        # through (to explicit io_config / env) when no AK/SK/token is set.
-        if require_credentials and not any(
-            catalog_options.get(k)
-            for k in ("fs.s3.accessKeyId", "fs.s3.accessKeySecret", "fs.s3.securityToken")
+        # Non-OSS (s3://, s3a://, local): require a complete key pair. An endpoint or a
+        # half credential is not credentials, so fall through to explicit io_config / env.
+        if require_credentials and not (
+            catalog_options.get("fs.s3.accessKeyId") and catalog_options.get("fs.s3.accessKeySecret")
         ):
             return None
         return _convert_paimon_catalog_options_to_io_config(catalog_options)
@@ -139,9 +138,9 @@ def _convert_paimon_catalog_options_to_file_io_config(
     key_id = catalog_options.get("fs.oss.accessKeyId")
     access_key = catalog_options.get("fs.oss.accessKeySecret")
     token = catalog_options.get("fs.oss.securityToken")
-    # An endpoint alone is not credentials: fall through (to explicit io_config / env)
-    # when only the endpoint is set, so a user-supplied io_config isn't overridden.
-    if require_credentials and not (key_id or access_key or token):
+    # Require a complete key pair. An endpoint or a half credential is not credentials,
+    # so fall through (to explicit io_config / env) rather than overriding a user config.
+    if require_credentials and not (key_id and access_key):
         return None
     return IOConfig(
         s3=S3Config(

--- a/paimon-python/pypaimon/daft/daft_io_config.py
+++ b/paimon-python/pypaimon/daft/daft_io_config.py
@@ -124,6 +124,13 @@ def _convert_paimon_catalog_options_to_file_io_config(
     """
     warehouse = catalog_options.get("warehouse", "")
     if (urlparse(warehouse).scheme if warehouse else "") != "oss":
+        # Non-OSS (s3://, s3a://, local): an endpoint alone is not credentials, so fall
+        # through (to explicit io_config / env) when no AK/SK/token is set.
+        if require_credentials and not any(
+            catalog_options.get(k)
+            for k in ("fs.s3.accessKeyId", "fs.s3.accessKeySecret", "fs.s3.securityToken")
+        ):
+            return None
         return _convert_paimon_catalog_options_to_io_config(catalog_options)
 
     endpoint = catalog_options.get("fs.oss.endpoint")

--- a/paimon-python/pypaimon/daft/daft_io_config.py
+++ b/paimon-python/pypaimon/daft/daft_io_config.py
@@ -130,15 +130,19 @@ def _convert_paimon_catalog_options_to_file_io_config(
     if endpoint and not endpoint.startswith(("http://", "https://")):
         endpoint = f"https://{endpoint}"
     key_id = catalog_options.get("fs.oss.accessKeyId")
-    if require_credentials and not endpoint and not key_id:
+    access_key = catalog_options.get("fs.oss.accessKeySecret")
+    token = catalog_options.get("fs.oss.securityToken")
+    # An endpoint alone is not credentials: fall through (to explicit io_config / env)
+    # when only the endpoint is set, so a user-supplied io_config isn't overridden.
+    if require_credentials and not (key_id or access_key or token):
         return None
     return IOConfig(
         s3=S3Config(
             endpoint_url=endpoint,
             region_name=catalog_options.get("fs.oss.region"),
             key_id=key_id,
-            access_key=catalog_options.get("fs.oss.accessKeySecret"),
-            session_token=catalog_options.get("fs.oss.securityToken"),
+            access_key=access_key,
+            session_token=token,
             force_virtual_addressing=True,
         ),
         protocol_aliases={"oss": "s3"},

--- a/paimon-python/pypaimon/daft/daft_io_config.py
+++ b/paimon-python/pypaimon/daft/daft_io_config.py
@@ -24,12 +24,7 @@ from daft.io import IOConfig, S3Config
 
 
 def serialize_io_config(io_config: IOConfig) -> bytes:
-    """Serialize an IOConfig to the bytes layout Daft's File physical struct expects.
-
-    Daft pickles IOConfig via ``__reduce__`` -> ``(IOConfig._from_serialized, (bytes,))``;
-    those bytes are exactly what the File struct's ``io_config`` field is deserialized from.
-    Validate that shape so a future Daft serialization change fails loudly, not silently.
-    """
+    """Serialize an IOConfig to the bytes Daft's File struct embeds, via its __reduce__."""
     reducer = io_config.__reduce__()
     if (reducer[0] is not IOConfig._from_serialized
             or not isinstance(reducer[1], tuple) or not reducer[1]
@@ -110,25 +105,14 @@ def _convert_paimon_catalog_options_to_io_config(catalog_options: dict[str, str]
 def _convert_paimon_catalog_options_to_file_io_config(
     catalog_options: dict[str, str], require_credentials: bool = True
 ) -> IOConfig | None:
-    """IOConfig for Daft native File ops (open/read/as_image) on blob columns.
-
-    Same as _convert_paimon_catalog_options_to_io_config, except OSS is routed through
-    Daft's S3 client (oss:// aliased to s3, virtual-hosted) instead of the OpenDAL OSS
-    backend: Daft's File.open() stat over OpenDAL/OSS fails to issue the request on some
-    Daft builds, while the S3 client works (OSS is S3-API compatible). Non-OSS schemes
-    (s3://, local) reuse the shared builder unchanged.
-
-    With require_credentials=False, OSS returns the oss->s3 alias even when no credentials
-    are derivable, so Daft's S3 client can fall back to environment/instance credentials
-    (matches Daft's Iceberg OSS handling).
-    """
+    """IOConfig for blob File ops. OSS routes through Daft's S3 client (oss:// aliased to s3,
+    virtual-hosted) because File.open() over OpenDAL/OSS is broken on some Daft builds.
+    require_credentials=False keeps a config without a key pair so the env chain is used."""
     warehouse = catalog_options.get("warehouse", "")
     if (urlparse(warehouse).scheme if warehouse else "") != "oss":
-        # Non-OSS (s3://, s3a://, local). With a complete key pair, embed the full config.
         if catalog_options.get("fs.s3.accessKeyId") and catalog_options.get("fs.s3.accessKeySecret"):
             return _convert_paimon_catalog_options_to_io_config(catalog_options)
-        # No complete pair: fall through (None) when required so an explicit io_config wins; else
-        # keep endpoint/region only (custom S3 like MinIO/Ceph) for the env credential chain.
+        # No complete pair: None when required (explicit wins), else endpoint/region-only for env.
         if require_credentials:
             return None
         endpoint = catalog_options.get("fs.s3.endpoint")
@@ -144,7 +128,7 @@ def _convert_paimon_catalog_options_to_file_io_config(
     access_key = catalog_options.get("fs.oss.accessKeySecret")
     token = catalog_options.get("fs.oss.securityToken")
     if not (key_id and access_key):
-        # No complete key pair: fall through if required, else drop it so the S3 env chain is used.
+        # No complete pair: None when required (explicit wins), else alias only for the env chain.
         if require_credentials:
             return None
         key_id = access_key = token = None
@@ -162,8 +146,8 @@ def _convert_paimon_catalog_options_to_file_io_config(
 
 
 def _with_oss_alias(io_config: IOConfig) -> IOConfig:
-    """Make oss:// use Daft's S3 client (alias + virtual-hosted) on a caller-supplied io_config,
-    deriving creds from an OpenDAL OSS backend when the S3 config has none, so File.open() works."""
+    """Add the oss->s3 alias + virtual-hosted to a caller's io_config, deriving creds from an
+    OpenDAL OSS backend if the S3 config has none, so File.open() works on oss:// blobs."""
     s3 = io_config.s3
     if s3 is None or s3.key_id is None:
         oss = (io_config.opendal_backends or {}).get("oss") or {}

--- a/paimon-python/pypaimon/daft/daft_io_config.py
+++ b/paimon-python/pypaimon/daft/daft_io_config.py
@@ -23,6 +23,15 @@ from urllib.parse import urlparse
 from daft.io import IOConfig, S3Config
 
 
+def serialize_io_config(io_config: IOConfig) -> bytes:
+    """Serialize an IOConfig to the bytes layout Daft's File physical struct expects.
+
+    Daft pickles IOConfig via ``__reduce__`` -> ``(IOConfig._from_serialized, (bytes,))``;
+    those bytes are exactly what the File struct's ``io_config`` field is deserialized from.
+    """
+    return io_config.__reduce__()[1][0]
+
+
 def _convert_paimon_catalog_options_to_io_config(catalog_options: dict[str, str]) -> IOConfig | None:
     """Convert pypaimon catalog options to Daft IOConfig.
 

--- a/paimon-python/pypaimon/daft/daft_io_config.py
+++ b/paimon-python/pypaimon/daft/daft_io_config.py
@@ -124,13 +124,18 @@ def _convert_paimon_catalog_options_to_file_io_config(
     """
     warehouse = catalog_options.get("warehouse", "")
     if (urlparse(warehouse).scheme if warehouse else "") != "oss":
-        # Non-OSS (s3://, local): embed only with a complete key pair; else null, so Daft's
-        # native s3:// handling uses its env credential chain (OSS alias relaxation is below).
-        if not (
-            catalog_options.get("fs.s3.accessKeyId") and catalog_options.get("fs.s3.accessKeySecret")
-        ):
+        # Non-OSS (s3://, s3a://, local). With a complete key pair, embed the full config.
+        if catalog_options.get("fs.s3.accessKeyId") and catalog_options.get("fs.s3.accessKeySecret"):
+            return _convert_paimon_catalog_options_to_io_config(catalog_options)
+        # No complete pair: fall through (None) when required so an explicit io_config wins; else
+        # keep endpoint/region only (custom S3 like MinIO/Ceph) for the env credential chain.
+        if require_credentials:
             return None
-        return _convert_paimon_catalog_options_to_io_config(catalog_options)
+        endpoint = catalog_options.get("fs.s3.endpoint")
+        region = catalog_options.get("fs.s3.region")
+        if not endpoint and not region:
+            return None
+        return IOConfig(s3=S3Config(endpoint_url=endpoint, region_name=region))
 
     endpoint = catalog_options.get("fs.oss.endpoint")
     if endpoint and not endpoint.startswith(("http://", "https://")):
@@ -154,3 +159,19 @@ def _convert_paimon_catalog_options_to_file_io_config(
         ),
         protocol_aliases={"oss": "s3"},
     )
+
+
+def _with_oss_alias(io_config: IOConfig) -> IOConfig:
+    """Make oss:// use Daft's S3 client (alias + virtual-hosted) on a caller-supplied io_config,
+    deriving creds from an OpenDAL OSS backend when the S3 config has none, so File.open() works."""
+    s3 = io_config.s3
+    if s3 is None or s3.key_id is None:
+        oss = (io_config.opendal_backends or {}).get("oss") or {}
+        if oss:
+            s3 = S3Config(
+                endpoint_url=oss.get("endpoint"), region_name=oss.get("region"),
+                key_id=oss.get("access_key_id"), access_key=oss.get("access_key_secret"),
+                session_token=oss.get("security_token"),
+            )
+    s3 = (s3 or S3Config()).replace(force_virtual_addressing=True)
+    return io_config.replace(s3=s3, protocol_aliases={**dict(io_config.protocol_aliases or {}), "oss": "s3"})

--- a/paimon-python/pypaimon/daft/daft_io_config.py
+++ b/paimon-python/pypaimon/daft/daft_io_config.py
@@ -28,8 +28,17 @@ def serialize_io_config(io_config: IOConfig) -> bytes:
 
     Daft pickles IOConfig via ``__reduce__`` -> ``(IOConfig._from_serialized, (bytes,))``;
     those bytes are exactly what the File struct's ``io_config`` field is deserialized from.
+    Validate that shape so a future Daft serialization change fails loudly, not silently.
     """
-    return io_config.__reduce__()[1][0]
+    reducer = io_config.__reduce__()
+    if (reducer[0] is not IOConfig._from_serialized
+            or not isinstance(reducer[1], tuple) or not reducer[1]
+            or not isinstance(reducer[1][0], bytes)):
+        raise TypeError(
+            f"Unexpected IOConfig.__reduce__ shape ({reducer!r}); "
+            "Daft may have changed its IOConfig serialization format."
+        )
+    return reducer[1][0]
 
 
 def _convert_paimon_catalog_options_to_io_config(catalog_options: dict[str, str]) -> IOConfig | None:
@@ -96,3 +105,35 @@ def _convert_paimon_catalog_options_to_io_config(catalog_options: dict[str, str]
     )
 
     return io_config if any_props_set else None
+
+
+def _convert_paimon_catalog_options_to_file_io_config(catalog_options: dict[str, str]) -> IOConfig | None:
+    """IOConfig for Daft native File ops (open/read/as_image) on blob columns.
+
+    Same as _convert_paimon_catalog_options_to_io_config, except OSS is routed through
+    Daft's S3 client (oss:// aliased to s3, virtual-hosted) instead of the OpenDAL OSS
+    backend: Daft's File.open() stat over OpenDAL/OSS fails to issue the request on some
+    Daft builds, while the S3 client works (OSS is S3-API compatible). Other schemes
+    (s3://, local) reuse the shared builder unchanged.
+    """
+    warehouse = catalog_options.get("warehouse", "")
+    if (urlparse(warehouse).scheme if warehouse else "") != "oss":
+        return _convert_paimon_catalog_options_to_io_config(catalog_options)
+
+    endpoint = catalog_options.get("fs.oss.endpoint")
+    if endpoint and not endpoint.startswith(("http://", "https://")):
+        endpoint = f"https://{endpoint}"
+    key_id = catalog_options.get("fs.oss.accessKeyId")
+    if not endpoint and not key_id:
+        return None
+    return IOConfig(
+        s3=S3Config(
+            endpoint_url=endpoint,
+            region_name=catalog_options.get("fs.oss.region"),
+            key_id=key_id,
+            access_key=catalog_options.get("fs.oss.accessKeySecret"),
+            session_token=catalog_options.get("fs.oss.securityToken"),
+            force_virtual_addressing=True,
+        ),
+        protocol_aliases={"oss": "s3"},
+    )

--- a/paimon-python/pypaimon/daft/daft_io_config.py
+++ b/paimon-python/pypaimon/daft/daft_io_config.py
@@ -124,9 +124,9 @@ def _convert_paimon_catalog_options_to_file_io_config(
     """
     warehouse = catalog_options.get("warehouse", "")
     if (urlparse(warehouse).scheme if warehouse else "") != "oss":
-        # Non-OSS (s3://, s3a://, local): require a complete key pair. An endpoint or a
-        # half credential is not credentials, so fall through to explicit io_config / env.
-        if require_credentials and not (
+        # Non-OSS (s3://, local): embed only with a complete key pair; else null, so Daft's
+        # native s3:// handling uses its env credential chain (OSS alias relaxation is below).
+        if not (
             catalog_options.get("fs.s3.accessKeyId") and catalog_options.get("fs.s3.accessKeySecret")
         ):
             return None

--- a/paimon-python/pypaimon/daft/daft_io_config.py
+++ b/paimon-python/pypaimon/daft/daft_io_config.py
@@ -107,14 +107,20 @@ def _convert_paimon_catalog_options_to_io_config(catalog_options: dict[str, str]
     return io_config if any_props_set else None
 
 
-def _convert_paimon_catalog_options_to_file_io_config(catalog_options: dict[str, str]) -> IOConfig | None:
+def _convert_paimon_catalog_options_to_file_io_config(
+    catalog_options: dict[str, str], require_credentials: bool = True
+) -> IOConfig | None:
     """IOConfig for Daft native File ops (open/read/as_image) on blob columns.
 
     Same as _convert_paimon_catalog_options_to_io_config, except OSS is routed through
     Daft's S3 client (oss:// aliased to s3, virtual-hosted) instead of the OpenDAL OSS
     backend: Daft's File.open() stat over OpenDAL/OSS fails to issue the request on some
-    Daft builds, while the S3 client works (OSS is S3-API compatible). Other schemes
+    Daft builds, while the S3 client works (OSS is S3-API compatible). Non-OSS schemes
     (s3://, local) reuse the shared builder unchanged.
+
+    With require_credentials=False, OSS returns the oss->s3 alias even when no credentials
+    are derivable, so Daft's S3 client can fall back to environment/instance credentials
+    (matches Daft's Iceberg OSS handling).
     """
     warehouse = catalog_options.get("warehouse", "")
     if (urlparse(warehouse).scheme if warehouse else "") != "oss":
@@ -124,7 +130,7 @@ def _convert_paimon_catalog_options_to_file_io_config(catalog_options: dict[str,
     if endpoint and not endpoint.startswith(("http://", "https://")):
         endpoint = f"https://{endpoint}"
     key_id = catalog_options.get("fs.oss.accessKeyId")
-    if not endpoint and not key_id:
+    if require_credentials and not endpoint and not key_id:
         return None
     return IOConfig(
         s3=S3Config(

--- a/paimon-python/pypaimon/daft/daft_io_config.py
+++ b/paimon-python/pypaimon/daft/daft_io_config.py
@@ -138,10 +138,11 @@ def _convert_paimon_catalog_options_to_file_io_config(
     key_id = catalog_options.get("fs.oss.accessKeyId")
     access_key = catalog_options.get("fs.oss.accessKeySecret")
     token = catalog_options.get("fs.oss.securityToken")
-    # Require a complete key pair. An endpoint or a half credential is not credentials,
-    # so fall through (to explicit io_config / env) rather than overriding a user config.
-    if require_credentials and not (key_id and access_key):
-        return None
+    if not (key_id and access_key):
+        # No complete key pair: fall through if required, else drop it so the S3 env chain is used.
+        if require_credentials:
+            return None
+        key_id = access_key = token = None
     return IOConfig(
         s3=S3Config(
             endpoint_url=endpoint,

--- a/paimon-python/pypaimon/daft/daft_paimon.py
+++ b/paimon-python/pypaimon/daft/daft_paimon.py
@@ -96,8 +96,7 @@ def _source_for_table(
     if catalog_options is None:
         catalog_options = {}
 
-    # Keep the caller-supplied io_config so blob File columns can fall back to it
-    # when no credentials are derivable from catalog options / REST token.
+    # Keep the caller's io_config as a blob File fallback when nothing else is derivable.
     explicit_io_config_bytes = serialize_io_config(io_config) if io_config is not None else None
 
     io_config = io_config or _convert_paimon_catalog_options_to_io_config(

--- a/paimon-python/pypaimon/daft/daft_paimon.py
+++ b/paimon-python/pypaimon/daft/daft_paimon.py
@@ -90,10 +90,15 @@ def _source_for_table(
     from pypaimon.daft.daft_datasource import PaimonDataSource
     from pypaimon.daft.daft_io_config import (
         _convert_paimon_catalog_options_to_io_config,
+        serialize_io_config,
     )
 
     if catalog_options is None:
         catalog_options = {}
+
+    # Keep the caller-supplied io_config so blob File columns can fall back to it
+    # when no credentials are derivable from catalog options / REST token.
+    explicit_io_config_bytes = serialize_io_config(io_config) if io_config is not None else None
 
     io_config = io_config or _convert_paimon_catalog_options_to_io_config(
         _enrich_options_with_rest_token(catalog_options, table)
@@ -104,7 +109,10 @@ def _source_for_table(
     storage_config = StorageConfig(multithreaded_io, io_config)
 
     return PaimonDataSource(
-        table, storage_config=storage_config, catalog_options=catalog_options
+        table,
+        storage_config=storage_config,
+        catalog_options=catalog_options,
+        explicit_io_config_bytes=explicit_io_config_bytes,
     )
 
 

--- a/paimon-python/pypaimon/tests/daft/daft_blob_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_blob_test.py
@@ -71,8 +71,7 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         self.assertEqual(IOConfig._from_serialized(serialize_io_config(cfg)).opendal_backends["oss"], oss)
 
     def test_file_io_config_routes_oss_through_s3(self):
-        # OSS -> Daft S3 client (oss:// aliased to s3, virtual-hosted); File.open() over
-        # OpenDAL/OSS fails to issue the request on some Daft builds.
+        # OSS -> Daft S3 client (File.open() over OpenDAL/OSS is broken on some Daft builds).
         cfg = _convert_paimon_catalog_options_to_file_io_config({
             "warehouse": "oss://b", "fs.oss.endpoint": "oss-test.example.com",
             "fs.oss.region": "test-region", "fs.oss.accessKeyId": "AK",
@@ -88,8 +87,7 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         self.assertEqual(dict(env.protocol_aliases)["oss"], "s3")
 
     def test_explicit_io_config_used_when_no_derivable_credentials(self):
-        # The explicit io_config passed to read_paimon must reach blob File columns when no
-        # complete credentials are derivable -- an endpoint or a half key pair is not enough.
+        # Explicit io_config must reach blob File columns when no complete creds are derivable.
         explicit = serialize_io_config(IOConfig(s3=S3Config(key_id="USERKEY", access_key="SK")))
 
         def blob_key(catalog_options):
@@ -142,8 +140,7 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         self.assertEqual(dict(cfg.protocol_aliases)["oss"], "s3")
 
     def test_non_oss_endpoint_kept_for_env_without_credentials(self):
-        # Custom-endpoint S3 (MinIO/Ceph): no complete key pair -> None when required (explicit
-        # wins); env tier keeps endpoint/region but embeds no (half) credentials.
+        # Custom-endpoint S3 (MinIO/Ceph), no key pair: None when required; env keeps endpoint, no creds.
         opts = {"warehouse": "s3a://b", "fs.s3.endpoint": "https://minio.example.com"}
         self.assertIsNone(_convert_paimon_catalog_options_to_file_io_config(opts))
         env = _convert_paimon_catalog_options_to_file_io_config(opts, require_credentials=False)
@@ -158,8 +155,7 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
 
     @pytest.mark.skipif(not has_file_range_reads(), reason="daft >= 0.7.11 required for File range metadata")
     def test_cast_to_file_reconstructs_io_config(self):
-        # The crux: embedded bytes must survive the cast to DataType.file() so a native
-        # Daft File carries the credentials.
+        # The crux: embedded bytes must survive the cast to DataType.file().
         blob = serialize_io_config(IOConfig(s3=S3Config(key_id="AK", region_name="test-region")))
         arr = blob_column_to_file_array(_descriptor_column([("s3://b/k", 0, 4)]), blob)
         df = daft.from_arrow(pa.table({"f": arr}))

--- a/paimon-python/pypaimon/tests/daft/daft_blob_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_blob_test.py
@@ -48,8 +48,8 @@ def _descriptor_column(specs):
     return pa.array(out, type=pa.large_binary())
 
 
-@pytest.mark.skipif(not has_file_range_reads(), reason="daft >= 0.7.11 required for File range metadata")
 class BlobColumnToFileArrayTest(unittest.TestCase):
+    # Pure config/arrow tests run on any installed Daft; only File-cast needs file ranges.
 
     def _io_field(self, arr):
         return arr.field("io_config")
@@ -104,6 +104,16 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         self.assertTrue(cfg.s3.force_virtual_addressing)
         self.assertEqual(dict(cfg.protocol_aliases)["oss"], "s3")
 
+    def test_file_io_config_oss_alias_without_credentials(self):
+        # env-credential case: with nothing derivable, OSS still returns the oss->s3 alias
+        # (require_credentials=False) so Daft's S3 client can use env/instance credentials.
+        from pypaimon.daft.daft_io_config import _convert_paimon_catalog_options_to_file_io_config
+
+        opts = {"warehouse": "oss://mybucket"}
+        self.assertIsNone(_convert_paimon_catalog_options_to_file_io_config(opts))
+        cfg = _convert_paimon_catalog_options_to_file_io_config(opts, require_credentials=False)
+        self.assertEqual(dict(cfg.protocol_aliases)["oss"], "s3")
+
     def test_blob_io_config_falls_back_to_explicit(self):
         # When no credentials are derivable from catalog options / REST token, the
         # io_config the caller passed to read_paimon must still reach blob File columns.
@@ -121,6 +131,7 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         self.assertEqual(out, blob)
         self.assertEqual(IOConfig._from_serialized(out).s3.key_id, "EXPLICIT")
 
+    @pytest.mark.skipif(not has_file_range_reads(), reason="daft >= 0.7.11 required for File range metadata")
     def test_cast_to_file_reconstructs_io_config(self):
         # The crux of the fix: embedded bytes must survive cast to DataType.file() so a native
         # Daft File carries the credentials. Round-trip through daft and read the io_config back.

--- a/paimon-python/pypaimon/tests/daft/daft_blob_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_blob_test.py
@@ -32,131 +32,84 @@ from pypaimon.daft.daft_compat import (
     file_range_size_field,
     has_file_range_reads,
 )
-from pypaimon.daft.daft_io_config import serialize_io_config
+from pypaimon.daft.daft_io_config import (
+    _convert_paimon_catalog_options_to_file_io_config,
+    serialize_io_config,
+)
+from pypaimon.daft.daft_datasource import _PaimonPKSplitTask
 from pypaimon.table.row.blob import BlobDescriptor
 
 
 def _descriptor_column(specs):
-    """Build a large_binary column of serialized BlobDescriptors (None for gaps)."""
-    out = []
-    for spec in specs:
-        if spec is None:
-            out.append(None)
-        else:
-            uri, off, length = spec
-            out.append(BlobDescriptor(uri, off, length).serialize())
+    """large_binary column of serialized BlobDescriptors (None for gaps)."""
+    out = [None if s is None else BlobDescriptor(*s).serialize() for s in specs]
     return pa.array(out, type=pa.large_binary())
 
 
 class BlobColumnToFileArrayTest(unittest.TestCase):
     # Pure config/arrow tests run on any installed Daft; only File-cast needs file ranges.
 
-    def _io_field(self, arr):
-        return arr.field("io_config")
-
-    def test_io_config_null_by_default(self):
-        col = _descriptor_column([("oss://b/k", 0, 10), None])
-        arr = blob_column_to_file_array(col)
-        io = self._io_field(arr)
-        self.assertEqual(io.null_count, 2)
-        self.assertEqual(arr.field("url").to_pylist(), ["oss://b/k", None])
-        self.assertEqual(arr.field(file_range_position_field()).to_pylist(), [0, None])
-        self.assertEqual(arr.field(file_range_size_field()).to_pylist(), [10, None])
-
-    def test_io_config_embedded_for_valid_rows_only(self):
-        cfg = IOConfig(s3=S3Config(key_id="AK", access_key="SK", region_name="cn-hangzhou"))
-        blob = serialize_io_config(cfg)
+    def test_blob_column_to_file_array(self):
+        # io_config is null without creds; embedded only for valid (non-null) rows with creds.
         col = _descriptor_column([("oss://b/k1", 0, 5), None, ("oss://b/k2", 8, 9)])
-        arr = blob_column_to_file_array(col, blob)
-        self.assertEqual(self._io_field(arr).to_pylist(), [blob, None, blob])
+        bare = blob_column_to_file_array(col)
+        self.assertEqual(bare.field("url").to_pylist(), ["oss://b/k1", None, "oss://b/k2"])
+        self.assertEqual(bare.field(file_range_position_field()).to_pylist(), [0, None, 8])
+        self.assertEqual(bare.field(file_range_size_field()).to_pylist(), [5, None, 9])
+        self.assertEqual(bare.field("io_config").null_count, 3)
+
+        blob = serialize_io_config(IOConfig(s3=S3Config(key_id="AK", access_key="SK")))
+        self.assertEqual(blob_column_to_file_array(col, blob).field("io_config").to_pylist(),
+                         [blob, None, blob])
 
     def test_serialize_io_config_roundtrips(self):
-        cfg = IOConfig(s3=S3Config(key_id="AK", access_key="SK", session_token="TOK"))
-        restored = IOConfig._from_serialized(serialize_io_config(cfg))
-        self.assertEqual(restored.s3.key_id, "AK")
-        self.assertEqual(restored.s3.session_token, "TOK")
-
-    def test_serialize_io_config_roundtrips_oss(self):
-        # OSS (the primary target) uses Daft's OpenDAL backend, which serializes
-        # differently from S3Config -- cover it explicitly.
-        oss = {"access_key_id": "AK", "access_key_secret": "SK",
-               "endpoint": "https://oss-cn-hangzhou.aliyuncs.com", "bucket": "b"}
+        s3 = IOConfig(s3=S3Config(key_id="AK", access_key="SK", session_token="TOK"))
+        self.assertEqual(IOConfig._from_serialized(serialize_io_config(s3)).s3.session_token, "TOK")
+        # OSS uses Daft's OpenDAL backend, which serializes differently from S3Config.
+        oss = {"access_key_id": "AK", "endpoint": "https://oss-cn-hangzhou.aliyuncs.com", "bucket": "b"}
         cfg = IOConfig(opendal_backends={"oss": oss})
-        restored = IOConfig._from_serialized(serialize_io_config(cfg))
-        self.assertEqual(restored.opendal_backends["oss"], oss)
+        self.assertEqual(IOConfig._from_serialized(serialize_io_config(cfg)).opendal_backends["oss"], oss)
 
     def test_file_io_config_routes_oss_through_s3(self):
-        # Daft's File.open() over OpenDAL/OSS is broken on some builds; the blob path
-        # must route OSS through Daft's S3 client (oss:// aliased to s3, virtual-hosted).
-        from pypaimon.daft.daft_io_config import _convert_paimon_catalog_options_to_file_io_config
-
+        # OSS -> Daft S3 client (oss:// aliased to s3, virtual-hosted); File.open() over
+        # OpenDAL/OSS fails to issue the request on some Daft builds.
         cfg = _convert_paimon_catalog_options_to_file_io_config({
-            "warehouse": "oss://mybucket",
-            "fs.oss.endpoint": "oss-cn-hangzhou.aliyuncs.com",
-            "fs.oss.region": "cn-hangzhou",
-            "fs.oss.accessKeyId": "AK",
-            "fs.oss.accessKeySecret": "SK",
-            "fs.oss.securityToken": "TOK",
+            "warehouse": "oss://b", "fs.oss.endpoint": "oss-cn-hangzhou.aliyuncs.com",
+            "fs.oss.region": "cn-hangzhou", "fs.oss.accessKeyId": "AK",
+            "fs.oss.accessKeySecret": "SK", "fs.oss.securityToken": "TOK",
         })
         self.assertEqual(cfg.s3.key_id, "AK")
-        self.assertEqual(cfg.s3.session_token, "TOK")
         self.assertEqual(cfg.s3.endpoint_url, "https://oss-cn-hangzhou.aliyuncs.com")
         self.assertTrue(cfg.s3.force_virtual_addressing)
         self.assertEqual(dict(cfg.protocol_aliases)["oss"], "s3")
+        # No credentials: None when required; oss->s3 alias otherwise (env/instance creds).
+        self.assertIsNone(_convert_paimon_catalog_options_to_file_io_config({"warehouse": "oss://b"}))
+        env = _convert_paimon_catalog_options_to_file_io_config({"warehouse": "oss://b"}, require_credentials=False)
+        self.assertEqual(dict(env.protocol_aliases)["oss"], "s3")
 
-    def test_file_io_config_oss_alias_without_credentials(self):
-        # env-credential case: with nothing derivable, OSS still returns the oss->s3 alias
-        # (require_credentials=False) so Daft's S3 client can use env/instance credentials.
-        from pypaimon.daft.daft_io_config import _convert_paimon_catalog_options_to_file_io_config
-
-        opts = {"warehouse": "oss://mybucket"}
-        self.assertIsNone(_convert_paimon_catalog_options_to_file_io_config(opts))
-        cfg = _convert_paimon_catalog_options_to_file_io_config(opts, require_credentials=False)
-        self.assertEqual(dict(cfg.protocol_aliases)["oss"], "s3")
-
-    def test_blob_io_config_falls_back_to_explicit(self):
-        # When no credentials are derivable from catalog options / REST token, the
-        # io_config the caller passed to read_paimon must still reach blob File columns.
-        from pypaimon.daft.daft_datasource import _PaimonPKSplitTask
-
-        cfg = IOConfig(s3=S3Config(key_id="EXPLICIT", access_key="SK"))
-        blob = serialize_io_config(cfg)
-        task = _PaimonPKSplitTask(
-            {},  # non-rest catalog options, nothing derivable
-            None, None, {}, None, None,
-            blob_column_names={"b"},
-            explicit_io_config_bytes=blob,
-        )
-        out = task._blob_io_config_bytes(None)
-        self.assertEqual(out, blob)
-        self.assertEqual(IOConfig._from_serialized(out).s3.key_id, "EXPLICIT")
-
-    def test_endpoint_only_does_not_override_explicit(self):
-        # An endpoint with no AK/SK/token is not credentials, so the explicit io_config
-        # the caller passed must still win for blob File columns.
-        from pypaimon.daft.daft_datasource import _PaimonPKSplitTask
-
+    def test_explicit_io_config_used_when_no_derivable_credentials(self):
+        # The explicit io_config passed to read_paimon must reach blob File columns when
+        # nothing is derivable -- including endpoint-only options (endpoint is not credentials).
         explicit = serialize_io_config(IOConfig(s3=S3Config(key_id="USERKEY", access_key="SK")))
-        task = _PaimonPKSplitTask(
-            {"warehouse": "oss://b", "fs.oss.endpoint": "oss-cn-hangzhou.aliyuncs.com"},
-            None, None, {}, None, None,
-            blob_column_names={"x"},
-            explicit_io_config_bytes=explicit,
-        )
-        out = task._blob_io_config_bytes(None)
-        self.assertEqual(IOConfig._from_serialized(out).s3.key_id, "USERKEY")
+
+        def blob_key(catalog_options):
+            task = _PaimonPKSplitTask(catalog_options, None, None, {}, None, None,
+                                      blob_column_names={"x"}, explicit_io_config_bytes=explicit)
+            return IOConfig._from_serialized(task._blob_io_config_bytes(None)).s3.key_id
+
+        self.assertEqual(blob_key({}), "USERKEY")
+        self.assertEqual(blob_key({"warehouse": "oss://b", "fs.oss.endpoint": "oss-cn-hangzhou.aliyuncs.com"}),
+                         "USERKEY")
 
     @pytest.mark.skipif(not has_file_range_reads(), reason="daft >= 0.7.11 required for File range metadata")
     def test_cast_to_file_reconstructs_io_config(self):
-        # The crux of the fix: embedded bytes must survive cast to DataType.file() so a native
-        # Daft File carries the credentials. Round-trip through daft and read the io_config back.
-        cfg = IOConfig(s3=S3Config(key_id="AK", access_key="SK", region_name="cn-hangzhou"))
-        blob = serialize_io_config(cfg)
+        # The crux: embedded bytes must survive the cast to DataType.file() so a native
+        # Daft File carries the credentials.
+        blob = serialize_io_config(IOConfig(s3=S3Config(key_id="AK", region_name="cn-hangzhou")))
         arr = blob_column_to_file_array(_descriptor_column([("s3://b/k", 0, 4)]), blob)
         df = daft.from_arrow(pa.table({"f": arr}))
         df = df.with_column("f", df["f"].cast(DataType.file()))
-        back = df.to_arrow().column("f")[0].as_py()
-        restored = IOConfig._from_serialized(back["io_config"])
+        restored = IOConfig._from_serialized(df.to_arrow().column("f")[0].as_py()["io_config"])
         self.assertEqual(restored.s3.key_id, "AK")
         self.assertEqual(restored.s3.region_name, "cn-hangzhou")
 

--- a/paimon-python/pypaimon/tests/daft/daft_blob_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_blob_test.py
@@ -106,6 +106,14 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         ):
             self.assertEqual(blob_key(opts), "USERKEY")
 
+    def test_non_oss_partial_config_left_null_for_env(self):
+        # Non-OSS endpoint-only (no key pair) -> null, so Daft's s3:// uses its env cred chain.
+        opts = {"warehouse": "s3://b", "fs.s3.endpoint": "https://s3.example.com"}
+        self.assertIsNone(_convert_paimon_catalog_options_to_file_io_config(opts))
+        self.assertIsNone(_convert_paimon_catalog_options_to_file_io_config(opts, require_credentials=False))
+        task = _PaimonPKSplitTask(opts, None, None, {}, None, None, blob_column_names={"x"})
+        self.assertIsNone(task._blob_io_config_bytes(None))
+
     @pytest.mark.skipif(not has_file_range_reads(), reason="daft >= 0.7.11 required for File range metadata")
     def test_cast_to_file_reconstructs_io_config(self):
         # The crux: embedded bytes must survive the cast to DataType.file() so a native

--- a/paimon-python/pypaimon/tests/daft/daft_blob_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_blob_test.py
@@ -131,6 +131,21 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         self.assertEqual(out, blob)
         self.assertEqual(IOConfig._from_serialized(out).s3.key_id, "EXPLICIT")
 
+    def test_endpoint_only_does_not_override_explicit(self):
+        # An endpoint with no AK/SK/token is not credentials, so the explicit io_config
+        # the caller passed must still win for blob File columns.
+        from pypaimon.daft.daft_datasource import _PaimonPKSplitTask
+
+        explicit = serialize_io_config(IOConfig(s3=S3Config(key_id="USERKEY", access_key="SK")))
+        task = _PaimonPKSplitTask(
+            {"warehouse": "oss://b", "fs.oss.endpoint": "oss-cn-hangzhou.aliyuncs.com"},
+            None, None, {}, None, None,
+            blob_column_names={"x"},
+            explicit_io_config_bytes=explicit,
+        )
+        out = task._blob_io_config_bytes(None)
+        self.assertEqual(IOConfig._from_serialized(out).s3.key_id, "USERKEY")
+
     @pytest.mark.skipif(not has_file_range_reads(), reason="daft >= 0.7.11 required for File range metadata")
     def test_cast_to_file_reconstructs_io_config(self):
         # The crux of the fix: embedded bytes must survive cast to DataType.file() so a native

--- a/paimon-python/pypaimon/tests/daft/daft_blob_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_blob_test.py
@@ -12,6 +12,7 @@
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
 import unittest
@@ -74,6 +75,51 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         restored = IOConfig._from_serialized(serialize_io_config(cfg))
         self.assertEqual(restored.s3.key_id, "AK")
         self.assertEqual(restored.s3.session_token, "TOK")
+
+    def test_serialize_io_config_roundtrips_oss(self):
+        # OSS (the primary target) uses Daft's OpenDAL backend, which serializes
+        # differently from S3Config -- cover it explicitly.
+        oss = {"access_key_id": "AK", "access_key_secret": "SK",
+               "endpoint": "https://oss-cn-hangzhou.aliyuncs.com", "bucket": "b"}
+        cfg = IOConfig(opendal_backends={"oss": oss})
+        restored = IOConfig._from_serialized(serialize_io_config(cfg))
+        self.assertEqual(restored.opendal_backends["oss"], oss)
+
+    def test_file_io_config_routes_oss_through_s3(self):
+        # Daft's File.open() over OpenDAL/OSS is broken on some builds; the blob path
+        # must route OSS through Daft's S3 client (oss:// aliased to s3, virtual-hosted).
+        from pypaimon.daft.daft_io_config import _convert_paimon_catalog_options_to_file_io_config
+
+        cfg = _convert_paimon_catalog_options_to_file_io_config({
+            "warehouse": "oss://mybucket",
+            "fs.oss.endpoint": "oss-cn-hangzhou.aliyuncs.com",
+            "fs.oss.region": "cn-hangzhou",
+            "fs.oss.accessKeyId": "AK",
+            "fs.oss.accessKeySecret": "SK",
+            "fs.oss.securityToken": "TOK",
+        })
+        self.assertEqual(cfg.s3.key_id, "AK")
+        self.assertEqual(cfg.s3.session_token, "TOK")
+        self.assertEqual(cfg.s3.endpoint_url, "https://oss-cn-hangzhou.aliyuncs.com")
+        self.assertTrue(cfg.s3.force_virtual_addressing)
+        self.assertEqual(dict(cfg.protocol_aliases)["oss"], "s3")
+
+    def test_blob_io_config_falls_back_to_explicit(self):
+        # When no credentials are derivable from catalog options / REST token, the
+        # io_config the caller passed to read_paimon must still reach blob File columns.
+        from pypaimon.daft.daft_datasource import _PaimonPKSplitTask
+
+        cfg = IOConfig(s3=S3Config(key_id="EXPLICIT", access_key="SK"))
+        blob = serialize_io_config(cfg)
+        task = _PaimonPKSplitTask(
+            {},  # non-rest catalog options, nothing derivable
+            None, None, {}, None, None,
+            blob_column_names={"b"},
+            explicit_io_config_bytes=blob,
+        )
+        out = task._blob_io_config_bytes(None)
+        self.assertEqual(out, blob)
+        self.assertEqual(IOConfig._from_serialized(out).s3.key_id, "EXPLICIT")
 
     def test_cast_to_file_reconstructs_io_config(self):
         # The crux of the fix: embedded bytes must survive cast to DataType.file() so a native

--- a/paimon-python/pypaimon/tests/daft/daft_blob_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_blob_test.py
@@ -106,6 +106,15 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         ):
             self.assertEqual(blob_key(opts), "USERKEY")
 
+    def test_oss_partial_credentials_cleared_for_env(self):
+        # OSS half key pair (no secret): keep only the oss->s3 alias, drop the partial key.
+        opts = {"warehouse": "oss://b", "fs.oss.endpoint": "oss-test.example.com",
+                "fs.oss.accessKeyId": "PARTIAL"}
+        self.assertIsNone(_convert_paimon_catalog_options_to_file_io_config(opts))
+        cfg = _convert_paimon_catalog_options_to_file_io_config(opts, require_credentials=False)
+        self.assertIsNone(cfg.s3.key_id)
+        self.assertEqual(dict(cfg.protocol_aliases)["oss"], "s3")
+
     def test_non_oss_partial_config_left_null_for_env(self):
         # Non-OSS endpoint-only (no key pair) -> null, so Daft's s3:// uses its env cred chain.
         opts = {"warehouse": "s3://b", "fs.s3.endpoint": "https://s3.example.com"}

--- a/paimon-python/pypaimon/tests/daft/daft_blob_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_blob_test.py
@@ -106,6 +106,32 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         ):
             self.assertEqual(blob_key(opts), "USERKEY")
 
+    def test_with_oss_alias_augments_explicit_config(self):
+        # s3 config -> add oss->s3 alias + virtual-hosted, keep creds.
+        from pypaimon.daft.daft_io_config import _with_oss_alias
+        s3 = _with_oss_alias(IOConfig(s3=S3Config(key_id="AK", access_key="SK")))
+        self.assertEqual(dict(s3.protocol_aliases)["oss"], "s3")
+        self.assertTrue(s3.s3.force_virtual_addressing)
+        self.assertEqual(s3.s3.key_id, "AK")
+        # opendal OSS config -> converted to S3Config + alias.
+        od = _with_oss_alias(IOConfig(opendal_backends={"oss": {
+            "access_key_id": "AK", "access_key_secret": "SK", "endpoint": "https://oss-test.example.com"}}))
+        self.assertEqual(dict(od.protocol_aliases)["oss"], "s3")
+        self.assertEqual(od.s3.key_id, "AK")
+        self.assertEqual(od.s3.endpoint_url, "https://oss-test.example.com")
+
+    def test_explicit_io_config_gets_oss_alias_for_oss_blobs(self):
+        # An oss:// table's explicit-fallback io_config gets the s3 alias so File.open() works.
+        class _OssTable:
+            table_path = "oss://b/db.db/t"
+
+        explicit = serialize_io_config(IOConfig(s3=S3Config(key_id="USERKEY", access_key="SK")))
+        task = _PaimonPKSplitTask({}, None, None, {}, None, None,
+                                  blob_column_names={"x"}, explicit_io_config_bytes=explicit)
+        cfg = IOConfig._from_serialized(task._blob_io_config_bytes(_OssTable()))
+        self.assertEqual(cfg.s3.key_id, "USERKEY")
+        self.assertEqual(dict(cfg.protocol_aliases)["oss"], "s3")
+
     def test_oss_partial_credentials_cleared_for_env(self):
         # OSS half key pair (no secret): keep only the oss->s3 alias, drop the partial key.
         opts = {"warehouse": "oss://b", "fs.oss.endpoint": "oss-test.example.com",
@@ -115,13 +141,20 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         self.assertIsNone(cfg.s3.key_id)
         self.assertEqual(dict(cfg.protocol_aliases)["oss"], "s3")
 
-    def test_non_oss_partial_config_left_null_for_env(self):
-        # Non-OSS endpoint-only (no key pair) -> null, so Daft's s3:// uses its env cred chain.
-        opts = {"warehouse": "s3://b", "fs.s3.endpoint": "https://s3.example.com"}
+    def test_non_oss_endpoint_kept_for_env_without_credentials(self):
+        # Custom-endpoint S3 (MinIO/Ceph): no complete key pair -> None when required (explicit
+        # wins); env tier keeps endpoint/region but embeds no (half) credentials.
+        opts = {"warehouse": "s3a://b", "fs.s3.endpoint": "https://minio.example.com"}
         self.assertIsNone(_convert_paimon_catalog_options_to_file_io_config(opts))
-        self.assertIsNone(_convert_paimon_catalog_options_to_file_io_config(opts, require_credentials=False))
-        task = _PaimonPKSplitTask(opts, None, None, {}, None, None, blob_column_names={"x"})
-        self.assertIsNone(task._blob_io_config_bytes(None))
+        env = _convert_paimon_catalog_options_to_file_io_config(opts, require_credentials=False)
+        self.assertEqual(env.s3.endpoint_url, "https://minio.example.com")
+        self.assertIsNone(env.s3.key_id)
+        # A half key is dropped; the endpoint is still kept.
+        partial = _convert_paimon_catalog_options_to_file_io_config(
+            {"warehouse": "s3://b", "fs.s3.endpoint": "https://minio.example.com",
+             "fs.s3.accessKeyId": "PARTIAL"}, require_credentials=False)
+        self.assertEqual(partial.s3.endpoint_url, "https://minio.example.com")
+        self.assertIsNone(partial.s3.key_id)
 
     @pytest.mark.skipif(not has_file_range_reads(), reason="daft >= 0.7.11 required for File range metadata")
     def test_cast_to_file_reconstructs_io_config(self):

--- a/paimon-python/pypaimon/tests/daft/daft_blob_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_blob_test.py
@@ -88,8 +88,8 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         self.assertEqual(dict(env.protocol_aliases)["oss"], "s3")
 
     def test_explicit_io_config_used_when_no_derivable_credentials(self):
-        # The explicit io_config passed to read_paimon must reach blob File columns when
-        # nothing is derivable -- including endpoint-only options (endpoint is not credentials).
+        # The explicit io_config passed to read_paimon must reach blob File columns when no
+        # complete credentials are derivable -- an endpoint or a half key pair is not enough.
         explicit = serialize_io_config(IOConfig(s3=S3Config(key_id="USERKEY", access_key="SK")))
 
         def blob_key(catalog_options):
@@ -100,8 +100,9 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         self.assertEqual(blob_key({}), "USERKEY")
         for opts in (
             {"warehouse": "oss://b", "fs.oss.endpoint": "oss-test.example.com"},
+            {"warehouse": "oss://b", "fs.oss.accessKeyId": "PARTIAL"},  # no secret
             {"warehouse": "s3://b", "fs.s3.endpoint": "https://s3.example.com"},
-            {"warehouse": "s3a://b", "fs.s3.endpoint": "https://s3.example.com"},
+            {"warehouse": "s3a://b", "fs.s3.accessKeyId": "PARTIAL"},  # no secret
         ):
             self.assertEqual(blob_key(opts), "USERKEY")
 

--- a/paimon-python/pypaimon/tests/daft/daft_blob_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_blob_test.py
@@ -1,0 +1,93 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# limitations under the License.
+################################################################################
+import unittest
+
+import pyarrow as pa
+import pytest
+
+pypaimon = pytest.importorskip("pypaimon")
+daft = pytest.importorskip("daft")
+
+from daft.datatype import DataType
+from daft.io import IOConfig, S3Config
+
+from pypaimon.daft.daft_blob import blob_column_to_file_array
+from pypaimon.daft.daft_compat import (
+    file_range_position_field,
+    file_range_size_field,
+    has_file_range_reads,
+)
+from pypaimon.daft.daft_io_config import serialize_io_config
+from pypaimon.table.row.blob import BlobDescriptor
+
+
+def _descriptor_column(specs):
+    """Build a large_binary column of serialized BlobDescriptors (None for gaps)."""
+    out = []
+    for spec in specs:
+        if spec is None:
+            out.append(None)
+        else:
+            uri, off, length = spec
+            out.append(BlobDescriptor(uri, off, length).serialize())
+    return pa.array(out, type=pa.large_binary())
+
+
+@pytest.mark.skipif(not has_file_range_reads(), reason="daft >= 0.7.11 required for File range metadata")
+class BlobColumnToFileArrayTest(unittest.TestCase):
+
+    def _io_field(self, arr):
+        return arr.field("io_config")
+
+    def test_io_config_null_by_default(self):
+        col = _descriptor_column([("oss://b/k", 0, 10), None])
+        arr = blob_column_to_file_array(col)
+        io = self._io_field(arr)
+        self.assertEqual(io.null_count, 2)
+        self.assertEqual(arr.field("url").to_pylist(), ["oss://b/k", None])
+        self.assertEqual(arr.field(file_range_position_field()).to_pylist(), [0, None])
+        self.assertEqual(arr.field(file_range_size_field()).to_pylist(), [10, None])
+
+    def test_io_config_embedded_for_valid_rows_only(self):
+        cfg = IOConfig(s3=S3Config(key_id="AK", access_key="SK", region_name="cn-hangzhou"))
+        blob = serialize_io_config(cfg)
+        col = _descriptor_column([("oss://b/k1", 0, 5), None, ("oss://b/k2", 8, 9)])
+        arr = blob_column_to_file_array(col, blob)
+        self.assertEqual(self._io_field(arr).to_pylist(), [blob, None, blob])
+
+    def test_serialize_io_config_roundtrips(self):
+        cfg = IOConfig(s3=S3Config(key_id="AK", access_key="SK", session_token="TOK"))
+        restored = IOConfig._from_serialized(serialize_io_config(cfg))
+        self.assertEqual(restored.s3.key_id, "AK")
+        self.assertEqual(restored.s3.session_token, "TOK")
+
+    def test_cast_to_file_reconstructs_io_config(self):
+        # The crux of the fix: embedded bytes must survive cast to DataType.file() so a native
+        # Daft File carries the credentials. Round-trip through daft and read the io_config back.
+        cfg = IOConfig(s3=S3Config(key_id="AK", access_key="SK", region_name="cn-hangzhou"))
+        blob = serialize_io_config(cfg)
+        arr = blob_column_to_file_array(_descriptor_column([("s3://b/k", 0, 4)]), blob)
+        df = daft.from_arrow(pa.table({"f": arr}))
+        df = df.with_column("f", df["f"].cast(DataType.file()))
+        back = df.to_arrow().column("f")[0].as_py()
+        restored = IOConfig._from_serialized(back["io_config"])
+        self.assertEqual(restored.s3.key_id, "AK")
+        self.assertEqual(restored.s3.region_name, "cn-hangzhou")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/daft/daft_blob_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_blob_test.py
@@ -66,7 +66,7 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         s3 = IOConfig(s3=S3Config(key_id="AK", access_key="SK", session_token="TOK"))
         self.assertEqual(IOConfig._from_serialized(serialize_io_config(s3)).s3.session_token, "TOK")
         # OSS uses Daft's OpenDAL backend, which serializes differently from S3Config.
-        oss = {"access_key_id": "AK", "endpoint": "https://oss-cn-hangzhou.aliyuncs.com", "bucket": "b"}
+        oss = {"access_key_id": "AK", "endpoint": "https://oss-test.example.com", "bucket": "b"}
         cfg = IOConfig(opendal_backends={"oss": oss})
         self.assertEqual(IOConfig._from_serialized(serialize_io_config(cfg)).opendal_backends["oss"], oss)
 
@@ -74,12 +74,12 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         # OSS -> Daft S3 client (oss:// aliased to s3, virtual-hosted); File.open() over
         # OpenDAL/OSS fails to issue the request on some Daft builds.
         cfg = _convert_paimon_catalog_options_to_file_io_config({
-            "warehouse": "oss://b", "fs.oss.endpoint": "oss-cn-hangzhou.aliyuncs.com",
-            "fs.oss.region": "cn-hangzhou", "fs.oss.accessKeyId": "AK",
+            "warehouse": "oss://b", "fs.oss.endpoint": "oss-test.example.com",
+            "fs.oss.region": "test-region", "fs.oss.accessKeyId": "AK",
             "fs.oss.accessKeySecret": "SK", "fs.oss.securityToken": "TOK",
         })
         self.assertEqual(cfg.s3.key_id, "AK")
-        self.assertEqual(cfg.s3.endpoint_url, "https://oss-cn-hangzhou.aliyuncs.com")
+        self.assertEqual(cfg.s3.endpoint_url, "https://oss-test.example.com")
         self.assertTrue(cfg.s3.force_virtual_addressing)
         self.assertEqual(dict(cfg.protocol_aliases)["oss"], "s3")
         # No credentials: None when required; oss->s3 alias otherwise (env/instance creds).
@@ -98,20 +98,24 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
             return IOConfig._from_serialized(task._blob_io_config_bytes(None)).s3.key_id
 
         self.assertEqual(blob_key({}), "USERKEY")
-        self.assertEqual(blob_key({"warehouse": "oss://b", "fs.oss.endpoint": "oss-cn-hangzhou.aliyuncs.com"}),
-                         "USERKEY")
+        for opts in (
+            {"warehouse": "oss://b", "fs.oss.endpoint": "oss-test.example.com"},
+            {"warehouse": "s3://b", "fs.s3.endpoint": "https://s3.example.com"},
+            {"warehouse": "s3a://b", "fs.s3.endpoint": "https://s3.example.com"},
+        ):
+            self.assertEqual(blob_key(opts), "USERKEY")
 
     @pytest.mark.skipif(not has_file_range_reads(), reason="daft >= 0.7.11 required for File range metadata")
     def test_cast_to_file_reconstructs_io_config(self):
         # The crux: embedded bytes must survive the cast to DataType.file() so a native
         # Daft File carries the credentials.
-        blob = serialize_io_config(IOConfig(s3=S3Config(key_id="AK", region_name="cn-hangzhou")))
+        blob = serialize_io_config(IOConfig(s3=S3Config(key_id="AK", region_name="test-region")))
         arr = blob_column_to_file_array(_descriptor_column([("s3://b/k", 0, 4)]), blob)
         df = daft.from_arrow(pa.table({"f": arr}))
         df = df.with_column("f", df["f"].cast(DataType.file()))
         restored = IOConfig._from_serialized(df.to_arrow().column("f")[0].as_py()["io_config"])
         self.assertEqual(restored.s3.key_id, "AK")
-        self.assertEqual(restored.s3.region_name, "cn-hangzhou")
+        self.assertEqual(restored.s3.region_name, "test-region")
 
 
 if __name__ == "__main__":

--- a/paimon-python/pypaimon/tests/daft/daft_catalog_rest_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_catalog_rest_test.py
@@ -243,12 +243,13 @@ class DaftRestReadTest(RESTBaseTest):
         captured = {}
         original_init = PaimonDataSource.__init__
 
-        def spy_init(_self, table, storage_config, catalog_options):
+        def spy_init(_self, table, storage_config, catalog_options, **kwargs):
             captured["catalog_options"] = dict(catalog_options)
             return original_init(
                 _self, table,
                 storage_config=storage_config,
                 catalog_options=catalog_options,
+                **kwargs,
             )
 
         with patch.object(PaimonDataSource, "__init__", spy_init):


### PR DESCRIPTION


### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential resolution and OSS/S3 routing for blob reads; mistakes could break object-store access or embed stale tokens, though read-time REST refresh and extensive tests mitigate this.
> 
> **Overview**
> **Blob File columns now carry serialized Daft `IOConfig`** so downstream native File operations (open, range reads) use the right credentials instead of only the global default.
> 
> When Paimon blob descriptors are converted to Daft `File` structs, **`io_config` is populated per row** (null rows stay null). Resolution at read time prefers **refreshed REST/DLF catalog credentials**, then the **`read_paimon` `io_config` fallback**, then **endpoint-only / OSS alias configs** for the environment credential chain.
> 
> **OSS blob paths are special-cased for File I/O**: blob File ops use **S3 client config with `oss`→`s3` protocol alias and virtual-hosted addressing**, avoiding broken OpenDAL `File.open()` on some Daft builds; explicit user `io_config` gets the same alias when the table is `oss://`.
> 
> New helpers include **`serialize_io_config`**, **`_convert_paimon_catalog_options_to_file_io_config`**, and **`_with_oss_alias`**. **`explicit_io_config_bytes`** is threaded through **`PaimonDataSource`**, PK split tasks, and pickling. **`daft_blob_test.py`** covers embedding, OSS routing, and cast-to-`DataType.file()` roundtrip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2887b884f141b2017bec60c4450818567246b3be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->