### PR TITLE
Spark batch vector search

### DIFF
--- a/docs/docs/multimodal-table/global-index/vector.mdx
+++ b/docs/docs/multimodal-table/global-index/vector.mdx
@@ -128,7 +128,18 @@ value for latency-sensitive queries.
 ```sql
 -- Search for top-5 nearest neighbors
 SELECT * FROM vector_search('my_table', 'embedding', array(1.0f, 2.0f, 3.0f), 5);
+
+-- Search many query vectors in one call. The result has an extra leading `query_index`
+-- column: rows with query_index = i are the top-5 for the i-th query vector.
+SELECT * FROM batch_vector_search(
+    'my_table', 'embedding',
+    array(array(1.0f, 2.0f, 3.0f), array(3.0f, 2.0f, 1.0f)), 5);
 ```
+
+Set `vector-search.distribute.enabled = true` on the table to evaluate the index shards on the
+Spark cluster instead of the driver; the fan-out parallelism reuses `global-index.thread-num`. The
+search only distributes when there are enough index shards (more than `2 * global-index.thread-num`),
+otherwise it falls back to a local search.
 
 </TabItem>
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/BatchVectorSearchTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/BatchVectorSearchTable.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.predicate.BatchVectorSearch;
+import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A table wrapper to hold batch vector search information. This is used to pass batch vector search
+ * pushdown information from logical plan optimization to physical plan execution. For now, it is
+ * only used by internal for Spark engine.
+ *
+ * <p>Unlike {@link VectorSearchTable}, a batch search carries multiple query vectors; result {@code
+ * i} corresponds to query vector {@code i}.
+ */
+public class BatchVectorSearchTable implements ReadonlyTable {
+
+    /**
+     * Leading synthetic output column identifying which query vector a result row belongs to (the
+     * 0-based position in the input {@code query_vectors}).
+     */
+    public static final String QUERY_INDEX_COLUMN = "query_index";
+
+    private final InnerTable origin;
+    private final BatchVectorSearch batchVectorSearch;
+
+    private BatchVectorSearchTable(InnerTable origin, BatchVectorSearch batchVectorSearch) {
+        this.origin = origin;
+        this.batchVectorSearch = batchVectorSearch;
+    }
+
+    public static BatchVectorSearchTable create(
+            InnerTable origin, BatchVectorSearch batchVectorSearch) {
+        return new BatchVectorSearchTable(origin, batchVectorSearch);
+    }
+
+    public BatchVectorSearch batchVectorSearch() {
+        return batchVectorSearch;
+    }
+
+    public InnerTable origin() {
+        return origin;
+    }
+
+    @Override
+    public String name() {
+        return origin.name();
+    }
+
+    @Override
+    public RowType rowType() {
+        // Prepend a synthetic query_index column. It is not read from data files; the Spark scan
+        // injects its value (the query vector position) per result group.
+        RowType originType = origin.rowType();
+        int maxId = originType.getFields().stream().mapToInt(DataField::id).max().orElse(0);
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(maxId + 1, QUERY_INDEX_COLUMN, DataTypes.INT().notNull()));
+        fields.addAll(originType.getFields());
+        return new RowType(fields);
+    }
+
+    @Override
+    public List<String> primaryKeys() {
+        return origin.primaryKeys();
+    }
+
+    @Override
+    public List<String> partitionKeys() {
+        return origin.partitionKeys();
+    }
+
+    @Override
+    public Map<String, String> options() {
+        return origin.options();
+    }
+
+    @Override
+    public FileIO fileIO() {
+        return origin.fileIO();
+    }
+
+    @Override
+    public InnerTableRead newRead() {
+        return origin.newRead();
+    }
+
+    @Override
+    public InnerTableScan newScan() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Table copy(Map<String, String> dynamicOptions) {
+        return new BatchVectorSearchTable(
+                (InnerTable) origin.copy(dynamicOptions), batchVectorSearch);
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
@@ -120,23 +120,4 @@ public class SparkConnectorOptions {
                     .withDescription(
                             "Whether to adjust the target split size based on pruned (projected) columns. "
                                     + "If enabled, split size estimation uses only the columns actually being read.");
-
-    public static final ConfigOption<Integer> BATCH_VECTOR_SEARCH_PARALLELISM =
-            key("vector-search.batch.parallelism")
-                    .intType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "Custom parallelism for the batch_vector_search table-valued function, i.e. the "
-                                    + "number of tasks the query vectors are distributed across; each task loads "
-                                    + "the vector index and searches its share of queries. By default, if this "
-                                    + "option is not defined, the parallelism is inferred from the number of query "
-                                    + "vectors, capped by 'vector-search.batch.infer-parallelism.max'.");
-
-    public static final ConfigOption<Integer> BATCH_VECTOR_SEARCH_INFER_PARALLELISM_MAX =
-            key("vector-search.batch.infer-parallelism.max")
-                    .intType()
-                    .defaultValue(1024)
-                    .withDescription(
-                            "When 'vector-search.batch.parallelism' is not set, limit the inferred parallelism "
-                                    + "of batch_vector_search through this option.");
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
@@ -120,4 +120,23 @@ public class SparkConnectorOptions {
                     .withDescription(
                             "Whether to adjust the target split size based on pruned (projected) columns. "
                                     + "If enabled, split size estimation uses only the columns actually being read.");
+
+    public static final ConfigOption<Integer> BATCH_VECTOR_SEARCH_PARALLELISM =
+            key("vector-search.batch.parallelism")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Custom parallelism for the batch_vector_search table-valued function, i.e. the "
+                                    + "number of tasks the query vectors are distributed across; each task loads "
+                                    + "the vector index and searches its share of queries. By default, if this "
+                                    + "option is not defined, the parallelism is inferred from the number of query "
+                                    + "vectors, capped by 'vector-search.batch.infer-parallelism.max'.");
+
+    public static final ConfigOption<Integer> BATCH_VECTOR_SEARCH_INFER_PARALLELISM_MAX =
+            key("vector-search.batch.infer-parallelism.max")
+                    .intType()
+                    .defaultValue(1024)
+                    .withDescription(
+                            "When 'vector-search.batch.parallelism' is not set, limit the inferred parallelism "
+                                    + "of batch_vector_search through this option.");
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkBatchVectorReadImpl.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkBatchVectorReadImpl.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.read;
+
+import org.apache.paimon.globalindex.GlobalIndexReadThreadPool;
+import org.apache.paimon.globalindex.GlobalIndexResult;
+import org.apache.paimon.globalindex.GlobalIndexResultSerializer;
+import org.apache.paimon.globalindex.GlobalIndexer;
+import org.apache.paimon.globalindex.GlobalIndexerFactoryUtils;
+import org.apache.paimon.globalindex.ScoredGlobalIndexResult;
+import org.apache.paimon.index.IndexPathFactory;
+import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.BatchVectorReadImpl;
+import org.apache.paimon.table.source.IndexVectorSearchSplit;
+import org.apache.paimon.table.source.RawVectorSearchSplit;
+import org.apache.paimon.table.source.VectorScan;
+import org.apache.paimon.table.source.VectorSearchSplit;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.utils.InstantiationUtil;
+import org.apache.paimon.utils.RoaringNavigableMap64;
+import org.apache.paimon.utils.SerializableFunction;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_THREAD_NUM;
+
+/**
+ * Spark-aware {@link BatchVectorReadImpl} that distributes the per-split vector index evaluation
+ * across the Spark cluster instead of evaluating it with the local thread pool. Mirrors {@link
+ * SparkVectorReadImpl} for the batch (multi-vector) path: each task evaluates a group of index
+ * splits against all query vectors and returns one partial result per query, then the driver merges
+ * per query and keeps the top-K.
+ *
+ * <p>Raw (un-indexed) splits are still searched locally per query (TODO: distribute as well).
+ */
+public class SparkBatchVectorReadImpl extends BatchVectorReadImpl {
+
+    private static final long serialVersionUID = 1L;
+
+    public SparkBatchVectorReadImpl(
+            FileStoreTable table,
+            @Nullable PartitionPredicate partitionFilter,
+            @Nullable Predicate filter,
+            int limit,
+            DataField vectorColumn,
+            float[][] vectors,
+            @Nullable Map<String, String> options) {
+        super(table, partitionFilter, filter, limit, vectorColumn, vectors, options);
+    }
+
+    @Override
+    public List<GlobalIndexResult> readBatch(VectorScan.Plan plan) {
+        int n = vectors.length;
+        List<IndexVectorSearchSplit> indexSplits = new ArrayList<>();
+        List<RawVectorSearchSplit> rawSplits = new ArrayList<>();
+        splitSearchSplits(plan.splits(), indexSplits, rawSplits);
+        if (indexSplits.isEmpty() && rawSplits.isEmpty()) {
+            List<GlobalIndexResult> empty = new ArrayList<>(n);
+            for (int i = 0; i < n; i++) {
+                empty.add(GlobalIndexResult.createEmpty());
+            }
+            return empty;
+        }
+
+        GlobalIndexer globalIndexer =
+                indexSplits.isEmpty() ? null : createGlobalIndexer(indexSplits);
+        ScoredGlobalIndexResult[] indexedResults =
+                indexSplits.isEmpty()
+                        ? emptyScoredResults(n)
+                        : readIndexedBatchInSpark(indexSplits, globalIndexer);
+
+        List<GlobalIndexResult> results = new ArrayList<>(n);
+        RoaringNavigableMap64 rawPreFilter = rawPreFilter(rawSplits);
+        for (int i = 0; i < n; i++) {
+            results.add(
+                    withRawSearch(
+                            indexedResults[i], rawSplits, globalIndexer, rawPreFilter, vectors[i]));
+        }
+        return results;
+    }
+
+    private ScoredGlobalIndexResult[] readIndexedBatchInSpark(
+            List<IndexVectorSearchSplit> splits, GlobalIndexer globalIndexer) {
+        int n = vectors.length;
+        int parallelism = sparkParallelism();
+        if (splits.size() < parallelism * 2) {
+            return readIndexedBatch(
+                    splits, globalIndexer == null ? createGlobalIndexer(splits) : globalIndexer);
+        }
+
+        List<RoaringNavigableMap64> preFilters = preFilters(splits);
+        String indexType = splits.get(0).vectorIndexFiles().get(0).indexType();
+        List<SerializedSplit> serializedSplits = new ArrayList<>(splits.size());
+        for (int i = 0; i < splits.size(); i++) {
+            try {
+                IndexVectorSearchSplit split = splits.get(i);
+                RoaringNavigableMap64 preFilter = preFilters.isEmpty() ? null : preFilters.get(i);
+                serializedSplits.add(
+                        new SerializedSplit(
+                                InstantiationUtil.serializeObject(split),
+                                preFilter == null
+                                        ? null
+                                        : InstantiationUtil.serializeObject(preFilter)));
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to serialize VectorSearchSplit", e);
+            }
+        }
+        List<List<SerializedSplit>> splitGroups = splitGroups(serializedSplits, parallelism);
+        int queryCount = n;
+
+        SerializableFunction<List<SerializedSplit>, byte[][]> task =
+                group -> {
+                    GlobalIndexer taskGlobalIndexer =
+                            GlobalIndexerFactoryUtils.load(indexType)
+                                    .create(vectorColumn, table.coreOptions().toConfiguration());
+                    IndexPathFactory indexPathFactory =
+                            table.store().pathFactory().globalIndexFileFactory();
+                    ExecutorService executor =
+                            GlobalIndexReadThreadPool.getExecutorService(
+                                    Math.min(parallelism, group.size()));
+
+                    List<CompletableFuture<List<Optional<ScoredGlobalIndexResult>>>> futures =
+                            new ArrayList<>(group.size());
+                    for (SerializedSplit serializedSplit : group) {
+                        IndexVectorSearchSplit split = deserializeSplit(serializedSplit.split);
+                        futures.add(
+                                evalBatch(
+                                        taskGlobalIndexer,
+                                        indexPathFactory,
+                                        split.rowRangeStart(),
+                                        split.rowRangeEnd(),
+                                        split.vectorIndexFiles(),
+                                        vectors,
+                                        deserializePreFilter(serializedSplit.preFilter),
+                                        executor));
+                    }
+                    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+                    ScoredGlobalIndexResult[] merged = new ScoredGlobalIndexResult[queryCount];
+                    for (int i = 0; i < queryCount; i++) {
+                        merged[i] = ScoredGlobalIndexResult.createEmpty();
+                    }
+                    for (CompletableFuture<List<Optional<ScoredGlobalIndexResult>>> f : futures) {
+                        List<Optional<ScoredGlobalIndexResult>> splitResults = f.join();
+                        for (int i = 0; i < queryCount; i++) {
+                            if (splitResults.get(i).isPresent()) {
+                                merged[i] = merged[i].or(splitResults.get(i).get());
+                            }
+                        }
+                    }
+
+                    GlobalIndexResultSerializer serializer = new GlobalIndexResultSerializer();
+                    byte[][] out = new byte[queryCount][];
+                    for (int i = 0; i < queryCount; i++) {
+                        ScoredGlobalIndexResult r = merged[i].topK(limit);
+                        if (r.results().isEmpty()) {
+                            out[i] = null;
+                        } else {
+                            try {
+                                out[i] = serializer.serialize(r);
+                            } catch (IOException e) {
+                                throw new RuntimeException(
+                                        "Failed to serialize ScoredGlobalIndexResult", e);
+                            }
+                        }
+                    }
+                    return out;
+                };
+
+        List<byte[][]> remoteResults = mapInSpark(splitGroups, task, splitGroups.size());
+
+        ScoredGlobalIndexResult[] result = new ScoredGlobalIndexResult[n];
+        for (int i = 0; i < n; i++) {
+            result[i] = ScoredGlobalIndexResult.createEmpty();
+        }
+        GlobalIndexResultSerializer serializer = new GlobalIndexResultSerializer();
+        for (byte[][] groupOut : remoteResults) {
+            if (groupOut == null) {
+                continue;
+            }
+            for (int i = 0; i < n; i++) {
+                if (groupOut[i] != null) {
+                    try {
+                        result[i] = result[i].or(serializer.deserialize(groupOut[i]));
+                    } catch (IOException e) {
+                        throw new RuntimeException("Failed to deserialize ScoredGlobalIndexResult", e);
+                    }
+                }
+            }
+        }
+        for (int i = 0; i < n; i++) {
+            result[i] = result[i].topK(limit);
+        }
+        return result;
+    }
+
+    protected int sparkParallelism() {
+        return Math.max(1, table.coreOptions().toConfiguration().get(GLOBAL_INDEX_THREAD_NUM));
+    }
+
+    protected <I, O> List<O> mapInSpark(
+            List<I> data, SerializableFunction<I, O> func, int parallelism) {
+        return new SparkEngineContext().map(data, func, parallelism);
+    }
+
+    private List<List<SerializedSplit>> splitGroups(
+            List<SerializedSplit> serializedSplits, int parallelism) {
+        List<List<SerializedSplit>> groups = new ArrayList<>(parallelism);
+        int groupSize = (serializedSplits.size() + parallelism - 1) / parallelism;
+        for (int start = 0; start < serializedSplits.size(); start += groupSize) {
+            groups.add(
+                    new ArrayList<>(
+                            serializedSplits.subList(
+                                    start, Math.min(start + groupSize, serializedSplits.size()))));
+        }
+        return groups;
+    }
+
+    private IndexVectorSearchSplit deserializeSplit(byte[] bytes) {
+        try {
+            return InstantiationUtil.deserializeObject(
+                    bytes, Thread.currentThread().getContextClassLoader());
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException("Failed to deserialize VectorSearchSplit", e);
+        }
+    }
+
+    @Nullable
+    private RoaringNavigableMap64 deserializePreFilter(@Nullable byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
+        try {
+            return InstantiationUtil.deserializeObject(
+                    bytes, Thread.currentThread().getContextClassLoader());
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException("Failed to deserialize vector pre-filter", e);
+        }
+    }
+
+    private static class SerializedSplit implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final byte[] split;
+        @Nullable private final byte[] preFilter;
+
+        private SerializedSplit(byte[] split, @Nullable byte[] preFilter) {
+            this.split = split;
+            this.preFilter = preFilter;
+        }
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkBatchVectorReadImpl.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkBatchVectorReadImpl.java
@@ -34,14 +34,12 @@ import org.apache.paimon.table.source.RawVectorSearchSplit;
 import org.apache.paimon.table.source.VectorScan;
 import org.apache.paimon.table.source.VectorSearchSplit;
 import org.apache.paimon.types.DataField;
-import org.apache.paimon.utils.InstantiationUtil;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 import org.apache.paimon.utils.SerializableFunction;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -117,25 +115,24 @@ public class SparkBatchVectorReadImpl extends BatchVectorReadImpl {
 
         List<RoaringNavigableMap64> preFilters = preFilters(splits);
         String indexType = splits.get(0).vectorIndexFiles().get(0).indexType();
-        List<SerializedSplit> serializedSplits = new ArrayList<>(splits.size());
+        List<SparkVectorReads.SerializedSplit> serializedSplits = new ArrayList<>(splits.size());
         for (int i = 0; i < splits.size(); i++) {
-            try {
-                IndexVectorSearchSplit split = splits.get(i);
-                RoaringNavigableMap64 preFilter = preFilters.isEmpty() ? null : preFilters.get(i);
-                serializedSplits.add(
-                        new SerializedSplit(
-                                InstantiationUtil.serializeObject(split),
-                                preFilter == null
-                                        ? null
-                                        : InstantiationUtil.serializeObject(preFilter)));
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to serialize VectorSearchSplit", e);
-            }
+            IndexVectorSearchSplit split = splits.get(i);
+            RoaringNavigableMap64 preFilter = preFilters.isEmpty() ? null : preFilters.get(i);
+            serializedSplits.add(
+                    new SparkVectorReads.SerializedSplit(
+                            SparkVectorReads.serialize(
+                                    split, "Failed to serialize VectorSearchSplit"),
+                            preFilter == null
+                                    ? null
+                                    : SparkVectorReads.serialize(
+                                            preFilter, "Failed to serialize vector pre-filter")));
         }
-        List<List<SerializedSplit>> splitGroups = splitGroups(serializedSplits, parallelism);
+        List<List<SparkVectorReads.SerializedSplit>> splitGroups =
+                SparkVectorReads.evenGroups(serializedSplits, parallelism);
         int queryCount = n;
 
-        SerializableFunction<List<SerializedSplit>, byte[][]> task =
+        SerializableFunction<List<SparkVectorReads.SerializedSplit>, byte[][]> task =
                 group -> {
                     GlobalIndexer taskGlobalIndexer =
                             GlobalIndexerFactoryUtils.load(indexType)
@@ -148,8 +145,9 @@ public class SparkBatchVectorReadImpl extends BatchVectorReadImpl {
 
                     List<CompletableFuture<List<Optional<ScoredGlobalIndexResult>>>> futures =
                             new ArrayList<>(group.size());
-                    for (SerializedSplit serializedSplit : group) {
-                        IndexVectorSearchSplit split = deserializeSplit(serializedSplit.split);
+                    for (SparkVectorReads.SerializedSplit serializedSplit : group) {
+                        IndexVectorSearchSplit split =
+                                SparkVectorReads.deserializeSplit(serializedSplit.split);
                         futures.add(
                                 evalBatch(
                                         taskGlobalIndexer,
@@ -158,7 +156,8 @@ public class SparkBatchVectorReadImpl extends BatchVectorReadImpl {
                                         split.rowRangeEnd(),
                                         split.vectorIndexFiles(),
                                         vectors,
-                                        deserializePreFilter(serializedSplit.preFilter),
+                                        SparkVectorReads.deserializePreFilter(
+                                                serializedSplit.preFilter),
                                         executor));
                     }
                     CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
@@ -228,53 +227,5 @@ public class SparkBatchVectorReadImpl extends BatchVectorReadImpl {
     protected <I, O> List<O> mapInSpark(
             List<I> data, SerializableFunction<I, O> func, int parallelism) {
         return new SparkEngineContext().map(data, func, parallelism);
-    }
-
-    private List<List<SerializedSplit>> splitGroups(
-            List<SerializedSplit> serializedSplits, int parallelism) {
-        List<List<SerializedSplit>> groups = new ArrayList<>(parallelism);
-        int groupSize = (serializedSplits.size() + parallelism - 1) / parallelism;
-        for (int start = 0; start < serializedSplits.size(); start += groupSize) {
-            groups.add(
-                    new ArrayList<>(
-                            serializedSplits.subList(
-                                    start, Math.min(start + groupSize, serializedSplits.size()))));
-        }
-        return groups;
-    }
-
-    private IndexVectorSearchSplit deserializeSplit(byte[] bytes) {
-        try {
-            return InstantiationUtil.deserializeObject(
-                    bytes, Thread.currentThread().getContextClassLoader());
-        } catch (IOException | ClassNotFoundException e) {
-            throw new RuntimeException("Failed to deserialize VectorSearchSplit", e);
-        }
-    }
-
-    @Nullable
-    private RoaringNavigableMap64 deserializePreFilter(@Nullable byte[] bytes) {
-        if (bytes == null) {
-            return null;
-        }
-        try {
-            return InstantiationUtil.deserializeObject(
-                    bytes, Thread.currentThread().getContextClassLoader());
-        } catch (IOException | ClassNotFoundException e) {
-            throw new RuntimeException("Failed to deserialize vector pre-filter", e);
-        }
-    }
-
-    private static class SerializedSplit implements Serializable {
-
-        private static final long serialVersionUID = 1L;
-
-        private final byte[] split;
-        @Nullable private final byte[] preFilter;
-
-        private SerializedSplit(byte[] split, @Nullable byte[] preFilter) {
-            this.split = split;
-            this.preFilter = preFilter;
-        }
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkBatchVectorReadImpl.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkBatchVectorReadImpl.java
@@ -38,6 +38,8 @@ import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 import org.apache.paimon.utils.SerializableFunction;
 
+import org.apache.spark.broadcast.Broadcast;
+
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -207,36 +209,31 @@ public class SparkBatchVectorReadImpl extends BatchVectorReadImpl {
             return local;
         }
 
-        byte[] preFilterBytes =
-                preFilter == null
-                        ? null
-                        : SparkVectorReads.serialize(
-                                preFilter, "Failed to serialize vector pre-filter");
-        List<SparkVectorReads.SerializedSplit> serializedGroups = new ArrayList<>();
+        // The pre-filter is identical for every range group, so broadcast it once instead of
+        // shipping a copy with each group.
+        Broadcast<RoaringNavigableMap64> preFilterBroadcast =
+                preFilter == null ? null : new SparkEngineContext().broadcast(preFilter);
+        List<byte[]> serializedRanges = new ArrayList<>();
         for (List<Range> rangeGroup : SparkVectorReads.rangeGroups(rawRowRanges, parallelism)) {
-            serializedGroups.add(
-                    new SparkVectorReads.SerializedSplit(
-                            SparkVectorReads.serialize(
-                                    rangeGroup, "Failed to serialize raw vector row ranges"),
-                            preFilterBytes));
+            serializedRanges.add(
+                    SparkVectorReads.serialize(
+                            rangeGroup, "Failed to serialize raw vector row ranges"));
         }
-        List<List<SparkVectorReads.SerializedSplit>> splitGroups =
-                SparkVectorReads.evenGroups(serializedGroups, parallelism);
+        List<List<byte[]>> splitGroups = SparkVectorReads.evenGroups(serializedRanges, parallelism);
         int queryCount = n;
 
-        SerializableFunction<List<SparkVectorReads.SerializedSplit>, byte[][]> task =
+        SerializableFunction<List<byte[]>, byte[][]> task =
                 group -> {
+                    RoaringNavigableMap64 groupPreFilter =
+                            preFilterBroadcast == null ? null : preFilterBroadcast.value();
                     ScoredGlobalIndexResult[] merged = new ScoredGlobalIndexResult[queryCount];
                     for (int i = 0; i < queryCount; i++) {
                         merged[i] = ScoredGlobalIndexResult.createEmpty();
                     }
-                    for (SparkVectorReads.SerializedSplit serializedSplit : group) {
+                    for (byte[] rangeBytes : group) {
                         List<Range> rowRanges =
                                 SparkVectorReads.deserialize(
-                                        serializedSplit.split,
-                                        "Failed to deserialize raw vector row ranges");
-                        RoaringNavigableMap64 groupPreFilter =
-                                SparkVectorReads.deserializePreFilter(serializedSplit.preFilter);
+                                        rangeBytes, "Failed to deserialize raw vector row ranges");
                         for (int i = 0; i < queryCount; i++) {
                             merged[i] =
                                     merged[i].or(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkBatchVectorReadImpl.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkBatchVectorReadImpl.java
@@ -245,6 +245,9 @@ public class SparkBatchVectorReadImpl extends BatchVectorReadImpl {
                 };
 
         List<byte[][]> remoteResults = mapInSpark(splitGroups, task, splitGroups.size());
+        if (preFilterBroadcast != null) {
+            preFilterBroadcast.unpersist();
+        }
         return mergeBatchRemoteResults(remoteResults, n);
     }
 

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkBatchVectorReadImpl.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkBatchVectorReadImpl.java
@@ -34,6 +34,7 @@ import org.apache.paimon.table.source.RawVectorSearchSplit;
 import org.apache.paimon.table.source.VectorScan;
 import org.apache.paimon.table.source.VectorSearchSplit;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 import org.apache.paimon.utils.SerializableFunction;
 
@@ -54,9 +55,8 @@ import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_THREAD_NUM;
  * across the Spark cluster instead of evaluating it with the local thread pool. Mirrors {@link
  * SparkVectorReadImpl} for the batch (multi-vector) path: each task evaluates a group of index
  * splits against all query vectors and returns one partial result per query, then the driver merges
- * per query and keeps the top-K.
- *
- * <p>Raw (un-indexed) splits are still searched locally per query (TODO: distribute as well).
+ * per query and keeps the top-K. Raw (un-indexed) splits are distributed the same way, by row-range
+ * group across all query vectors.
  */
 public class SparkBatchVectorReadImpl extends BatchVectorReadImpl {
 
@@ -94,12 +94,12 @@ public class SparkBatchVectorReadImpl extends BatchVectorReadImpl {
                         ? emptyScoredResults(n)
                         : readIndexedBatchInSpark(indexSplits, globalIndexer);
 
+        ScoredGlobalIndexResult[] rawResults =
+                readRawBatchInSpark(rawSplits, globalIndexer, rawPreFilter(rawSplits));
+
         List<GlobalIndexResult> results = new ArrayList<>(n);
-        RoaringNavigableMap64 rawPreFilter = rawPreFilter(rawSplits);
         for (int i = 0; i < n; i++) {
-            results.add(
-                    withRawSearch(
-                            indexedResults[i], rawSplits, globalIndexer, rawPreFilter, vectors[i]));
+            results.add(indexedResults[i].or(rawResults[i]).topK(limit));
         }
         return results;
     }
@@ -175,26 +175,103 @@ public class SparkBatchVectorReadImpl extends BatchVectorReadImpl {
                         }
                     }
 
-                    GlobalIndexResultSerializer serializer = new GlobalIndexResultSerializer();
-                    byte[][] out = new byte[queryCount][];
-                    for (int i = 0; i < queryCount; i++) {
-                        ScoredGlobalIndexResult r = merged[i].topK(limit);
-                        if (r.results().isEmpty()) {
-                            out[i] = null;
-                        } else {
-                            try {
-                                out[i] = serializer.serialize(r);
-                            } catch (IOException e) {
-                                throw new RuntimeException(
-                                        "Failed to serialize ScoredGlobalIndexResult", e);
-                            }
-                        }
-                    }
-                    return out;
+                    return serializeTopKPerQuery(merged);
                 };
 
         List<byte[][]> remoteResults = mapInSpark(splitGroups, task, splitGroups.size());
+        return mergeBatchRemoteResults(remoteResults, n);
+    }
 
+    /**
+     * Distributes the raw (un-indexed) search across the Spark cluster, mirroring {@link
+     * SparkVectorReadImpl} but evaluating every query vector per row-range group. Returns one
+     * top-k raw result per query (empty when there are no raw rows).
+     */
+    private ScoredGlobalIndexResult[] readRawBatchInSpark(
+            List<RawVectorSearchSplit> rawSplits,
+            @Nullable GlobalIndexer globalIndexer,
+            @Nullable RoaringNavigableMap64 preFilter) {
+        int n = vectors.length;
+        List<Range> rawRowRanges = rawRowRanges(rawSplits);
+        if (rawRowRanges.isEmpty()) {
+            return emptyScoredResults(n);
+        }
+
+        int parallelism = sparkParallelism();
+        String metric = rawSearchMetric(rawSearchIndexer(rawSplits, globalIndexer));
+        if (SparkVectorReads.rawRowCount(rawRowRanges) < parallelism * 2L) {
+            ScoredGlobalIndexResult[] local = new ScoredGlobalIndexResult[n];
+            for (int i = 0; i < n; i++) {
+                local[i] = readRawSearch(rawRowRanges, preFilter, metric, vectors[i]);
+            }
+            return local;
+        }
+
+        byte[] preFilterBytes =
+                preFilter == null
+                        ? null
+                        : SparkVectorReads.serialize(
+                                preFilter, "Failed to serialize vector pre-filter");
+        List<SparkVectorReads.SerializedSplit> serializedGroups = new ArrayList<>();
+        for (List<Range> rangeGroup : SparkVectorReads.rangeGroups(rawRowRanges, parallelism)) {
+            serializedGroups.add(
+                    new SparkVectorReads.SerializedSplit(
+                            SparkVectorReads.serialize(
+                                    rangeGroup, "Failed to serialize raw vector row ranges"),
+                            preFilterBytes));
+        }
+        List<List<SparkVectorReads.SerializedSplit>> splitGroups =
+                SparkVectorReads.evenGroups(serializedGroups, parallelism);
+        int queryCount = n;
+
+        SerializableFunction<List<SparkVectorReads.SerializedSplit>, byte[][]> task =
+                group -> {
+                    ScoredGlobalIndexResult[] merged = new ScoredGlobalIndexResult[queryCount];
+                    for (int i = 0; i < queryCount; i++) {
+                        merged[i] = ScoredGlobalIndexResult.createEmpty();
+                    }
+                    for (SparkVectorReads.SerializedSplit serializedSplit : group) {
+                        List<Range> rowRanges =
+                                SparkVectorReads.deserialize(
+                                        serializedSplit.split,
+                                        "Failed to deserialize raw vector row ranges");
+                        RoaringNavigableMap64 groupPreFilter =
+                                SparkVectorReads.deserializePreFilter(serializedSplit.preFilter);
+                        for (int i = 0; i < queryCount; i++) {
+                            merged[i] =
+                                    merged[i].or(
+                                            readRawSearch(
+                                                    rowRanges, groupPreFilter, metric, vectors[i]));
+                        }
+                    }
+                    return serializeTopKPerQuery(merged);
+                };
+
+        List<byte[][]> remoteResults = mapInSpark(splitGroups, task, splitGroups.size());
+        return mergeBatchRemoteResults(remoteResults, n);
+    }
+
+    /** Serializes each query's top-k result for Spark dispatch; {@code null} for empty results. */
+    private byte[][] serializeTopKPerQuery(ScoredGlobalIndexResult[] merged) {
+        GlobalIndexResultSerializer serializer = new GlobalIndexResultSerializer();
+        byte[][] out = new byte[merged.length][];
+        for (int i = 0; i < merged.length; i++) {
+            ScoredGlobalIndexResult r = merged[i].topK(limit);
+            if (r.results().isEmpty()) {
+                out[i] = null;
+            } else {
+                try {
+                    out[i] = serializer.serialize(r);
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to serialize ScoredGlobalIndexResult", e);
+                }
+            }
+        }
+        return out;
+    }
+
+    /** Merges per-group, per-query serialized results back into one top-k result per query. */
+    private ScoredGlobalIndexResult[] mergeBatchRemoteResults(List<byte[][]> remoteResults, int n) {
         ScoredGlobalIndexResult[] result = new ScoredGlobalIndexResult[n];
         for (int i = 0; i < n; i++) {
             result[i] = ScoredGlobalIndexResult.createEmpty();
@@ -209,7 +286,8 @@ public class SparkBatchVectorReadImpl extends BatchVectorReadImpl {
                     try {
                         result[i] = result[i].or(serializer.deserialize(groupOut[i]));
                     } catch (IOException e) {
-                        throw new RuntimeException("Failed to deserialize ScoredGlobalIndexResult", e);
+                        throw new RuntimeException(
+                                "Failed to deserialize ScoredGlobalIndexResult", e);
                     }
                 }
             }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkBatchVectorSearchBuilderImpl.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkBatchVectorSearchBuilderImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.read;
+
+import org.apache.paimon.table.InnerTable;
+import org.apache.paimon.table.source.BatchVectorRead;
+import org.apache.paimon.table.source.BatchVectorSearchBuilderImpl;
+
+/**
+ * Spark-aware {@link BatchVectorSearchBuilderImpl} which produces a {@link SparkBatchVectorReadImpl}
+ * so the per-split vector index evaluation is dispatched through Spark instead of the local thread
+ * pool. Mirrors {@link SparkVectorSearchBuilderImpl} for the batch (multi-vector) path.
+ */
+public class SparkBatchVectorSearchBuilderImpl extends BatchVectorSearchBuilderImpl {
+
+    private static final long serialVersionUID = 1L;
+
+    public SparkBatchVectorSearchBuilderImpl(InnerTable table) {
+        super(table);
+    }
+
+    @Override
+    public BatchVectorRead newBatchVectorRead() {
+        return new SparkBatchVectorReadImpl(
+                table, partitionFilter, filter, limit, vectorColumn, vectors, options);
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorReadImpl.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorReadImpl.java
@@ -227,6 +227,9 @@ public class SparkVectorReadImpl extends VectorReadImpl {
                 };
 
         List<byte[]> remoteResults = mapInSpark(splitGroups, task, splitGroups.size());
+        if (preFilterBroadcast != null) {
+            preFilterBroadcast.unpersist();
+        }
         return mergeRemoteResults(remoteResults);
     }
 

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorReadImpl.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorReadImpl.java
@@ -33,7 +33,6 @@ import org.apache.paimon.table.source.RawVectorSearchSplit;
 import org.apache.paimon.table.source.VectorReadImpl;
 import org.apache.paimon.table.source.VectorScan;
 import org.apache.paimon.types.DataField;
-import org.apache.paimon.utils.InstantiationUtil;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 import org.apache.paimon.utils.SerializableFunction;
@@ -104,23 +103,22 @@ public class SparkVectorReadImpl extends VectorReadImpl {
 
         List<RoaringNavigableMap64> preFilters = preFilters(splits);
         String indexType = splits.get(0).vectorIndexFiles().get(0).indexType();
-        List<SerializedSplit> serializedSplits = new ArrayList<>(splits.size());
+        List<SparkVectorReads.SerializedSplit> serializedSplits = new ArrayList<>(splits.size());
         for (int i = 0; i < splits.size(); i++) {
-            try {
-                IndexVectorSearchSplit split = splits.get(i);
-                RoaringNavigableMap64 preFilter = preFilters.isEmpty() ? null : preFilters.get(i);
-                serializedSplits.add(
-                        new SerializedSplit(
-                                InstantiationUtil.serializeObject(split),
-                                preFilter == null
-                                        ? null
-                                        : InstantiationUtil.serializeObject(preFilter)));
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to serialize VectorSearchSplit", e);
-            }
+            IndexVectorSearchSplit split = splits.get(i);
+            RoaringNavigableMap64 preFilter = preFilters.isEmpty() ? null : preFilters.get(i);
+            serializedSplits.add(
+                    new SparkVectorReads.SerializedSplit(
+                            SparkVectorReads.serialize(
+                                    split, "Failed to serialize VectorSearchSplit"),
+                            preFilter == null
+                                    ? null
+                                    : SparkVectorReads.serialize(
+                                            preFilter, "Failed to serialize vector pre-filter")));
         }
-        List<List<SerializedSplit>> splitGroups = splitGroups(serializedSplits, parallelism);
-        SerializableFunction<List<SerializedSplit>, byte[]> task =
+        List<List<SparkVectorReads.SerializedSplit>> splitGroups =
+                SparkVectorReads.evenGroups(serializedSplits, parallelism);
+        SerializableFunction<List<SparkVectorReads.SerializedSplit>, byte[]> task =
                 group -> {
                     GlobalIndexer taskGlobalIndexer =
                             GlobalIndexerFactoryUtils.load(indexType)
@@ -133,8 +131,9 @@ public class SparkVectorReadImpl extends VectorReadImpl {
                                     Math.min(parallelism, group.size()));
                     List<CompletableFuture<Optional<ScoredGlobalIndexResult>>> futures =
                             new ArrayList<>(group.size());
-                    for (SerializedSplit serializedSplit : group) {
-                        IndexVectorSearchSplit split = deserializeSplit(serializedSplit.split);
+                    for (SparkVectorReads.SerializedSplit serializedSplit : group) {
+                        IndexVectorSearchSplit split =
+                                SparkVectorReads.deserializeSplit(serializedSplit.split);
                         futures.add(
                                 eval(
                                         taskGlobalIndexer,
@@ -143,7 +142,8 @@ public class SparkVectorReadImpl extends VectorReadImpl {
                                         split.rowRangeEnd(),
                                         split.vectorIndexFiles(),
                                         vector,
-                                        deserializePreFilter(serializedSplit.preFilter),
+                                        SparkVectorReads.deserializePreFilter(
+                                                serializedSplit.preFilter),
                                         executor));
                     }
                     CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
@@ -188,30 +188,34 @@ public class SparkVectorReadImpl extends VectorReadImpl {
 
         String metric = rawSearchMetric(rawSearchIndexer(splits, globalIndexer));
         List<List<Range>> rangeGroups = rangeGroups(rawRowRanges, parallelism);
-        List<SerializedSplit> serializedSplits = new ArrayList<>(rangeGroups.size());
+        List<SparkVectorReads.SerializedSplit> serializedSplits =
+                new ArrayList<>(rangeGroups.size());
         for (List<Range> rangeGroup : rangeGroups) {
-            try {
-                serializedSplits.add(
-                        new SerializedSplit(
-                                InstantiationUtil.serializeObject(rangeGroup),
-                                preFilter == null
-                                        ? null
-                                        : InstantiationUtil.serializeObject(preFilter)));
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to serialize raw vector row ranges", e);
-            }
+            serializedSplits.add(
+                    new SparkVectorReads.SerializedSplit(
+                            SparkVectorReads.serialize(
+                                    rangeGroup, "Failed to serialize raw vector row ranges"),
+                            preFilter == null
+                                    ? null
+                                    : SparkVectorReads.serialize(
+                                            preFilter, "Failed to serialize vector pre-filter")));
         }
-        List<List<SerializedSplit>> splitGroups = splitGroups(serializedSplits, parallelism);
+        List<List<SparkVectorReads.SerializedSplit>> splitGroups =
+                SparkVectorReads.evenGroups(serializedSplits, parallelism);
 
-        SerializableFunction<List<SerializedSplit>, byte[]> task =
+        SerializableFunction<List<SparkVectorReads.SerializedSplit>, byte[]> task =
                 group -> {
                     ScoredGlobalIndexResult result = ScoredGlobalIndexResult.createEmpty();
-                    for (SerializedSplit serializedSplit : group) {
-                        List<Range> rowRanges = deserializeRanges(serializedSplit.split);
+                    for (SparkVectorReads.SerializedSplit serializedSplit : group) {
+                        List<Range> rowRanges =
+                                SparkVectorReads.deserialize(
+                                        serializedSplit.split,
+                                        "Failed to deserialize raw vector row ranges");
                         ScoredGlobalIndexResult splitResult =
                                 readRawSearch(
                                         rowRanges,
-                                        deserializePreFilter(serializedSplit.preFilter),
+                                        SparkVectorReads.deserializePreFilter(
+                                                serializedSplit.preFilter),
                                         metric,
                                         vector);
                         result = result.or(splitResult);
@@ -243,50 +247,6 @@ public class SparkVectorReadImpl extends VectorReadImpl {
     protected <I, O> List<O> mapInSpark(
             List<I> data, SerializableFunction<I, O> func, int parallelism) {
         return createEngineContext().map(data, func, parallelism);
-    }
-
-    private IndexVectorSearchSplit deserializeSplit(byte[] bytes) {
-        try {
-            return InstantiationUtil.deserializeObject(
-                    bytes, Thread.currentThread().getContextClassLoader());
-        } catch (IOException | ClassNotFoundException e) {
-            throw new RuntimeException("Failed to deserialize VectorSearchSplit", e);
-        }
-    }
-
-    private List<Range> deserializeRanges(byte[] bytes) {
-        try {
-            return InstantiationUtil.deserializeObject(
-                    bytes, Thread.currentThread().getContextClassLoader());
-        } catch (IOException | ClassNotFoundException e) {
-            throw new RuntimeException("Failed to deserialize raw vector row ranges", e);
-        }
-    }
-
-    @Nullable
-    private RoaringNavigableMap64 deserializePreFilter(@Nullable byte[] bytes) {
-        if (bytes == null) {
-            return null;
-        }
-        try {
-            return InstantiationUtil.deserializeObject(
-                    bytes, Thread.currentThread().getContextClassLoader());
-        } catch (IOException | ClassNotFoundException e) {
-            throw new RuntimeException("Failed to deserialize vector pre-filter", e);
-        }
-    }
-
-    private List<List<SerializedSplit>> splitGroups(
-            List<SerializedSplit> serializedSplits, int parallelism) {
-        List<List<SerializedSplit>> groups = new ArrayList<>(parallelism);
-        int groupSize = (serializedSplits.size() + parallelism - 1) / parallelism;
-        for (int start = 0; start < serializedSplits.size(); start += groupSize) {
-            groups.add(
-                    new ArrayList<>(
-                            serializedSplits.subList(
-                                    start, Math.min(start + groupSize, serializedSplits.size()))));
-        }
-        return groups;
     }
 
     private ScoredGlobalIndexResult mergeRemoteResults(List<byte[]> remoteResults) {
@@ -344,18 +304,5 @@ public class SparkVectorReadImpl extends VectorReadImpl {
             rowCount += count;
         }
         return rowCount;
-    }
-
-    private static class SerializedSplit implements java.io.Serializable {
-
-        private static final long serialVersionUID = 1L;
-
-        private final byte[] split;
-        @Nullable private final byte[] preFilter;
-
-        private SerializedSplit(byte[] split, @Nullable byte[] preFilter) {
-            this.split = split;
-            this.preFilter = preFilter;
-        }
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorReadImpl.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorReadImpl.java
@@ -181,13 +181,13 @@ public class SparkVectorReadImpl extends VectorReadImpl {
         }
 
         int parallelism = sparkParallelism();
-        if (rawRowCount(rawRowRanges) < parallelism * 2L) {
+        if (SparkVectorReads.rawRowCount(rawRowRanges) < parallelism * 2L) {
             return readRawSearch(
                     rawRowRanges, preFilter, rawSearchIndexer(splits, globalIndexer), vector);
         }
 
         String metric = rawSearchMetric(rawSearchIndexer(splits, globalIndexer));
-        List<List<Range>> rangeGroups = rangeGroups(rawRowRanges, parallelism);
+        List<List<Range>> rangeGroups = SparkVectorReads.rangeGroups(rawRowRanges, parallelism);
         List<SparkVectorReads.SerializedSplit> serializedSplits =
                 new ArrayList<>(rangeGroups.size());
         for (List<Range> rangeGroup : rangeGroups) {
@@ -262,47 +262,5 @@ public class SparkVectorReadImpl extends VectorReadImpl {
             }
         }
         return result.topK(limit);
-    }
-
-    private List<List<Range>> rangeGroups(List<Range> ranges, int parallelism) {
-        long rowCount = rawRowCount(ranges);
-        int groupCount = (int) Math.min(parallelism, rowCount);
-        long targetRowsPerGroup = (rowCount - 1) / groupCount + 1;
-
-        List<List<Range>> groups = new ArrayList<>(groupCount);
-        List<Range> currentGroup = new ArrayList<>();
-        long currentRows = 0;
-        for (Range range : ranges) {
-            long from = range.from;
-            while (from <= range.to) {
-                if (currentRows == targetRowsPerGroup) {
-                    groups.add(currentGroup);
-                    currentGroup = new ArrayList<>();
-                    currentRows = 0;
-                }
-                long remainingGroupRows = targetRowsPerGroup - currentRows;
-                long to = Math.min(range.to, from + remainingGroupRows - 1);
-                Range next = new Range(from, to);
-                currentGroup.add(next);
-                currentRows += next.count();
-                from = to + 1;
-            }
-        }
-        if (!currentGroup.isEmpty()) {
-            groups.add(currentGroup);
-        }
-        return groups;
-    }
-
-    private long rawRowCount(List<Range> ranges) {
-        long rowCount = 0;
-        for (Range range : ranges) {
-            long count = range.count();
-            if (Long.MAX_VALUE - rowCount < count) {
-                return Long.MAX_VALUE;
-            }
-            rowCount += count;
-        }
-        return rowCount;
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorReadImpl.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorReadImpl.java
@@ -37,6 +37,8 @@ import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 import org.apache.paimon.utils.SerializableFunction;
 
+import org.apache.spark.broadcast.Broadcast;
+
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -187,38 +189,30 @@ public class SparkVectorReadImpl extends VectorReadImpl {
         }
 
         String metric = rawSearchMetric(rawSearchIndexer(splits, globalIndexer));
-        List<List<Range>> rangeGroups = SparkVectorReads.rangeGroups(rawRowRanges, parallelism);
-        List<SparkVectorReads.SerializedSplit> serializedSplits =
-                new ArrayList<>(rangeGroups.size());
-        for (List<Range> rangeGroup : rangeGroups) {
-            serializedSplits.add(
-                    new SparkVectorReads.SerializedSplit(
-                            SparkVectorReads.serialize(
-                                    rangeGroup, "Failed to serialize raw vector row ranges"),
-                            preFilter == null
-                                    ? null
-                                    : SparkVectorReads.serialize(
-                                            preFilter, "Failed to serialize vector pre-filter")));
+        // The pre-filter is identical for every range group, so broadcast it once instead of
+        // shipping a copy with each group.
+        Broadcast<RoaringNavigableMap64> preFilterBroadcast =
+                preFilter == null ? null : createEngineContext().broadcast(preFilter);
+        List<byte[]> serializedRanges = new ArrayList<>();
+        for (List<Range> rangeGroup : SparkVectorReads.rangeGroups(rawRowRanges, parallelism)) {
+            serializedRanges.add(
+                    SparkVectorReads.serialize(
+                            rangeGroup, "Failed to serialize raw vector row ranges"));
         }
-        List<List<SparkVectorReads.SerializedSplit>> splitGroups =
-                SparkVectorReads.evenGroups(serializedSplits, parallelism);
+        List<List<byte[]>> splitGroups = SparkVectorReads.evenGroups(serializedRanges, parallelism);
 
-        SerializableFunction<List<SparkVectorReads.SerializedSplit>, byte[]> task =
+        SerializableFunction<List<byte[]>, byte[]> task =
                 group -> {
+                    RoaringNavigableMap64 groupPreFilter =
+                            preFilterBroadcast == null ? null : preFilterBroadcast.value();
                     ScoredGlobalIndexResult result = ScoredGlobalIndexResult.createEmpty();
-                    for (SparkVectorReads.SerializedSplit serializedSplit : group) {
+                    for (byte[] rangeBytes : group) {
                         List<Range> rowRanges =
                                 SparkVectorReads.deserialize(
-                                        serializedSplit.split,
-                                        "Failed to deserialize raw vector row ranges");
-                        ScoredGlobalIndexResult splitResult =
-                                readRawSearch(
-                                        rowRanges,
-                                        SparkVectorReads.deserializePreFilter(
-                                                serializedSplit.preFilter),
-                                        metric,
-                                        vector);
-                        result = result.or(splitResult);
+                                        rangeBytes, "Failed to deserialize raw vector row ranges");
+                        result =
+                                result.or(
+                                        readRawSearch(rowRanges, groupPreFilter, metric, vector));
                     }
                     result = result.topK(limit);
                     if (result.results().isEmpty()) {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorReads.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorReads.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.read;
+
+import org.apache.paimon.table.source.IndexVectorSearchSplit;
+import org.apache.paimon.utils.InstantiationUtil;
+import org.apache.paimon.utils.RoaringNavigableMap64;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared helpers for the Spark-dispatched vector reads ({@link SparkVectorReadImpl} and {@link
+ * SparkBatchVectorReadImpl}): split serialization and even grouping for {@code SparkEngineContext}
+ * dispatch.
+ */
+final class SparkVectorReads {
+
+    private SparkVectorReads() {}
+
+    /** Splits {@code items} into at most {@code parallelism} contiguous, evenly sized groups. */
+    static <T> List<List<T>> evenGroups(List<T> items, int parallelism) {
+        List<List<T>> groups = new ArrayList<>(parallelism);
+        int groupSize = (items.size() + parallelism - 1) / parallelism;
+        for (int start = 0; start < items.size(); start += groupSize) {
+            groups.add(new ArrayList<>(items.subList(start, Math.min(start + groupSize, items.size()))));
+        }
+        return groups;
+    }
+
+    static IndexVectorSearchSplit deserializeSplit(byte[] bytes) {
+        return deserialize(bytes, "Failed to deserialize VectorSearchSplit");
+    }
+
+    @Nullable
+    static RoaringNavigableMap64 deserializePreFilter(@Nullable byte[] bytes) {
+        return bytes == null ? null : deserialize(bytes, "Failed to deserialize vector pre-filter");
+    }
+
+    static <T> T deserialize(byte[] bytes, String message) {
+        try {
+            return InstantiationUtil.deserializeObject(
+                    bytes, Thread.currentThread().getContextClassLoader());
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException(message, e);
+        }
+    }
+
+    static byte[] serialize(Object value, String message) {
+        try {
+            return InstantiationUtil.serializeObject((Serializable) value);
+        } catch (IOException e) {
+            throw new RuntimeException(message, e);
+        }
+    }
+
+    /** A search split (and its optional row-id pre-filter) serialized for Spark dispatch. */
+    static final class SerializedSplit implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        final byte[] split;
+        @Nullable final byte[] preFilter;
+
+        SerializedSplit(byte[] split, @Nullable byte[] preFilter) {
+            this.split = split;
+            this.preFilter = preFilter;
+        }
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorReads.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorReads.java
@@ -20,6 +20,7 @@ package org.apache.paimon.spark.read;
 
 import org.apache.paimon.table.source.IndexVectorSearchSplit;
 import org.apache.paimon.utils.InstantiationUtil;
+import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import javax.annotation.Nullable;
@@ -46,6 +47,49 @@ final class SparkVectorReads {
             groups.add(new ArrayList<>(items.subList(start, Math.min(start + groupSize, items.size()))));
         }
         return groups;
+    }
+
+    /** Splits raw row ranges into at most {@code parallelism} groups of (roughly) equal row count. */
+    static List<List<Range>> rangeGroups(List<Range> ranges, int parallelism) {
+        long rowCount = rawRowCount(ranges);
+        int groupCount = (int) Math.min(parallelism, rowCount);
+        long targetRowsPerGroup = (rowCount - 1) / groupCount + 1;
+
+        List<List<Range>> groups = new ArrayList<>(groupCount);
+        List<Range> currentGroup = new ArrayList<>();
+        long currentRows = 0;
+        for (Range range : ranges) {
+            long from = range.from;
+            while (from <= range.to) {
+                if (currentRows == targetRowsPerGroup) {
+                    groups.add(currentGroup);
+                    currentGroup = new ArrayList<>();
+                    currentRows = 0;
+                }
+                long remainingGroupRows = targetRowsPerGroup - currentRows;
+                long to = Math.min(range.to, from + remainingGroupRows - 1);
+                Range next = new Range(from, to);
+                currentGroup.add(next);
+                currentRows += next.count();
+                from = to + 1;
+            }
+        }
+        if (!currentGroup.isEmpty()) {
+            groups.add(currentGroup);
+        }
+        return groups;
+    }
+
+    static long rawRowCount(List<Range> ranges) {
+        long rowCount = 0;
+        for (Range range : ranges) {
+            long count = range.count();
+            if (Long.MAX_VALUE - rowCount < count) {
+                return Long.MAX_VALUE;
+            }
+            rowCount += count;
+        }
+        return rowCount;
     }
 
     static IndexVectorSearchSplit deserializeSplit(byte[] bytes) {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -23,7 +23,7 @@ import org.apache.paimon.globalindex.GlobalIndexResult
 import org.apache.paimon.partition.PartitionPredicate
 import org.apache.paimon.predicate.{BatchVectorSearch, PredicateBuilder}
 import org.apache.paimon.spark.metric.SparkMetricRegistry
-import org.apache.paimon.spark.read.{BaseScan, BatchReadTagCleanupListener, PaimonSupportsRuntimeFiltering, SparkHybridSearchBuilderImpl, SparkVectorSearchBuilderImpl}
+import org.apache.paimon.spark.read.{BaseScan, BatchReadTagCleanupListener, PaimonSupportsRuntimeFiltering, SparkBatchVectorSearchBuilderImpl, SparkHybridSearchBuilderImpl, SparkVectorSearchBuilderImpl}
 import org.apache.paimon.spark.sources.PaimonMicroBatchStream
 import org.apache.paimon.spark.util.OptionUtils
 import org.apache.paimon.table.{BatchVectorSearchTable, DataTable, FileStoreTable, InnerTable}
@@ -112,8 +112,13 @@ abstract class PaimonBaseScan(table: InnerTable)
   }
 
   private def evalBatchVectorSearch(bvs: BatchVectorSearch): Seq[GlobalIndexResult] = {
-    val builder = table
-      .newBatchVectorSearchBuilder()
+    val builder =
+      if (CoreOptions.fromMap(table.options).vectorSearchDistributeEnabled()) {
+        new SparkBatchVectorSearchBuilderImpl(table)
+      } else {
+        table.newBatchVectorSearchBuilder()
+      }
+    builder
       .withVectors(bvs.vectors())
       .withVectorColumn(bvs.fieldName())
       .withLimit(bvs.limit())

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -21,12 +21,12 @@ package org.apache.paimon.spark
 import org.apache.paimon.CoreOptions
 import org.apache.paimon.globalindex.GlobalIndexResult
 import org.apache.paimon.partition.PartitionPredicate
-import org.apache.paimon.predicate.PredicateBuilder
+import org.apache.paimon.predicate.{BatchVectorSearch, PredicateBuilder}
 import org.apache.paimon.spark.metric.SparkMetricRegistry
 import org.apache.paimon.spark.read.{BaseScan, BatchReadTagCleanupListener, PaimonSupportsRuntimeFiltering, SparkHybridSearchBuilderImpl, SparkVectorSearchBuilderImpl}
 import org.apache.paimon.spark.sources.PaimonMicroBatchStream
 import org.apache.paimon.spark.util.OptionUtils
-import org.apache.paimon.table.{DataTable, FileStoreTable, InnerTable}
+import org.apache.paimon.table.{BatchVectorSearchTable, DataTable, FileStoreTable, InnerTable}
 import org.apache.paimon.table.source.{DataTableBatchScan, InnerTableScan, Split}
 
 import org.apache.spark.sql.SparkSession
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.connector.metric.{CustomMetric, CustomTaskMetric}
 import org.apache.spark.sql.connector.read.Batch
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream
+import org.apache.spark.sql.types.{IntegerType, StructField}
 
 import scala.collection.JavaConverters._
 
@@ -44,7 +45,17 @@ abstract class PaimonBaseScan(table: InnerTable)
 
   private lazy val paimonMetricsRegistry: SparkMetricRegistry = SparkMetricRegistry()
 
+  // Set by PaimonScanBuilder.build() for the batch_vector_search TVF. Threaded as a
+  // post-construction field (rather than a constructor param) so the per-version PaimonScan
+  // case-class constructors do not need to change.
+  private[spark] var pushedBatchVectorSearch: Option[BatchVectorSearch] = None
+
   protected def getInputSplits: Array[Split] = {
+    if (pushedBatchVectorSearch.isDefined) {
+      // Flattened union of all query results' splits (used for stats/metrics); the per-query
+      // tagged partitions used for the actual read are produced in [[inputPartitions]].
+      return batchVectorResults.flatMap(splitsOf).toArray
+    }
     val scan = readBuilder
       .newScan()
       .withGlobalIndexResult(evalGlobalIndexSearch())
@@ -61,6 +72,59 @@ abstract class PaimonBaseScan(table: InnerTable)
     }
 
     plan.splits().asScala.toArray
+  }
+
+  // ---- batch_vector_search ----
+
+  /** Native batch search executed once; result i corresponds to query vector i. */
+  private lazy val batchVectorResults: Seq[GlobalIndexResult] =
+    evalBatchVectorSearch(pushedBatchVectorSearch.get)
+
+  override protected def leadingSyntheticColumns: Seq[StructField] = {
+    if (pushedBatchVectorSearch.isDefined) {
+      Seq(StructField(BatchVectorSearchTable.QUERY_INDEX_COLUMN, IntegerType, nullable = false))
+    } else {
+      Seq.empty
+    }
+  }
+
+  override protected def toBatchInputPartitions: Seq[PaimonInputPartition] = {
+    if (pushedBatchVectorSearch.isEmpty) {
+      return super.toBatchInputPartitions
+    }
+    batchVectorResults.zipWithIndex.flatMap {
+      case (result, queryIndex) =>
+        getInputPartitions(splitsOf(result).toArray)
+          .map(p => PaimonQueryIndexedInputPartition(p.splits, queryIndex))
+    }
+  }
+
+  private def splitsOf(result: GlobalIndexResult): Seq[Split] = {
+    readBuilder
+      .newScan()
+      .withGlobalIndexResult(result)
+      .asInstanceOf[InnerTableScan]
+      .withMetricRegistry(paimonMetricsRegistry)
+      .plan()
+      .splits()
+      .asScala
+      .toSeq
+  }
+
+  private def evalBatchVectorSearch(bvs: BatchVectorSearch): Seq[GlobalIndexResult] = {
+    val builder = table
+      .newBatchVectorSearchBuilder()
+      .withVectors(bvs.vectors())
+      .withVectorColumn(bvs.fieldName())
+      .withLimit(bvs.limit())
+      .withOptions(bvs.options())
+    if (pushedPartitionFilters.nonEmpty) {
+      builder.withPartitionFilter(PartitionPredicate.and(pushedPartitionFilters.asJava))
+    }
+    if (pushedDataFilters.nonEmpty) {
+      builder.withFilter(PredicateBuilder.and(pushedDataFilters.asJava))
+    }
+    builder.executeBatchLocal().asScala.toSeq
   }
 
   private def evalGlobalIndexSearch(): GlobalIndexResult = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScanBuilder.scala
@@ -23,7 +23,7 @@ import org.apache.paimon.partition.PartitionPredicate
 import org.apache.paimon.partition.PartitionPredicate.splitPartitionPredicatesAndDataPredicates
 import org.apache.paimon.predicate.{PartitionPredicateVisitor, Predicate, TopN, VectorSearch}
 import org.apache.paimon.predicate.FullTextSearch
-import org.apache.paimon.table.{SpecialFields, Table}
+import org.apache.paimon.table.{BatchVectorSearchTable, SpecialFields, Table}
 import org.apache.paimon.types.RowType
 
 import org.apache.spark.sql.connector.expressions.filter.{Predicate => SparkPredicate}
@@ -68,10 +68,17 @@ abstract class PaimonBaseScanBuilder
     val pushableDataFilters = mutable.ArrayBuffer.empty[Predicate]
     val postScan = mutable.ArrayBuffer.empty[SparkPredicate]
 
-    var newRowType = rowType
+    // Data filters target the origin table columns. batch_vector_search wraps the table with a
+    // leading synthetic query_index column, so convert filters against the origin row type to keep
+    // field indices aligned with the actual (origin-schema) read; otherwise every real column is
+    // shifted by one and the pushed predicate reads the wrong column.
+    var newRowType = table match {
+      case bvst: BatchVectorSearchTable => bvst.origin().rowType()
+      case _ => rowType
+    }
     if (
       coreOptions.rowTrackingEnabled() && coreOptions
-        .dataEvolutionEnabled() && !rowType.containsField(SpecialFields.ROW_ID.name())
+        .dataEvolutionEnabled() && !newRowType.containsField(SpecialFields.ROW_ID.name())
     ) {
       newRowType = SpecialFields.rowTypeWithRowTracking(newRowType);
     }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonInputPartition.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonInputPartition.scala
@@ -36,6 +36,14 @@ trait PaimonInputPartition extends InputPartition {
 }
 
 case class SimplePaimonInputPartition(splits: Seq[Split]) extends PaimonInputPartition
+
+/**
+ * Input partition for batch_vector_search. All rows produced from these splits belong to query
+ * vector [[queryIndex]]; the reader prepends [[queryIndex]] as the leading `query_index` column.
+ */
+case class PaimonQueryIndexedInputPartition(splits: Seq[Split], queryIndex: Int)
+  extends PaimonInputPartition
+
 object PaimonInputPartition {
   def apply(split: Split): PaimonInputPartition = {
     SimplePaimonInputPartition(Seq(split))

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionReaderFactory.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionReaderFactory.scala
@@ -22,6 +22,8 @@ import org.apache.paimon.spark.schema.PaimonMetadataColumn
 import org.apache.paimon.table.source.ReadBuilder
 
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, JoinedRow}
+import org.apache.spark.sql.connector.metric.CustomTaskMetric
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
 
 import java.util.Objects
@@ -34,6 +36,9 @@ case class PaimonPartitionReaderFactory(
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     partition match {
+      case qip: PaimonQueryIndexedInputPartition =>
+        val base = PaimonPartitionReader(readBuilder, qip, metadataColumns, blobAsDescriptor)
+        new QueryIndexPrependPartitionReader(base, qip.queryIndex)
       case paimonInputPartition: PaimonInputPartition =>
         PaimonPartitionReader(readBuilder, paimonInputPartition, metadataColumns, blobAsDescriptor)
       case _ =>
@@ -53,4 +58,25 @@ case class PaimonPartitionReaderFactory(
   override def hashCode(): Int = {
     Objects.hashCode(readBuilder)
   }
+}
+
+/**
+ * Wraps a base reader to prepend a constant `query_index` value as the leading column of every row,
+ * for the batch_vector_search TVF.
+ */
+private class QueryIndexPrependPartitionReader(
+    delegate: PartitionReader[InternalRow],
+    queryIndex: Int)
+  extends PartitionReader[InternalRow] {
+
+  private val prefix = new GenericInternalRow(Array[Any](queryIndex))
+  private val joined = new JoinedRow()
+
+  override def next(): Boolean = delegate.next()
+
+  override def get(): InternalRow = joined(prefix, delegate.get())
+
+  override def currentMetricsValues(): Array[CustomTaskMetric] = delegate.currentMetricsValues()
+
+  override def close(): Unit = delegate.close()
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
@@ -129,17 +129,20 @@ class PaimonScanBuilder(val table: InnerTable)
     localScan match {
       case Some(scan) => scan
       case None =>
-        val (actualTable, vectorSearch, hybridSearch, fullTextSearch) = table match {
-          case vst: org.apache.paimon.table.VectorSearchTable =>
-            (vst.origin(), Option(vst.vectorSearch()), None, None)
-          case hst: org.apache.paimon.table.HybridSearchTable =>
-            (hst.origin(), None, Option(hst.hybridSearch()), None)
-          case ftst: org.apache.paimon.table.FullTextSearchTable =>
-            (ftst.origin(), None, None, Option(ftst.fullTextSearch()))
-          case _ => (table, pushedVectorSearch, None, pushedFullTextSearch)
-        }
+        val (actualTable, vectorSearch, hybridSearch, fullTextSearch, batchVectorSearch) =
+          table match {
+            case vst: org.apache.paimon.table.VectorSearchTable =>
+              (vst.origin(), Option(vst.vectorSearch()), None, None, None)
+            case bvst: org.apache.paimon.table.BatchVectorSearchTable =>
+              (bvst.origin(), None, None, None, Option(bvst.batchVectorSearch()))
+            case hst: org.apache.paimon.table.HybridSearchTable =>
+              (hst.origin(), None, Option(hst.hybridSearch()), None, None)
+            case ftst: org.apache.paimon.table.FullTextSearchTable =>
+              (ftst.origin(), None, None, Option(ftst.fullTextSearch()), None)
+            case _ => (table, pushedVectorSearch, None, pushedFullTextSearch, None)
+          }
 
-        PaimonScan(
+        val scan = PaimonScan(
           actualTable,
           requiredSchema,
           pushedPartitionFilters,
@@ -151,6 +154,10 @@ class PaimonScanBuilder(val table: InnerTable)
           fullTextSearch,
           acceptedVariantExtractions
         )
+        // Batch vector search is threaded via a post-construction field on the shared
+        // PaimonBaseScan to avoid touching the per-version PaimonScan constructors.
+        scan.pushedBatchVectorSearch = batchVectorSearch
+        scan
     }
   }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/plans/logical/PaimonTableValuedFunctions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/plans/logical/PaimonTableValuedFunctions.scala
@@ -20,11 +20,11 @@ package org.apache.paimon.spark.catalyst.plans.logical
 
 import org.apache.paimon.CoreOptions
 import org.apache.paimon.globalindex.HybridSearchRanker
-import org.apache.paimon.predicate.{FullTextQuery, FullTextSearch, HybridSearch, HybridSearchRoute, Predicate, VectorSearch}
+import org.apache.paimon.predicate.{BatchVectorSearch, FullTextQuery, FullTextSearch, HybridSearch, HybridSearchRoute, Predicate, VectorSearch}
 import org.apache.paimon.spark.{SparkTable, SparkTypeUtils, SparkV2FilterConverter}
 import org.apache.paimon.spark.catalyst.plans.logical.PaimonTableValuedFunctions._
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
-import org.apache.paimon.table.{DataTable, FullTextSearchTable, HybridSearchTable, InnerTable, VectorSearchTable}
+import org.apache.paimon.table.{BatchVectorSearchTable, DataTable, FullTextSearchTable, HybridSearchTable, InnerTable, VectorSearchTable}
 import org.apache.paimon.table.source.snapshot.TimeTravelUtil.InconsistentTagBucketException
 
 import org.apache.spark.sql.PaimonUtils.{createDataset, normalizeExprs, toAttributes, translateFilterV2}
@@ -57,6 +57,7 @@ object PaimonTableValuedFunctions {
   val INCREMENTAL_BETWEEN_TIMESTAMP = "paimon_incremental_between_timestamp"
   val INCREMENTAL_TO_AUTO_TAG = "paimon_incremental_to_auto_tag"
   val VECTOR_SEARCH = "vector_search"
+  val BATCH_VECTOR_SEARCH = "batch_vector_search"
   val HYBRID_SEARCH = "hybrid_search"
   val FULL_TEXT_SEARCH = "full_text_search"
 
@@ -66,6 +67,7 @@ object PaimonTableValuedFunctions {
       INCREMENTAL_BETWEEN_TIMESTAMP,
       INCREMENTAL_TO_AUTO_TAG,
       VECTOR_SEARCH,
+      BATCH_VECTOR_SEARCH,
       HYBRID_SEARCH,
       FULL_TEXT_SEARCH)
 
@@ -98,6 +100,8 @@ object PaimonTableValuedFunctions {
         FunctionRegistryBase.build[IncrementalToAutoTag](fnName, since = None)
       case VECTOR_SEARCH =>
         FunctionRegistryBase.build[VectorSearchQuery](fnName, since = None)
+      case BATCH_VECTOR_SEARCH =>
+        FunctionRegistryBase.build[BatchVectorSearchQuery](fnName, since = None)
       case HYBRID_SEARCH =>
         FunctionRegistryBase.build[HybridSearchQuery](fnName, since = None)
       case FULL_TEXT_SEARCH =>
@@ -136,6 +140,8 @@ object PaimonTableValuedFunctions {
     tvf match {
       case vsq: VectorSearchQuery =>
         resolveVectorSearchQuery(sparkTable, sparkCatalog, ident, vsq, args.tail)
+      case bvsq: BatchVectorSearchQuery =>
+        resolveBatchVectorSearchQuery(sparkTable, sparkCatalog, ident, bvsq, args.tail)
       case hsq: HybridSearchQuery =>
         resolveHybridSearchQuery(sparkTable, sparkCatalog, ident, hsq, args.tail)
       case ftsq: FullTextSearchQuery =>
@@ -176,6 +182,28 @@ object PaimonTableValuedFunctions {
       case _ =>
         throw new RuntimeException(
           "vector_search only supports Paimon SparkTable backed by InnerTable, " +
+            s"but got table implementation: ${sparkTable.getClass.getName}")
+    }
+  }
+
+  private def resolveBatchVectorSearchQuery(
+      sparkTable: Table,
+      sparkCatalog: TableCatalog,
+      ident: Identifier,
+      bvsq: BatchVectorSearchQuery,
+      argsWithoutTable: Seq[Expression]): LogicalPlan = {
+    sparkTable match {
+      case st @ SparkTable(innerTable: InnerTable) =>
+        val batchVectorSearch = bvsq.createBatchVectorSearch(innerTable, argsWithoutTable)
+        val batchVectorSearchTable = BatchVectorSearchTable.create(innerTable, batchVectorSearch)
+        DataSourceV2Relation.create(
+          st.copy(table = batchVectorSearchTable),
+          Some(sparkCatalog),
+          Some(ident),
+          CaseInsensitiveStringMap.empty())
+      case _ =>
+        throw new RuntimeException(
+          "batch_vector_search only supports Paimon SparkTable backed by InnerTable, " +
             s"but got table implementation: ${sparkTable.getClass.getName}")
     }
   }
@@ -633,6 +661,69 @@ case class VectorSearchQuery(override val args: Seq[Expression])
       limit,
       options,
       toAttributes(SparkTypeUtils.fromPaimonRowType(innerTable.rowType())))
+  }
+}
+
+/**
+ * Plan for the [[BATCH_VECTOR_SEARCH]] table-valued function.
+ *
+ * Usage: batch_vector_search(table_name, column_name, query_vectors, limit[, options])
+ *   - query_vectors: array of query vectors, i.e. array<array<float>>
+ *
+ * The result has an additional leading `query_index` column (the 0-based position of the query
+ * vector in `query_vectors`); rows with `query_index = i` are the top-k for `query_vectors[i]`.
+ *
+ * Example: SELECT * FROM batch_vector_search('T', 'v', array(array(1.0f, 2.0f), array(3.0f, 4.0f)),
+ * 5)
+ */
+case class BatchVectorSearchQuery(override val args: Seq[Expression])
+  extends PaimonTableValueFunction(BATCH_VECTOR_SEARCH) {
+
+  override def parseArgs(args: Seq[Expression]): Map[String, String] = Map.empty
+
+  def createBatchVectorSearch(
+      innerTable: InnerTable,
+      argsWithoutTable: Seq[Expression]): BatchVectorSearch = {
+    if (argsWithoutTable.size != 3 && argsWithoutTable.size != 4) {
+      throw new RuntimeException(
+        s"$BATCH_VECTOR_SEARCH needs three or four parameters after table_name: " +
+          s"column_name, query_vectors, limit[, options]. " +
+          s"Got ${argsWithoutTable.size} parameters after table_name.")
+    }
+    val helper = VectorSearchQuery(Seq.empty)
+    val columnName = argsWithoutTable.head.eval().toString
+    if (!innerTable.rowType().containsField(columnName)) {
+      throw new RuntimeException(
+        s"Column $columnName does not exist in table ${innerTable.name()}")
+    }
+    val queryVectors = extractQueryVectors(argsWithoutTable(1))
+    if (queryVectors.isEmpty) {
+      throw new IllegalArgumentException(
+        s"$BATCH_VECTOR_SEARCH requires at least one query vector.")
+    }
+    val limit = parsePositiveLimit(argsWithoutTable(2).eval())
+    val options: Map[String, String] =
+      if (argsWithoutTable.size == 4) {
+        helper.extractOptions(argsWithoutTable(3))
+      } else {
+        Map.empty[String, String]
+      }
+    new BatchVectorSearch(queryVectors, limit, columnName, options.asJava)
+  }
+
+  private def extractQueryVectors(expr: Expression): Array[Array[Float]] = {
+    val helper = VectorSearchQuery(Seq.empty)
+    expr match {
+      case CreateArray(elements, _) if elements != null =>
+        elements.map(helper.extractQueryVector).toArray
+      case Literal(arrayData: org.apache.spark.sql.catalyst.util.ArrayData, _)
+          if arrayData != null =>
+        (0 until arrayData.numElements()).map {
+          i => arrayData.getArray(i).toFloatArray()
+        }.toArray
+      case _ =>
+        throw new RuntimeException(s"Cannot extract query vectors from expression: $expr")
+    }
   }
 }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
@@ -87,8 +87,12 @@ trait BaseScan extends Scan with SupportsReportStatistics with Logging {
    */
   protected def leadingSyntheticColumns: Seq[StructField] = Seq.empty
 
-  /** Pruned read RowType, with variant fields rewritten if variant pushdown was accepted. */
-  private[paimon] val (readTableRowType, metadataFields) = {
+  /**
+   * Pruned read RowType, with variant fields rewritten if variant pushdown was accepted. Lazy so
+   * [[leadingSyntheticColumns]] is evaluated after construction (e.g. batch_vector_search injects
+   * its state post-construction), not during the trait initializer.
+   */
+  private[paimon] lazy val (readTableRowType, metadataFields) = {
     val syntheticNames = leadingSyntheticColumns.map(_.name).toSet
     val nonSyntheticFields = requiredSchema.fields.filterNot(f => syntheticNames.contains(f.name))
     nonSyntheticFields.foreach(f => checkMetadataColumn(f.name))

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
@@ -32,7 +32,7 @@ import org.apache.paimon.types.RowType
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.metric.{CustomMetric, CustomTaskMetric}
 import org.apache.spark.sql.connector.read.{Batch, Scan, Statistics, SupportsReportStatistics}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{StructField, StructType}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
@@ -80,11 +80,20 @@ trait BaseScan extends Scan with SupportsReportStatistics with Logging {
     }
   }
 
+  /**
+   * Leading synthetic output columns that are not stored in data files and are injected by the
+   * scan (e.g. `query_index` for batch_vector_search). They are excluded from the Paimon read and
+   * the table/metadata column partitioning, and prepended back in [[readSchema]].
+   */
+  protected def leadingSyntheticColumns: Seq[StructField] = Seq.empty
+
   /** Pruned read RowType, with variant fields rewritten if variant pushdown was accepted. */
   private[paimon] val (readTableRowType, metadataFields) = {
-    requiredSchema.fields.foreach(f => checkMetadataColumn(f.name))
+    val syntheticNames = leadingSyntheticColumns.map(_.name).toSet
+    val nonSyntheticFields = requiredSchema.fields.filterNot(f => syntheticNames.contains(f.name))
+    nonSyntheticFields.foreach(f => checkMetadataColumn(f.name))
     val (_requiredTableFields, _metadataFields) =
-      requiredSchema.fields.partition(field => tableRowType.containsField(field.name))
+      nonSyntheticFields.partition(field => tableRowType.containsField(field.name))
     val pruned =
       SparkTypeUtils.prunePaimonRowType(StructType(_requiredTableFields), tableRowType)
     val withVariants =
@@ -125,8 +134,11 @@ trait BaseScan extends Scan with SupportsReportStatistics with Logging {
   }
 
   override def readSchema(): StructType = {
+    val syntheticPresent =
+      leadingSyntheticColumns.filter(c => requiredSchema.fieldNames.contains(c.name))
     val _readSchema = StructType(
-      SparkTypeUtils.fromPaimonRowType(readTableRowType).fields ++ metadataFields)
+      syntheticPresent ++
+        SparkTypeUtils.fromPaimonRowType(readTableRowType).fields ++ metadataFields)
     if (!_readSchema.equals(requiredSchema)) {
       logInfo(
         s"Actual readSchema: ${_readSchema} is not equal to spark pushed requiredSchema: $requiredSchema")
@@ -134,10 +146,16 @@ trait BaseScan extends Scan with SupportsReportStatistics with Logging {
     _readSchema
   }
 
+  /**
+   * Input partitions fed to [[PaimonBatch]]. Defaults to [[inputPartitions]]; overridden by scans
+   * that produce tagged partitions (e.g. batch_vector_search emits per-query partitions).
+   */
+  protected def toBatchInputPartitions: Seq[PaimonInputPartition] = inputPartitions
+
   override def toBatch: Batch = {
     val metadataColumns = metadataFields.map(
       field => PaimonMetadataColumn.get(field.name, SparkTypeUtils.toSparkPartitionType(table)))
-    PaimonBatch(inputPartitions, readBuilder, coreOptions.blobAsDescriptor(), metadataColumns)
+    PaimonBatch(toBatchInputPartitions, readBuilder, coreOptions.blobAsDescriptor(), metadataColumns)
   }
 
   def estimateStatistics: Statistics = {

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/catalyst/plans/logical/VectorSearchQueryTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/catalyst/plans/logical/VectorSearchQueryTest.scala
@@ -293,6 +293,36 @@ class VectorSearchQueryTest extends AnyFunSuite {
     assert(vectorSearch.options().get("hnsw.ef_search") == "64")
   }
 
+  test("create batch vector search basic") {
+    val bvs = createBatchVectorSearch(
+      Literal("v"),
+      CreateArray(
+        Seq(
+          CreateArray(Seq(Literal(1.0f), Literal(2.0f))),
+          CreateArray(Seq(Literal(3.0f), Literal(4.0f))))),
+      Literal(5)
+    )
+    assert(bvs.vectorCount() == 2)
+    assert(bvs.fieldName() == "v")
+    assert(bvs.limit() == 5)
+    assert(bvs.vectors()(0).sameElements(Array(1.0f, 2.0f)))
+    assert(bvs.vectors()(1).sameElements(Array(3.0f, 4.0f)))
+  }
+
+  test("create batch vector search with options") {
+    val bvs = createBatchVectorSearch(
+      Literal("v"),
+      CreateArray(Seq(CreateArray(Seq(Literal(1.0f), Literal(2.0f))))),
+      Literal(3),
+      CreateMap(Seq(Literal("ivf.nprobe"), Literal("16")))
+    )
+    assert(bvs.vectorCount() == 1)
+    assert(bvs.options().get("ivf.nprobe") == "16")
+  }
+
+  private def createBatchVectorSearch(args: Expression*) =
+    BatchVectorSearchQuery(Seq.empty).createBatchVectorSearch(innerTable, args)
+
   private def createVectorSearch(args: Expression*) =
     VectorSearchQuery(Seq.empty).createVectorSearch(innerTable, args)
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
@@ -200,6 +200,72 @@ class LuminaVectorIndexTest extends PaimonSparkTestBase {
     }
   }
 
+  test("batch_vector_search - distributed raw search with a scalar pre-filter") {
+    withTable("T") {
+      spark.sql("""
+                  |CREATE TABLE T (id INT, v ARRAY<FLOAT>)
+                  |TBLPROPERTIES (
+                  |  'bucket' = '-1',
+                  |  'global-index.row-count-per-shard' = '10',
+                  |  'global-index.thread-num' = '2',
+                  |  'global-index.search-mode' = 'full',
+                  |  'vector-search.distribute.enabled' = 'true',
+                  |  'row-tracking.enabled' = 'true',
+                  |  'data-evolution.enabled' = 'true',
+                  |  'btree-index.records-per-range' = '20')
+                  |""".stripMargin)
+
+      def rowsOf(from: Int, until: Int): String =
+        (from until until)
+          .map(
+            i => s"($i, array(cast($i as float), cast(${i + 1} as float), cast(${i + 2} as float)))")
+          .mkString(",")
+
+      spark.sql(s"INSERT INTO T VALUES ${rowsOf(0, 100)}")
+      // The vector index covers only rows 0..99.
+      assert(
+        spark
+          .sql(
+            s"CALL sys.create_global_index(table => 'test.T', index_column => 'v', index_type => '$indexType', options => '$defaultOptions')")
+          .collect()
+          .head
+          .getBoolean(0))
+
+      // Rows 100..199 are un-indexed for the vector index -> searched via the raw path.
+      spark.sql(s"INSERT INTO T VALUES ${rowsOf(100, 200)}")
+      // The btree scalar index covers all rows (incl. the raw region), so a filter on id attaches
+      // a scalar index to the raw split and produces a non-null (broadcast) pre-filter.
+      assert(
+        spark
+          .sql(
+            "CALL sys.create_global_index(table => 'test.T', index_column => 'id', index_type => 'btree', options => 'btree-index.records-per-range=20')")
+          .collect()
+          .head
+          .getBoolean(0))
+
+      // id < 160 pushes down as a scalar pre-filter, so the distributed raw search runs with a
+      // non-null (broadcast) pre-filter. With a pre-filter the top-5 are drawn from ids < 160; a
+      // post-filter would instead drop the higher-scoring ids >= 160 and return fewer rows.
+      val batch = spark
+        .sql(
+          """
+            |SELECT * FROM batch_vector_search('T', 'v', array(array(150.0f, 151.0f, 152.0f)), 5)
+            |WHERE id < 160
+            |""".stripMargin)
+        .collect()
+      assert(batch.length == 5, s"expected 5 pre-filtered results, got ${batch.length}")
+      assert(batch.forall(_.getInt(1) < 160), s"pre-filter not applied: ${batch.map(_.getInt(1)).toSeq}")
+
+      val single = spark
+        .sql(
+          "SELECT id FROM vector_search('T', 'v', array(150.0f, 151.0f, 152.0f), 5) WHERE id < 160")
+        .collect()
+        .map(_.getInt(0))
+        .toSet
+      assert(batch.map(_.getInt(1)).toSet == single)
+    }
+  }
+
   test("create lumina vector index - legacy index type") {
     withTable("T") {
       spark.sql("""

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
@@ -69,6 +69,60 @@ class LuminaVectorIndexTest extends PaimonSparkTestBase {
     }
   }
 
+  test("batch_vector_search - multiple query vectors with query_index") {
+    withTable("T") {
+      spark.sql("""
+                  |CREATE TABLE T (id INT, v ARRAY<FLOAT>)
+                  |TBLPROPERTIES (
+                  |  'bucket' = '-1',
+                  |  'global-index.row-count-per-shard' = '10000',
+                  |  'row-tracking.enabled' = 'true',
+                  |  'data-evolution.enabled' = 'true')
+                  |""".stripMargin)
+
+      val values = (0 until 100)
+        .map(
+          i => s"($i, array(cast($i as float), cast(${i + 1} as float), cast(${i + 2} as float)))")
+        .mkString(",")
+      spark.sql(s"INSERT INTO T VALUES $values")
+
+      val created = spark
+        .sql(
+          s"CALL sys.create_global_index(table => 'test.T', index_column => 'v', index_type => '$indexType', options => '$defaultOptions')")
+        .collect()
+        .head
+      assert(created.getBoolean(0))
+
+      // Two query vectors, top-5 each => 10 rows tagged with query_index 0 and 1.
+      val batch = spark
+        .sql(
+          """
+            |SELECT * FROM batch_vector_search(
+            |  'T', 'v', array(array(10.0f, 11.0f, 12.0f), array(80.0f, 81.0f, 82.0f)), 5)
+            |""".stripMargin)
+        .collect()
+      assert(batch.length == 10)
+      assert(batch.count(_.getInt(0) == 0) == 5)
+      assert(batch.count(_.getInt(0) == 1) == 5)
+
+      // Each query_index group must equal the corresponding single vector_search result.
+      val single0 = spark
+        .sql("SELECT id FROM vector_search('T', 'v', array(10.0f, 11.0f, 12.0f), 5)")
+        .collect()
+        .map(_.getInt(0))
+        .toSet
+      val single1 = spark
+        .sql("SELECT id FROM vector_search('T', 'v', array(80.0f, 81.0f, 82.0f), 5)")
+        .collect()
+        .map(_.getInt(0))
+        .toSet
+      val batch0 = batch.filter(_.getInt(0) == 0).map(_.getInt(1)).toSet
+      val batch1 = batch.filter(_.getInt(0) == 1).map(_.getInt(1)).toSet
+      assert(batch0 == single0)
+      assert(batch1 == single1)
+    }
+  }
+
   test("create lumina vector index - legacy index type") {
     withTable("T") {
       spark.sql("""

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
@@ -123,26 +123,28 @@ class LuminaVectorIndexTest extends PaimonSparkTestBase {
     }
   }
 
-  test("batch_vector_search - distributed across index shards") {
+  test("batch_vector_search - distributed across index shards and raw splits") {
     withTable("T") {
       // Small shard size + small thread-num so the index splits exceed thread-num * 2 and the
       // distributed read (SparkBatchVectorReadImpl) actually fans out instead of running locally.
+      // search-mode = full enables searching un-indexed rows via the raw path.
       spark.sql("""
                   |CREATE TABLE T (id INT, v ARRAY<FLOAT>)
                   |TBLPROPERTIES (
                   |  'bucket' = '-1',
                   |  'global-index.row-count-per-shard' = '10',
                   |  'global-index.thread-num' = '2',
+                  |  'global-index.search-mode' = 'full',
                   |  'vector-search.distribute.enabled' = 'true',
                   |  'row-tracking.enabled' = 'true',
                   |  'data-evolution.enabled' = 'true')
                   |""".stripMargin)
 
-      val values = (0 until 100)
+      val indexed = (0 until 100)
         .map(
           i => s"($i, array(cast($i as float), cast(${i + 1} as float), cast(${i + 2} as float)))")
         .mkString(",")
-      spark.sql(s"INSERT INTO T VALUES $values")
+      spark.sql(s"INSERT INTO T VALUES $indexed")
 
       val created = spark
         .sql(
@@ -151,7 +153,7 @@ class LuminaVectorIndexTest extends PaimonSparkTestBase {
         .head
       assert(created.getBoolean(0))
 
-      // Distribution only kicks in when splits >= thread-num * 2 (= 4); assert we have enough shards.
+      // Index distribution only kicks in when splits >= thread-num * 2 (= 4).
       val shardCount = loadTable("T")
         .store()
         .newIndexFileHandler()
@@ -160,11 +162,19 @@ class LuminaVectorIndexTest extends PaimonSparkTestBase {
         .count(_.indexFile().indexType() == indexType)
       assert(shardCount >= 4, s"need >= 4 shards to exercise the distributed path, got $shardCount")
 
+      // Rows written after the index build are un-indexed and searched via the raw path. 100 raw
+      // rows >= thread-num * 2, so the raw search distributes too. Query 1 targets this region.
+      val raw = (100 until 200)
+        .map(
+          i => s"($i, array(cast($i as float), cast(${i + 1} as float), cast(${i + 2} as float)))")
+        .mkString(",")
+      spark.sql(s"INSERT INTO T VALUES $raw")
+
       val batch = spark
         .sql(
           """
             |SELECT * FROM batch_vector_search(
-            |  'T', 'v', array(array(10.0f, 11.0f, 12.0f), array(80.0f, 81.0f, 82.0f)), 5)
+            |  'T', 'v', array(array(10.0f, 11.0f, 12.0f), array(150.0f, 151.0f, 152.0f)), 5)
             |""".stripMargin)
         .collect()
       assert(batch.length == 10)
@@ -177,10 +187,12 @@ class LuminaVectorIndexTest extends PaimonSparkTestBase {
         .map(_.getInt(0))
         .toSet
       val single1 = spark
-        .sql("SELECT id FROM vector_search('T', 'v', array(80.0f, 81.0f, 82.0f), 5)")
+        .sql("SELECT id FROM vector_search('T', 'v', array(150.0f, 151.0f, 152.0f), 5)")
         .collect()
         .map(_.getInt(0))
         .toSet
+      // Query 1 must surface un-indexed ids, proving the (distributed) raw search ran.
+      assert(single1.exists(_ >= 100), s"raw search should surface un-indexed rows, got $single1")
       val batch0 = batch.filter(_.getInt(0) == 0).map(_.getInt(1)).toSet
       val batch1 = batch.filter(_.getInt(0) == 1).map(_.getInt(1)).toSet
       assert(batch0 == single0)

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
@@ -123,6 +123,71 @@ class LuminaVectorIndexTest extends PaimonSparkTestBase {
     }
   }
 
+  test("batch_vector_search - distributed across index shards") {
+    withTable("T") {
+      // Small shard size + small thread-num so the index splits exceed thread-num * 2 and the
+      // distributed read (SparkBatchVectorReadImpl) actually fans out instead of running locally.
+      spark.sql("""
+                  |CREATE TABLE T (id INT, v ARRAY<FLOAT>)
+                  |TBLPROPERTIES (
+                  |  'bucket' = '-1',
+                  |  'global-index.row-count-per-shard' = '10',
+                  |  'global-index.thread-num' = '2',
+                  |  'vector-search.distribute.enabled' = 'true',
+                  |  'row-tracking.enabled' = 'true',
+                  |  'data-evolution.enabled' = 'true')
+                  |""".stripMargin)
+
+      val values = (0 until 100)
+        .map(
+          i => s"($i, array(cast($i as float), cast(${i + 1} as float), cast(${i + 2} as float)))")
+        .mkString(",")
+      spark.sql(s"INSERT INTO T VALUES $values")
+
+      val created = spark
+        .sql(
+          s"CALL sys.create_global_index(table => 'test.T', index_column => 'v', index_type => '$indexType', options => '$defaultOptions')")
+        .collect()
+        .head
+      assert(created.getBoolean(0))
+
+      // Distribution only kicks in when splits >= thread-num * 2 (= 4); assert we have enough shards.
+      val shardCount = loadTable("T")
+        .store()
+        .newIndexFileHandler()
+        .scanEntries()
+        .asScala
+        .count(_.indexFile().indexType() == indexType)
+      assert(shardCount >= 4, s"need >= 4 shards to exercise the distributed path, got $shardCount")
+
+      val batch = spark
+        .sql(
+          """
+            |SELECT * FROM batch_vector_search(
+            |  'T', 'v', array(array(10.0f, 11.0f, 12.0f), array(80.0f, 81.0f, 82.0f)), 5)
+            |""".stripMargin)
+        .collect()
+      assert(batch.length == 10)
+      assert(batch.count(_.getInt(0) == 0) == 5)
+      assert(batch.count(_.getInt(0) == 1) == 5)
+
+      val single0 = spark
+        .sql("SELECT id FROM vector_search('T', 'v', array(10.0f, 11.0f, 12.0f), 5)")
+        .collect()
+        .map(_.getInt(0))
+        .toSet
+      val single1 = spark
+        .sql("SELECT id FROM vector_search('T', 'v', array(80.0f, 81.0f, 82.0f), 5)")
+        .collect()
+        .map(_.getInt(0))
+        .toSet
+      val batch0 = batch.filter(_.getInt(0) == 0).map(_.getInt(1)).toSet
+      val batch1 = batch.filter(_.getInt(0) == 1).map(_.getInt(1)).toSet
+      assert(batch0 == single0)
+      assert(batch1 == single1)
+    }
+  }
+
   test("create lumina vector index - legacy index type") {
     withTable("T") {
       spark.sql("""


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ANN search correctness (multi-query merge, distributed raw/index paths, and filter alignment with synthetic `query_index`); mistakes could return wrong neighbors or mis-apply predicates, though behavior is covered by new integration tests.
> 
> **Overview**
> Adds Spark SQL **`batch_vector_search`**, a table-valued function that runs top-k ANN for many query vectors in one call. Results include a leading synthetic **`query_index`** column so rows can be tied back to the *i*-th input vector; the scan runs one batch search, builds per-query splits, and readers inject the index via **`PaimonQueryIndexedInputPartition`**.
> 
> When **`vector-search.distribute.enabled`** is set, batch search uses **`SparkBatchVectorReadImpl`** to fan out index-shard and raw (un-indexed) evaluation on the cluster (same **`2 × global-index.thread-num`** threshold as single-vector search), merging partial top-k per query on the driver. Predicate pushdown on batch searches maps filters to the **origin** table schema so columns are not shifted by `query_index`.
> 
> **`SparkVectorReads`** centralizes split serialization/grouping for distributed reads; single-vector **`SparkVectorReadImpl`** now **broadcasts** shared raw-search pre-filters instead of shipping them per task. Docs cover the new TVF and distribute option; integration tests cover multi-query correctness, distributed index/raw paths, and pre-filter pushdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2a27db42cee66fd4fc53b78d50a57ef42aee29e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->