### PR TITLE
Support bucket join

### DIFF
--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -339,6 +339,54 @@ table_write = (
 table_write.write_ray(ray_dataset)
 ```
 
+## Bucket Join
+
+`bucket_join` joins two **co-bucketed** tables (same bucket count and the same
+bucket-key) on the bucket-key, with **no global shuffle**: the same key lands in
+the same bucket on both sides, so each bucket is read and joined in its own Ray
+task. It returns a `ray.data.Dataset` whose results stay distributed (never
+pulled into the driver).
+
+A common use is looking up a global `_ROW_ID` for a batch of keys without a
+shuffle join against a large table: keep a small co-bucketed `(key, _ROW_ID)`
+side table, `bucket_join` the incoming keys against it, then feed the resulting
+row ids into a row-id update.
+
+```python
+from pypaimon.ray import bucket_join
+
+ds = bucket_join(
+    left="database_name.incoming_keys",   # co-bucketed table identifier
+    right="database_name.key_rowid",       # co-bucketed table identifier
+    catalog_options={"warehouse": "/path/to/warehouse"},
+    on="url",                              # must equal the bucket-key
+    left_projection=["url"],               # optional; must keep the join key
+    right_projection=["url", "row_id"],    # optional; must keep the join key
+)
+# ds: ray.data.Dataset of the joined rows, e.g. {"url": ..., "row_id": ...}
+```
+
+**Parameters:**
+- `left` / `right`: identifiers of the two co-bucketed tables to join.
+- `on`: the join key(s). Must be exactly the bucket-key — equal keys only
+  co-locate by bucket when joining on the bucket-key.
+- `left_projection` / `right_projection`: optional column projections applied on
+  read. If given, each must include the join key.
+- `join_type`: only `"inner"` is supported (an outer join would need the union
+  of buckets, which per-bucket intersection cannot produce).
+- `ray_remote_args`: Ray remote options applied to each per-bucket join task.
+
+**Returns:** a `ray.data.Dataset` of the joined rows.
+
+**Notes:**
+- Both tables must be fixed-bucket (`bucket > 0`) with the same bucket count and
+  the same bucket-key; otherwise `bucket_join` raises. For primary-key tables
+  that do not set `bucket-key` explicitly, the bucket-key resolves to the
+  (partition-trimmed) primary key.
+- The two sides must not share columns other than the join key, or the
+  underlying pyarrow join would collide; project or rename them away first.
+- Partitioned tables are not supported yet (bucket ids are per-partition).
+
 ## Merge Into
 
 `merge_into` updates (and optionally inserts) rows of a **data-evolution** table

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -380,11 +380,15 @@ ds = bucket_join(
 
 **Notes:**
 - Both tables must be fixed-bucket (`bucket > 0`) with the same bucket count and
-  the same bucket-key; otherwise `bucket_join` raises. For primary-key tables
-  that do not set `bucket-key` explicitly, the bucket-key resolves to the
-  (partition-trimmed) primary key.
+  the same bucket-key (same column names, order, and types); otherwise
+  `bucket_join` raises. For primary-key tables that do not set `bucket-key`
+  explicitly, the bucket-key resolves to the (partition-trimmed) primary key.
 - The two sides must not share columns other than the join key, or the
-  underlying pyarrow join would collide; project or rename them away first.
+  underlying pyarrow join would collide; project them away with
+  `left_projection` / `right_projection` first.
+- Each side is planned at its own latest snapshot, and one bucket is joined by a
+  single Ray task that reads the whole bucket into memory. Choose a bucket count
+  that spreads keys evenly to avoid skewed, memory-heavy tasks.
 - Partitioned tables are not supported yet (bucket ids are per-partition).
 
 ## Merge Into

--- a/paimon-python/pypaimon/ray/__init__.py
+++ b/paimon-python/pypaimon/ray/__init__.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from pypaimon.ray.ray_paimon import read_paimon, write_paimon
+from pypaimon.ray.bucket_join import bucket_join
 from pypaimon.ray.data_evolution_merge_into import (
     WhenMatched,
     WhenNotMatched,
@@ -30,6 +31,7 @@ from pypaimon.ray.data_evolution_merge_transform import (
 __all__ = [
     "read_paimon",
     "write_paimon",
+    "bucket_join",
     "merge_into",
     "WhenMatched",
     "WhenNotMatched",

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -33,9 +33,10 @@ def _norm(on: OnSpec) -> List[str]:
 
 
 def _bucketing(table):
-    count = table.options.bucket()
-    key = table.options.bucket_key()
-    return count, ([k.strip() for k in key.split(",")] if key else [])
+    # Use the resolved bucket keys, not the raw ``bucket-key`` option: a primary-key
+    # table that does not set ``bucket-key`` explicitly is still bucketed by its
+    # (partition-trimmed) primary key, and reading the raw option would miss that.
+    return table.options.bucket(), list(table.table_schema.bucket_keys)
 
 
 # Per-process table cache so a worker reuses table metadata across the many buckets
@@ -121,6 +122,23 @@ def bucket_join(
         # Outer joins would need the union of buckets (a bucket missing on one side
         # still emits rows); only inner is correct with the per-bucket intersection.
         raise ValueError(f"bucket_join currently supports only join_type='inner'; got {join_type!r}.")
+
+    # The join key must survive projection on both sides, or ``Table.join`` has no key.
+    if left_projection is not None and not set(on_cols) <= set(left_projection):
+        raise ValueError(
+            f"left_projection must include the join key {on_cols}; got {left_projection}.")
+    if right_projection is not None and not set(on_cols) <= set(right_projection):
+        raise ValueError(
+            f"right_projection must include the join key {on_cols}; got {right_projection}.")
+    # The two sides must not share non-key columns, or pyarrow's join collides on them.
+    # Check up front (against the projected columns) instead of failing inside a task.
+    lcols = left_projection if left_projection is not None else ltable.field_names
+    rcols = right_projection if right_projection is not None else rtable.field_names
+    collisions = sorted((set(lcols) & set(rcols)) - set(on_cols))
+    if collisions:
+        raise ValueError(
+            f"bucket_join sides must not share columns other than the join key {on_cols}; "
+            f"both have {collisions}. Project or rename them away.")
 
     # Plan each side's manifest once (driver-side, split metadata only -- the join
     # results stay distributed below), then dispatch per-bucket splits to the tasks.

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -33,6 +33,11 @@ def _norm(on: OnSpec) -> List[str]:
     return [on] if isinstance(on, str) else list(on)
 
 
+def _key_type(table, col):
+    # Logical type without nullability -- a present key hashes the same either way.
+    return str(table.field_dict[col].type).replace(" NOT NULL", "")
+
+
 def _bucketing(table):
     # Resolved bucket keys (a PK table without an explicit bucket-key buckets by its
     # trimmed primary key) plus the bucket function: same key co-locates only under both.
@@ -154,10 +159,7 @@ def bucket_join(
             "Equal keys only co-locate by bucket when joining on the bucket-key "
             "(the comparison is order-sensitive for composite keys).")
     # Same name isn't enough: differing key types (INT vs BIGINT) can hash apart and
-    # silently drop matches. Compare logical types, ignoring nullability (it doesn't
-    # affect the hash of a present key).
-    def _key_type(table, col):
-        return str(table.field_dict[col].type).replace(" NOT NULL", "")
+    # silently drop matches (types compared without nullability).
     key_type_mismatch = [
         (c, _key_type(ltable, c), _key_type(rtable, c))
         for c in on_cols

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -15,13 +15,10 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-"""Bucket-aligned join on Ray for two fixed-bucket (HASH_FIXED) Paimon tables.
+"""Bucket-aligned join on Ray for two co-bucketed Paimon tables.
 
-Both tables must share the same bucket count and bucket-key, and the join key must
-be the bucket-key, so equal keys land in the same bucket on both sides. Each bucket
-is read and joined locally in its own Ray task -- no global shuffle. This is the
-no-shuffle alternative to ``ray.data.join`` for co-bucketed tables (e.g. a
-``url -> row_id`` locator table joined with a per-task input table).
+Same key -> same bucket on both sides, so each bucket is read and joined in its own
+Ray task with no global shuffle -- the no-shuffle alternative to ``ray.data.join``.
 """
 
 from typing import Any, Dict, List, Optional, Sequence, Union
@@ -70,19 +67,9 @@ def bucket_join(
     join_type: str = "inner",
     ray_remote_args: Optional[Dict[str, Any]] = None,
 ) -> "ray.data.Dataset":
-    """Join two co-bucketed Paimon tables without a global shuffle.
-
-    Args:
-        left, right: table identifiers, e.g. ``"db.input"`` / ``"db.locator"``.
-        catalog_options: options passed to ``CatalogFactory.create()``.
-        on: join key column(s); must equal the tables' bucket-key.
-        left_projection, right_projection: optional column projections per side.
-        join_type: pyarrow join type (default ``"inner"``).
-        ray_remote_args: optional kwargs for the per-bucket ``ray.remote`` tasks.
-
-    Returns:
-        A ``ray.data.Dataset`` of joined rows.
-    """
+    """Join two co-bucketed tables (same bucket count + bucket-key, joined on the
+    bucket-key) with no global shuffle. ``on`` must equal the bucket-key. Returns a
+    ``ray.data.Dataset``."""
     import ray
     from pypaimon.catalog.catalog_factory import CatalogFactory
 

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -21,6 +21,7 @@ Same key -> same bucket on both sides, so each bucket is read and joined in its 
 Ray task with no global shuffle -- the no-shuffle alternative to ``ray.data.join``.
 """
 
+import threading
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 __all__ = ["bucket_join"]
@@ -33,30 +34,33 @@ def _norm(on: OnSpec) -> List[str]:
 
 
 def _bucketing(table):
-    # Use the resolved bucket keys, not the raw ``bucket-key`` option: a primary-key
-    # table that does not set ``bucket-key`` explicitly is still bucketed by its
-    # (partition-trimmed) primary key, and reading the raw option would miss that.
-    return table.options.bucket(), list(table.table_schema.bucket_keys)
+    # Resolved bucket keys (a PK table without an explicit bucket-key buckets by its
+    # trimmed primary key) plus the bucket function: same key co-locates only under both.
+    return (table.options.bucket(),
+            list(table.table_schema.bucket_keys),
+            table.table_schema.options.get("bucket-function.type", "default"))
 
 
-# Per-process table cache so a worker reuses table metadata across the many buckets
-# it runs, instead of reloading the catalog per bucket. Only used when reading given
-# splits (snapshot-independent); planning always loads a fresh table.
+# Per-worker table cache, keyed by schema id (so a schema change invalidates it) and
+# lock-guarded against concurrent tasks. Planning always loads a fresh table.
 _TABLE_CACHE: Dict = {}
+_TABLE_CACHE_LOCK = threading.Lock()
 
 
-def _get_table(table_id, catalog_options, use_cache):
+def _get_table(table_id, catalog_options, cache_key=None):
     from pypaimon.catalog.catalog_factory import CatalogFactory
-    if not use_cache:
+    if cache_key is None:
         return CatalogFactory.create(catalog_options).get_table(table_id)
-    key = (table_id, tuple(sorted(catalog_options.items())))
-    if key not in _TABLE_CACHE:
-        _TABLE_CACHE[key] = CatalogFactory.create(catalog_options).get_table(table_id)
-    return _TABLE_CACHE[key]
+    with _TABLE_CACHE_LOCK:
+        table = _TABLE_CACHE.get(cache_key)
+        if table is None:
+            table = CatalogFactory.create(catalog_options).get_table(table_id)
+            _TABLE_CACHE[cache_key] = table
+        return table
 
 
-def _read_builder(table_id, catalog_options, projection, use_cache=False):
-    rb = _get_table(table_id, catalog_options, use_cache).new_read_builder()
+def _read_builder(table_id, catalog_options, projection, cache_key=None):
+    rb = _get_table(table_id, catalog_options, cache_key).new_read_builder()
     return rb.with_projection(projection) if projection is not None else rb
 
 
@@ -68,9 +72,11 @@ def _plan_splits_by_bucket(table_id, catalog_options, projection):
     return by_bucket
 
 
-def _read_splits(table_id, catalog_options, projection, splits):
-    # Reading given splits is snapshot-independent, so the cached table is safe here.
-    return _read_builder(table_id, catalog_options, projection, use_cache=True).new_read().to_arrow(splits)
+def _read_splits(table_id, catalog_options, projection, splits, schema_id):
+    # Snapshot-independent but schema-dependent: cache by schema id, not just table id.
+    cache_key = (table_id, tuple(sorted(catalog_options.items())), schema_id)
+    return _read_builder(
+        table_id, catalog_options, projection, cache_key).new_read().to_arrow(splits)
 
 
 def bucket_join(
@@ -94,8 +100,8 @@ def bucket_join(
     on_cols = _norm(on)
     cat = CatalogFactory.create(catalog_options)
     ltable, rtable = cat.get_table(left), cat.get_table(right)
-    lcount, lkey = _bucketing(ltable)
-    rcount, rkey = _bucketing(rtable)
+    lcount, lkey, lfunc = _bucketing(ltable)
+    rcount, rkey, rfunc = _bucketing(rtable)
 
     if ltable.partition_keys or rtable.partition_keys:
         # Bucket numbers are per-partition, so the same bucket id lives in every
@@ -114,10 +120,26 @@ def bucket_join(
     if lkey != rkey:
         raise ValueError(
             f"bucket_join requires the same bucket-key; {left}={lkey}, {right}={rkey}.")
+    if lfunc != rfunc:
+        # Different bucket functions hash the same key to different buckets.
+        raise ValueError(
+            f"bucket_join requires the same bucket-function.type; {left}={lfunc}, {right}={rfunc}.")
     if on_cols != lkey:
         raise ValueError(
             f"bucket_join requires the join key to be the bucket-key {lkey}; got on={on_cols}. "
-            "Equal keys only co-locate by bucket when joining on the bucket-key.")
+            "Equal keys only co-locate by bucket when joining on the bucket-key "
+            "(the comparison is order-sensitive for composite keys).")
+    # Same name isn't enough: differing key types (INT vs BIGINT) can hash apart and
+    # silently drop matches, since the bucket is hash(key) %% bucket_count.
+    key_type_mismatch = [
+        (c, str(ltable.field_dict[c].type), str(rtable.field_dict[c].type))
+        for c in on_cols
+        if str(ltable.field_dict[c].type) != str(rtable.field_dict[c].type)
+    ]
+    if key_type_mismatch:
+        raise ValueError(
+            "bucket_join requires the bucket-key columns to have the same type on both "
+            f"sides; mismatched (column, left, right): {key_type_mismatch}.")
     if join_type != "inner":
         # Outer joins would need the union of buckets (a bucket missing on one side
         # still emits rows); only inner is correct with the per-bucket intersection.
@@ -145,9 +167,11 @@ def bucket_join(
     left_by_bucket = _plan_splits_by_bucket(left, catalog_options, left_projection)
     right_by_bucket = _plan_splits_by_bucket(right, catalog_options, right_projection)
 
+    l_schema_id, r_schema_id = ltable.table_schema.id, rtable.table_schema.id
+
     def _join_bucket(left_splits, right_splits):
-        left_t = _read_splits(left, catalog_options, left_projection, left_splits)
-        right_t = _read_splits(right, catalog_options, right_projection, right_splits)
+        left_t = _read_splits(left, catalog_options, left_projection, left_splits, l_schema_id)
+        right_t = _read_splits(right, catalog_options, right_projection, right_splits, r_schema_id)
         return left_t.join(right_t, keys=on_cols, join_type=join_type)
 
     # ``@ray.remote()`` (empty parens) is rejected by Ray, so wrap conditionally.
@@ -156,8 +180,8 @@ def bucket_join(
     buckets = sorted(set(left_by_bucket) & set(right_by_bucket))
     if not buckets:
         # No shared bucket: empty result, but keep the join schema (join two empties).
-        empty = _read_splits(left, catalog_options, left_projection, []).join(
-            _read_splits(right, catalog_options, right_projection, []),
+        empty = _read_splits(left, catalog_options, left_projection, [], l_schema_id).join(
+            _read_splits(right, catalog_options, right_projection, [], r_schema_id),
             keys=on_cols, join_type=join_type)
         return ray.data.from_arrow(empty)
     # Keep each bucket's result as a distributed object ref -- never pulled into the driver.

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -77,12 +77,18 @@ def _read_builder(table_id, catalog_options, projection, schema_id=None):
 
 
 def _plan_splits_by_bucket(table_id, catalog_options, projection, expected_total_buckets):
-    """Plan the manifest and group splits by bucket (driver-side)."""
+    """Plan the manifest and group splits by bucket (driver-side).
+
+    Returns ``(by_bucket, schema_id)``: the schema id of the table instance that
+    built this plan, so workers validate against the schema the plan was made with
+    (not a possibly-newer one loaded earlier by the caller).
+    """
     from pypaimon.common.options.core_options import CoreOptions
     table = _get_table(table_id, catalog_options)  # fresh, latest schema
+    schema_id = table.table_schema.id
     snapshot = table.snapshot_manager().get_latest_snapshot()
     if snapshot is None:
-        return {}
+        return {}, schema_id
     # Pin the guard and the split plan to one snapshot, else a commit between the two
     # manifest reads could slip stale-bucket files past the guard.
     table.options.options.set(CoreOptions.SCAN_SNAPSHOT_ID, snapshot.id)
@@ -99,7 +105,7 @@ def _plan_splits_by_bucket(table_id, catalog_options, projection, expected_total
     by_bucket = {}
     for s in scan.plan().splits():
         by_bucket.setdefault(s.bucket, []).append(s)
-    return by_bucket
+    return by_bucket, schema_id
 
 
 def _read_splits(table_id, catalog_options, projection, splits, schema_id):
@@ -193,10 +199,10 @@ def bucket_join(
 
     # Plan each side's manifest once (driver-side, split metadata only -- the join
     # results stay distributed below), then dispatch per-bucket splits to the tasks.
-    left_by_bucket = _plan_splits_by_bucket(left, catalog_options, left_projection, lcount)
-    right_by_bucket = _plan_splits_by_bucket(right, catalog_options, right_projection, rcount)
-
-    l_schema_id, r_schema_id = ltable.table_schema.id, rtable.table_schema.id
+    left_by_bucket, l_schema_id = _plan_splits_by_bucket(
+        left, catalog_options, left_projection, lcount)
+    right_by_bucket, r_schema_id = _plan_splits_by_bucket(
+        right, catalog_options, right_projection, rcount)
 
     def _join_bucket(left_splits, right_splits):
         left_t = _read_splits(left, catalog_options, left_projection, left_splits, l_schema_id)

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -92,6 +92,10 @@ def bucket_join(
         raise ValueError(
             f"bucket_join requires the join key to be the bucket-key {lkey}; got on={on_cols}. "
             "Equal keys only co-locate by bucket when joining on the bucket-key.")
+    if join_type != "inner":
+        # Outer joins would need the union of buckets (a bucket missing on one side
+        # still emits rows); only inner is correct with the per-bucket intersection.
+        raise ValueError(f"bucket_join currently supports only join_type='inner'; got {join_type!r}.")
 
     # Plan each side's manifest once, then dispatch per-bucket splits to the tasks.
     left_by_bucket = _plan_splits_by_bucket(left, catalog_options, left_projection)
@@ -100,16 +104,14 @@ def bucket_join(
     def _join_bucket(left_splits, right_splits):
         left_t = _read_splits(left, catalog_options, left_projection, left_splits)
         right_t = _read_splits(right, catalog_options, right_projection, right_splits)
-        if left_t.num_rows == 0 or right_t.num_rows == 0:
-            return None
         return left_t.join(right_t, keys=on_cols, join_type=join_type)
 
     # ``@ray.remote()`` (empty parens) is rejected by Ray, so wrap conditionally.
     remote_fn = ray.remote(**ray_remote_args)(_join_bucket) if ray_remote_args else ray.remote(_join_bucket)
-    # Inner join: only buckets present on both sides can contribute matches.
+    # Inner join: only buckets present on both sides can match.
     buckets = sorted(set(left_by_bucket) & set(right_by_bucket))
-    refs = [remote_fn.remote(left_by_bucket[b], right_by_bucket[b]) for b in buckets]
-    parts = [p for p in ray.get(refs) if p is not None and p.num_rows > 0]
-    if not parts:
+    if not buckets:
         return ray.data.from_items([])
-    return ray.data.from_arrow(parts)
+    # Keep each bucket's result as a distributed object ref -- never pulled into the driver.
+    refs = [remote_fn.remote(left_by_bucket[b], right_by_bucket[b]) for b in buckets]
+    return ray.data.from_arrow_refs(refs)

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -90,8 +90,17 @@ def _plan_splits_by_bucket(table_id, catalog_options, projection, expected_total
     if snapshot is None:
         return {}, schema_id
     # Pin the guard and the split plan to one snapshot, else a commit between the two
-    # manifest reads could slip stale-bucket files past the guard.
-    table.options.options.set(CoreOptions.SCAN_SNAPSHOT_ID, snapshot.id)
+    # manifest reads could slip stale-bucket files past the guard. Drop any existing
+    # scan.mode / point-in-time options first so snapshot-id doesn't clash with them.
+    opts = table.options.options
+    for key in (CoreOptions.SCAN_MODE, CoreOptions.SCAN_SNAPSHOT_ID,
+                CoreOptions.SCAN_TAG_NAME, CoreOptions.SCAN_WATERMARK,
+                CoreOptions.SCAN_TIMESTAMP, CoreOptions.SCAN_TIMESTAMP_MILLIS,
+                CoreOptions.INCREMENTAL_BETWEEN_TIMESTAMP,
+                CoreOptions.SCAN_FILE_CREATION_TIME_MILLIS,
+                CoreOptions.SCAN_CREATION_TIME_MILLIS):
+        opts.data.pop(key.key(), None)
+    opts.set(CoreOptions.SCAN_SNAPSHOT_ID, snapshot.id)
     rb = table.new_read_builder()
     scan = (rb.with_projection(projection) if projection is not None else rb).new_scan()
     # Splits carry only ``bucket``; a rescaled table (old files under a different

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -64,10 +64,19 @@ def _read_builder(table_id, catalog_options, projection, cache_key=None):
     return rb.with_projection(projection) if projection is not None else rb
 
 
-def _plan_splits_by_bucket(table_id, catalog_options, projection):
+def _plan_splits_by_bucket(table_id, catalog_options, projection, expected_total_buckets):
     """Plan the manifest once and group splits by bucket (driver-side, fresh snapshot)."""
+    scan = _read_builder(table_id, catalog_options, projection).new_scan()
+    # Splits carry only ``bucket``; a rescaled table (old files under a different
+    # total_buckets) would falsely co-locate. Reject files outside the current space.
+    stale = {e.total_buckets for e in scan.file_scanner.plan_files()
+             if e.total_buckets != expected_total_buckets}
+    if stale:
+        raise ValueError(
+            f"bucket_join needs {table_id} fully in bucket count {expected_total_buckets}, "
+            f"but files exist under {sorted(stale)} (rescale in progress); rewrite first.")
     by_bucket = {}
-    for s in _read_builder(table_id, catalog_options, projection).new_scan().plan().splits():
+    for s in scan.plan().splits():
         by_bucket.setdefault(s.bucket, []).append(s)
     return by_bucket
 
@@ -130,11 +139,14 @@ def bucket_join(
             "Equal keys only co-locate by bucket when joining on the bucket-key "
             "(the comparison is order-sensitive for composite keys).")
     # Same name isn't enough: differing key types (INT vs BIGINT) can hash apart and
-    # silently drop matches, since the bucket is hash(key) %% bucket_count.
+    # silently drop matches. Compare logical types, ignoring nullability (it doesn't
+    # affect the hash of a present key).
+    def _key_type(table, col):
+        return str(table.field_dict[col].type).replace(" NOT NULL", "")
     key_type_mismatch = [
-        (c, str(ltable.field_dict[c].type), str(rtable.field_dict[c].type))
+        (c, _key_type(ltable, c), _key_type(rtable, c))
         for c in on_cols
-        if str(ltable.field_dict[c].type) != str(rtable.field_dict[c].type)
+        if _key_type(ltable, c) != _key_type(rtable, c)
     ]
     if key_type_mismatch:
         raise ValueError(
@@ -164,8 +176,8 @@ def bucket_join(
 
     # Plan each side's manifest once (driver-side, split metadata only -- the join
     # results stay distributed below), then dispatch per-bucket splits to the tasks.
-    left_by_bucket = _plan_splits_by_bucket(left, catalog_options, left_projection)
-    right_by_bucket = _plan_splits_by_bucket(right, catalog_options, right_projection)
+    left_by_bucket = _plan_splits_by_bucket(left, catalog_options, left_projection, lcount)
+    right_by_bucket = _plan_splits_by_bucket(right, catalog_options, right_projection, rcount)
 
     l_schema_id, r_schema_id = ltable.table_schema.id, rtable.table_schema.id
 

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -47,26 +47,42 @@ _TABLE_CACHE: Dict = {}
 _TABLE_CACHE_LOCK = threading.Lock()
 
 
-def _get_table(table_id, catalog_options, cache_key=None):
+def _get_table(table_id, catalog_options, schema_id=None):
     from pypaimon.catalog.catalog_factory import CatalogFactory
-    if cache_key is None:
+    if schema_id is None:  # planning: always load the latest schema
         return CatalogFactory.create(catalog_options).get_table(table_id)
+    key = (table_id, tuple(sorted(catalog_options.items())), schema_id)
     with _TABLE_CACHE_LOCK:
-        table = _TABLE_CACHE.get(cache_key)
+        table = _TABLE_CACHE.get(key)
         if table is None:
             table = CatalogFactory.create(catalog_options).get_table(table_id)
-            _TABLE_CACHE[cache_key] = table
+            if table.table_schema.id != schema_id:
+                # get_table loads the latest schema; a mismatch means the schema moved
+                # after the driver planned, so the split plan is stale -- fail fast.
+                raise ValueError(
+                    f"{table_id} schema changed during bucket_join (planned {schema_id}, "
+                    f"now {table.table_schema.id}); retry.")
+            _TABLE_CACHE[key] = table
         return table
 
 
-def _read_builder(table_id, catalog_options, projection, cache_key=None):
-    rb = _get_table(table_id, catalog_options, cache_key).new_read_builder()
+def _read_builder(table_id, catalog_options, projection, schema_id=None):
+    rb = _get_table(table_id, catalog_options, schema_id).new_read_builder()
     return rb.with_projection(projection) if projection is not None else rb
 
 
 def _plan_splits_by_bucket(table_id, catalog_options, projection, expected_total_buckets):
-    """Plan the manifest once and group splits by bucket (driver-side, fresh snapshot)."""
-    scan = _read_builder(table_id, catalog_options, projection).new_scan()
+    """Plan the manifest and group splits by bucket (driver-side)."""
+    from pypaimon.common.options.core_options import CoreOptions
+    table = _get_table(table_id, catalog_options)  # fresh, latest schema
+    snapshot = table.snapshot_manager().get_latest_snapshot()
+    if snapshot is None:
+        return {}
+    # Pin the guard and the split plan to one snapshot, else a commit between the two
+    # manifest reads could slip stale-bucket files past the guard.
+    table.options.options.set(CoreOptions.SCAN_SNAPSHOT_ID, snapshot.id)
+    rb = table.new_read_builder()
+    scan = (rb.with_projection(projection) if projection is not None else rb).new_scan()
     # Splits carry only ``bucket``; a rescaled table (old files under a different
     # total_buckets) would falsely co-locate. Reject files outside the current space.
     stale = {e.total_buckets for e in scan.file_scanner.plan_files()
@@ -82,10 +98,9 @@ def _plan_splits_by_bucket(table_id, catalog_options, projection, expected_total
 
 
 def _read_splits(table_id, catalog_options, projection, splits, schema_id):
-    # Snapshot-independent but schema-dependent: cache by schema id, not just table id.
-    cache_key = (table_id, tuple(sorted(catalog_options.items())), schema_id)
+    # Snapshot-independent but schema-dependent -> cache by schema id (in _get_table).
     return _read_builder(
-        table_id, catalog_options, projection, cache_key).new_read().to_arrow(splits)
+        table_id, catalog_options, projection, schema_id).new_read().to_arrow(splits)
 
 
 def bucket_join(

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -1,0 +1,118 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+"""Bucket-aligned join on Ray for two fixed-bucket (HASH_FIXED) Paimon tables.
+
+Both tables must share the same bucket count and bucket-key, and the join key must
+be the bucket-key, so equal keys land in the same bucket on both sides. Each bucket
+is read and joined locally in its own Ray task -- no global shuffle. This is the
+no-shuffle alternative to ``ray.data.join`` for co-bucketed tables (e.g. a
+``url -> row_id`` locator table joined with a per-task input table).
+"""
+
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+__all__ = ["bucket_join"]
+
+OnSpec = Union[str, Sequence[str]]
+
+
+def _norm(on: OnSpec) -> List[str]:
+    return [on] if isinstance(on, str) else list(on)
+
+
+def _bucketing(table):
+    count = table.options.bucket()
+    key = table.options.bucket_key()
+    return count, ([k.strip() for k in key.split(",")] if key else [])
+
+
+def _read_bucket(table_id, catalog_options, projection, bucket):
+    from pypaimon.catalog.catalog_factory import CatalogFactory
+    cat = CatalogFactory.create(catalog_options)
+    t = cat.get_table(table_id)
+    rb = t.new_read_builder()
+    if projection is not None:
+        rb = rb.with_projection(projection)
+    rd = rb.new_read()
+    # TODO(perf): plan once in the driver and dispatch per-bucket splits, instead
+    # of re-planning the manifest in every bucket task.
+    splits = [s for s in rb.new_scan().plan().splits() if s.bucket == bucket]
+    return rd.to_arrow(splits) if splits else None
+
+
+def bucket_join(
+    left: str,
+    right: str,
+    catalog_options: Dict[str, str],
+    *,
+    on: OnSpec,
+    left_projection: Optional[List[str]] = None,
+    right_projection: Optional[List[str]] = None,
+    join_type: str = "inner",
+    ray_remote_args: Optional[Dict[str, Any]] = None,
+) -> "ray.data.Dataset":
+    """Join two co-bucketed Paimon tables without a global shuffle.
+
+    Args:
+        left, right: table identifiers, e.g. ``"db.input"`` / ``"db.locator"``.
+        catalog_options: options passed to ``CatalogFactory.create()``.
+        on: join key column(s); must equal the tables' bucket-key.
+        left_projection, right_projection: optional column projections per side.
+        join_type: pyarrow join type (default ``"inner"``).
+        ray_remote_args: optional kwargs for the per-bucket ``ray.remote`` tasks.
+
+    Returns:
+        A ``ray.data.Dataset`` of joined rows.
+    """
+    import ray
+    from pypaimon.catalog.catalog_factory import CatalogFactory
+
+    on_cols = _norm(on)
+    cat = CatalogFactory.create(catalog_options)
+    lcount, lkey = _bucketing(cat.get_table(left))
+    rcount, rkey = _bucketing(cat.get_table(right))
+
+    if not lcount or lcount <= 0 or not rcount or rcount <= 0:
+        raise ValueError(
+            "bucket_join requires both tables to be fixed-bucket (bucket > 0); "
+            f"got {left}={lcount}, {right}={rcount}.")
+    if lcount != rcount:
+        raise ValueError(
+            f"bucket_join requires the same bucket count; {left}={lcount}, {right}={rcount}.")
+    if lkey != rkey:
+        raise ValueError(
+            f"bucket_join requires the same bucket-key; {left}={lkey}, {right}={rkey}.")
+    if on_cols != lkey:
+        raise ValueError(
+            f"bucket_join requires the join key to be the bucket-key {lkey}; got on={on_cols}. "
+            "Equal keys only co-locate by bucket when joining on the bucket-key.")
+
+    def _join_bucket(bucket):
+        left_t = _read_bucket(left, catalog_options, left_projection, bucket)
+        right_t = _read_bucket(right, catalog_options, right_projection, bucket)
+        if left_t is None or right_t is None or left_t.num_rows == 0 or right_t.num_rows == 0:
+            return None
+        return left_t.join(right_t, keys=on_cols, join_type=join_type)
+
+    # ``@ray.remote()`` (empty parens) is rejected by Ray, so wrap conditionally.
+    remote_fn = ray.remote(**ray_remote_args)(_join_bucket) if ray_remote_args else ray.remote(_join_bucket)
+    parts = [p for p in ray.get([remote_fn.remote(b) for b in range(lcount)])
+             if p is not None and p.num_rows > 0]
+    if not parts:
+        return ray.data.from_items([])
+    return ray.data.from_arrow(parts)

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -103,14 +103,17 @@ def _plan_splits_by_bucket(table_id, catalog_options, projection, expected_total
     opts.set(CoreOptions.SCAN_SNAPSHOT_ID, snapshot.id)
     rb = table.new_read_builder()
     scan = (rb.with_projection(projection) if projection is not None else rb).new_scan()
-    # Splits carry only ``bucket``; a rescaled table (old files under a different
-    # total_buckets) would falsely co-locate. Reject files outside the current space.
-    stale = {e.total_buckets for e in scan.file_scanner.plan_files()
-             if e.total_buckets != expected_total_buckets}
+    # Guard against a rescaled table (old files under a different total_buckets, which
+    # splits -- bucket only -- can't tell apart); read the entries once for it.
+    fs = scan.file_scanner
+    entries = fs.plan_files()
+    stale = {e.total_buckets for e in entries if e.total_buckets != expected_total_buckets}
     if stale:
         raise ValueError(
             f"bucket_join needs {table_id} fully in bucket count {expected_total_buckets}, "
             f"but files exist under {sorted(stale)} (rescale in progress); rewrite first.")
+    # Reuse those entries: scan.plan() re-reads plan_files() (append/pk) otherwise.
+    fs.plan_files = lambda *a, **k: entries
     by_bucket = {}
     for s in scan.plan().splits():
         by_bucket.setdefault(s.bucket, []).append(s)
@@ -140,6 +143,11 @@ def bucket_join(
     would otherwise collide). Returns a ``ray.data.Dataset``."""
     import ray
     from pypaimon.catalog.catalog_factory import CatalogFactory
+
+    if not hasattr(ray.data, "from_arrow_refs"):
+        raise RuntimeError(
+            "bucket_join needs a Ray version with ray.data.from_arrow_refs; "
+            f"installed ray is {ray.__version__}.")
 
     on_cols = _norm(on)
     cat = CatalogFactory.create(catalog_options)

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -92,9 +92,17 @@ def bucket_join(
 
     on_cols = _norm(on)
     cat = CatalogFactory.create(catalog_options)
-    lcount, lkey = _bucketing(cat.get_table(left))
-    rcount, rkey = _bucketing(cat.get_table(right))
+    ltable, rtable = cat.get_table(left), cat.get_table(right)
+    lcount, lkey = _bucketing(ltable)
+    rcount, rkey = _bucketing(rtable)
 
+    if ltable.partition_keys or rtable.partition_keys:
+        # Bucket numbers are per-partition, so the same bucket id lives in every
+        # partition -- grouping splits by bucket alone would join across partitions.
+        # Supporting this needs grouping by (partition, bucket); not done yet.
+        raise ValueError(
+            "bucket_join does not support partitioned tables yet; got partition keys "
+            f"{left}={ltable.partition_keys}, {right}={rtable.partition_keys}.")
     if not lcount or lcount <= 0 or not rcount or rcount <= 0:
         raise ValueError(
             "bucket_join requires both tables to be fixed-bucket (bucket > 0); "

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -41,18 +41,22 @@ def _bucketing(table):
     return count, ([k.strip() for k in key.split(",")] if key else [])
 
 
-def _read_bucket(table_id, catalog_options, projection, bucket):
+def _read_builder(table_id, catalog_options, projection):
     from pypaimon.catalog.catalog_factory import CatalogFactory
-    cat = CatalogFactory.create(catalog_options)
-    t = cat.get_table(table_id)
-    rb = t.new_read_builder()
-    if projection is not None:
-        rb = rb.with_projection(projection)
-    rd = rb.new_read()
-    # TODO(perf): plan once in the driver and dispatch per-bucket splits, instead
-    # of re-planning the manifest in every bucket task.
-    splits = [s for s in rb.new_scan().plan().splits() if s.bucket == bucket]
-    return rd.to_arrow(splits) if splits else None
+    rb = CatalogFactory.create(catalog_options).get_table(table_id).new_read_builder()
+    return rb.with_projection(projection) if projection is not None else rb
+
+
+def _plan_splits_by_bucket(table_id, catalog_options, projection):
+    """Plan the manifest once and group splits by bucket (driver-side)."""
+    by_bucket = {}
+    for s in _read_builder(table_id, catalog_options, projection).new_scan().plan().splits():
+        by_bucket.setdefault(s.bucket, []).append(s)
+    return by_bucket
+
+
+def _read_splits(table_id, catalog_options, projection, splits):
+    return _read_builder(table_id, catalog_options, projection).new_read().to_arrow(splits)
 
 
 def bucket_join(
@@ -102,17 +106,23 @@ def bucket_join(
             f"bucket_join requires the join key to be the bucket-key {lkey}; got on={on_cols}. "
             "Equal keys only co-locate by bucket when joining on the bucket-key.")
 
-    def _join_bucket(bucket):
-        left_t = _read_bucket(left, catalog_options, left_projection, bucket)
-        right_t = _read_bucket(right, catalog_options, right_projection, bucket)
-        if left_t is None or right_t is None or left_t.num_rows == 0 or right_t.num_rows == 0:
+    # Plan each side's manifest once, then dispatch per-bucket splits to the tasks.
+    left_by_bucket = _plan_splits_by_bucket(left, catalog_options, left_projection)
+    right_by_bucket = _plan_splits_by_bucket(right, catalog_options, right_projection)
+
+    def _join_bucket(left_splits, right_splits):
+        left_t = _read_splits(left, catalog_options, left_projection, left_splits)
+        right_t = _read_splits(right, catalog_options, right_projection, right_splits)
+        if left_t.num_rows == 0 or right_t.num_rows == 0:
             return None
         return left_t.join(right_t, keys=on_cols, join_type=join_type)
 
     # ``@ray.remote()`` (empty parens) is rejected by Ray, so wrap conditionally.
     remote_fn = ray.remote(**ray_remote_args)(_join_bucket) if ray_remote_args else ray.remote(_join_bucket)
-    parts = [p for p in ray.get([remote_fn.remote(b) for b in range(lcount)])
-             if p is not None and p.num_rows > 0]
+    # Inner join: only buckets present on both sides can contribute matches.
+    buckets = sorted(set(left_by_bucket) & set(right_by_bucket))
+    refs = [remote_fn.remote(left_by_bucket[b], right_by_bucket[b]) for b in buckets]
+    parts = [p for p in ray.get(refs) if p is not None and p.num_rows > 0]
     if not parts:
         return ray.data.from_items([])
     return ray.data.from_arrow(parts)

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -113,7 +113,7 @@ def _plan_splits_by_bucket(table_id, catalog_options, projection, expected_total
             f"bucket_join needs {table_id} fully in bucket count {expected_total_buckets}, "
             f"but files exist under {sorted(stale)} (rescale in progress); rewrite first.")
     # Reuse those entries: scan.plan() re-reads plan_files() (append/pk) otherwise.
-    fs.plan_files = lambda *a, **k: entries
+    fs.plan_files = lambda: entries
     by_bucket = {}
     for s in scan.plan().splits():
         by_bucket.setdefault(s.bucket, []).append(s)

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -38,14 +38,29 @@ def _bucketing(table):
     return count, ([k.strip() for k in key.split(",")] if key else [])
 
 
-def _read_builder(table_id, catalog_options, projection):
+# Per-process table cache so a worker reuses table metadata across the many buckets
+# it runs, instead of reloading the catalog per bucket. Only used when reading given
+# splits (snapshot-independent); planning always loads a fresh table.
+_TABLE_CACHE: Dict = {}
+
+
+def _get_table(table_id, catalog_options, use_cache):
     from pypaimon.catalog.catalog_factory import CatalogFactory
-    rb = CatalogFactory.create(catalog_options).get_table(table_id).new_read_builder()
+    if not use_cache:
+        return CatalogFactory.create(catalog_options).get_table(table_id)
+    key = (table_id, tuple(sorted(catalog_options.items())))
+    if key not in _TABLE_CACHE:
+        _TABLE_CACHE[key] = CatalogFactory.create(catalog_options).get_table(table_id)
+    return _TABLE_CACHE[key]
+
+
+def _read_builder(table_id, catalog_options, projection, use_cache=False):
+    rb = _get_table(table_id, catalog_options, use_cache).new_read_builder()
     return rb.with_projection(projection) if projection is not None else rb
 
 
 def _plan_splits_by_bucket(table_id, catalog_options, projection):
-    """Plan the manifest once and group splits by bucket (driver-side)."""
+    """Plan the manifest once and group splits by bucket (driver-side, fresh snapshot)."""
     by_bucket = {}
     for s in _read_builder(table_id, catalog_options, projection).new_scan().plan().splits():
         by_bucket.setdefault(s.bucket, []).append(s)
@@ -53,7 +68,8 @@ def _plan_splits_by_bucket(table_id, catalog_options, projection):
 
 
 def _read_splits(table_id, catalog_options, projection, splits):
-    return _read_builder(table_id, catalog_options, projection).new_read().to_arrow(splits)
+    # Reading given splits is snapshot-independent, so the cached table is safe here.
+    return _read_builder(table_id, catalog_options, projection, use_cache=True).new_read().to_arrow(splits)
 
 
 def bucket_join(
@@ -68,8 +84,9 @@ def bucket_join(
     ray_remote_args: Optional[Dict[str, Any]] = None,
 ) -> "ray.data.Dataset":
     """Join two co-bucketed tables (same bucket count + bucket-key, joined on the
-    bucket-key) with no global shuffle. ``on`` must equal the bucket-key. Returns a
-    ``ray.data.Dataset``."""
+    bucket-key) with no global shuffle. ``on`` must equal the bucket-key. The two
+    sides must not share column names other than the join key (pyarrow ``join``
+    would otherwise collide). Returns a ``ray.data.Dataset``."""
     import ray
     from pypaimon.catalog.catalog_factory import CatalogFactory
 
@@ -97,7 +114,8 @@ def bucket_join(
         # still emits rows); only inner is correct with the per-bucket intersection.
         raise ValueError(f"bucket_join currently supports only join_type='inner'; got {join_type!r}.")
 
-    # Plan each side's manifest once, then dispatch per-bucket splits to the tasks.
+    # Plan each side's manifest once (driver-side, split metadata only -- the join
+    # results stay distributed below), then dispatch per-bucket splits to the tasks.
     left_by_bucket = _plan_splits_by_bucket(left, catalog_options, left_projection)
     right_by_bucket = _plan_splits_by_bucket(right, catalog_options, right_projection)
 
@@ -111,7 +129,11 @@ def bucket_join(
     # Inner join: only buckets present on both sides can match.
     buckets = sorted(set(left_by_bucket) & set(right_by_bucket))
     if not buckets:
-        return ray.data.from_items([])
+        # No shared bucket: empty result, but keep the join schema (join two empties).
+        empty = _read_splits(left, catalog_options, left_projection, []).join(
+            _read_splits(right, catalog_options, right_projection, []),
+            keys=on_cols, join_type=join_type)
+        return ray.data.from_arrow(empty)
     # Keep each bucket's result as a distributed object ref -- never pulled into the driver.
     refs = [remote_fn.remote(left_by_bucket[b], right_by_bucket[b]) for b in buckets]
     return ray.data.from_arrow_refs(refs)

--- a/paimon-python/pypaimon/tests/ray_bucket_join_test.py
+++ b/paimon-python/pypaimon/tests/ray_bucket_join_test.py
@@ -61,10 +61,12 @@ class RayBucketJoinTest(unittest.TestCase):
             pass
         shutil.rmtree(cls.tempdir, ignore_errors=True)
 
-    def _bucketed_table(self, name, schema, key, data, primary_keys=None):
+    def _bucketed_table(self, name, schema, key, data, primary_keys=None, extra_opts=None):
         opts = {"bucket": str(self.NUM_BUCKETS)}
         if primary_keys is None:  # append table: bucket-key must be explicit
             opts["bucket-key"] = key
+        if extra_opts:
+            opts.update(extra_opts)
         # PK table: leave bucket-key unset so it defaults to the primary key.
         self.catalog.create_table(
             name,
@@ -126,6 +128,27 @@ class RayBucketJoinTest(unittest.TestCase):
             "default.in_fan", "default.loc_fan", self.catalog_options,
             on="url", left_projection=["url"], right_projection=["url", "row_id"])
         self.assertEqual(sorted(r["row_id"] for r in ds.take_all()), [0, 1])
+
+    def test_join_with_explicit_scan_mode(self):
+        # An explicit scan.mode on the tables must not clash with the internal
+        # snapshot pin during planning.
+        loc = pa.schema([("url", pa.string()), ("row_id", pa.int64())])
+        ins = pa.schema([("url", pa.string())])
+        mode = {"scan.mode": "latest-full"}
+        self._bucketed_table(
+            "default.sm_loc", loc, "url",
+            pa.Table.from_pydict({"url": [f"u{i}" for i in range(50)],
+                                  "row_id": list(range(50))}, schema=loc),
+            extra_opts=mode)
+        self._bucketed_table(
+            "default.sm_in", ins, "url",
+            pa.Table.from_pydict({"url": [f"u{i}" for i in range(20)]}, schema=ins),
+            extra_opts=mode)
+        ds = bucket_join(
+            "default.sm_in", "default.sm_loc", self.catalog_options,
+            on="url", left_projection=["url"], right_projection=["url", "row_id"])
+        got = {r["url"]: r["row_id"] for r in ds.take_all()}
+        self.assertEqual(got, {f"u{i}": i for i in range(20)})
 
     def test_dispatches_one_task_per_shared_bucket(self):
         # No cross-bucket shuffle: exactly one Ray task (object ref) per shared bucket.

--- a/paimon-python/pypaimon/tests/ray_bucket_join_test.py
+++ b/paimon-python/pypaimon/tests/ray_bucket_join_test.py
@@ -26,8 +26,15 @@ import pytest
 pypaimon = pytest.importorskip("pypaimon")
 ray = pytest.importorskip("ray")
 
+import importlib
+from unittest import mock
+
 from pypaimon import CatalogFactory, Schema
 from pypaimon.ray import bucket_join
+
+# The package attribute ``pypaimon.ray.bucket_join`` is the function (it shadows the
+# submodule); import the module explicitly to reach its internal helpers.
+bjmod = importlib.import_module("pypaimon.ray.bucket_join")
 
 
 class RayBucketJoinTest(unittest.TestCase):
@@ -71,8 +78,11 @@ class RayBucketJoinTest(unittest.TestCase):
         w.close()
         return name
 
-    def _create_bucketed(self, name, schema, key, num_buckets, partition_keys=None):
+    def _create_bucketed(self, name, schema, key, num_buckets,
+                         partition_keys=None, extra_opts=None):
         opts = {"bucket": str(num_buckets), "bucket-key": key}
+        if extra_opts:
+            opts.update(extra_opts)
         self.catalog.create_table(
             name,
             Schema.from_pyarrow_schema(schema, partition_keys=partition_keys, options=opts),
@@ -116,6 +126,69 @@ class RayBucketJoinTest(unittest.TestCase):
             "default.in_fan", "default.loc_fan", self.catalog_options,
             on="url", left_projection=["url"], right_projection=["url", "row_id"])
         self.assertEqual(sorted(r["row_id"] for r in ds.take_all()), [0, 1])
+
+    def test_dispatches_one_task_per_shared_bucket(self):
+        # No cross-bucket shuffle: exactly one Ray task (object ref) per shared bucket.
+        loc = pa.schema([("url", pa.string()), ("row_id", pa.int64())])
+        ins = pa.schema([("url", pa.string())])
+        self._bucketed_table(
+            "default.disp_loc", loc, "url",
+            pa.Table.from_pydict({"url": [f"u{i}" for i in range(200)],
+                                  "row_id": list(range(200))}, schema=loc))
+        self._bucketed_table(
+            "default.disp_in", ins, "url",
+            pa.Table.from_pydict({"url": [f"u{i}" for i in range(100)]}, schema=ins))
+        lbb = bjmod._plan_splits_by_bucket("default.disp_in", self.catalog_options, ["url"])
+        rbb = bjmod._plan_splits_by_bucket("default.disp_loc", self.catalog_options, ["url", "row_id"])
+        shared = set(lbb) & set(rbb)
+        self.assertGreater(len(shared), 1)  # genuinely spread across buckets
+
+        captured = {}
+        real = ray.data.from_arrow_refs
+
+        def spy(refs):
+            captured["n"] = len(refs)
+            return real(refs)
+
+        with mock.patch.object(ray.data, "from_arrow_refs", spy):
+            ds = bucket_join(
+                "default.disp_in", "default.disp_loc", self.catalog_options,
+                on="url", left_projection=["url"], right_projection=["url", "row_id"])
+            ds.take_all()
+        self.assertEqual(captured["n"], len(shared))
+
+    def test_composite_bucket_key(self):
+        # Happy path for a multi-column bucket-key joined on both columns.
+        loc = pa.schema([("a", pa.string()), ("b", pa.int64()), ("row_id", pa.int64())])
+        ins = pa.schema([("a", pa.string()), ("b", pa.int64())])
+        self._bucketed_table(
+            "default.comp_loc", loc, "a,b",
+            pa.Table.from_pydict({"a": [f"k{i}" for i in range(50)], "b": list(range(50)),
+                                  "row_id": list(range(50))}, schema=loc))
+        self._bucketed_table(
+            "default.comp_in", ins, "a,b",
+            pa.Table.from_pydict({"a": [f"k{i}" for i in range(20)], "b": list(range(20))},
+                                 schema=ins))
+        ds = bucket_join(
+            "default.comp_in", "default.comp_loc", self.catalog_options,
+            on=["a", "b"], left_projection=["a", "b"], right_projection=["a", "b", "row_id"])
+        got = {(r["a"], r["b"]): r["row_id"] for r in ds.take_all()}
+        self.assertEqual(len(got), 20)
+        self.assertTrue(all(got[(f"k{i}", i)] == i for i in range(20)))
+
+    def test_read_cache_keyed_by_schema_id(self):
+        # A schema change must invalidate the per-worker table cache: different schema
+        # id -> different cache entry (reload), same id -> reuse.
+        self._create_bucketed("default.cache_t", pa.schema([("url", pa.string())]), "url", 8)
+        bjmod._TABLE_CACHE.clear()
+        opts = self.catalog_options
+        k0 = ("default.cache_t", tuple(sorted(opts.items())), 0)
+        k1 = ("default.cache_t", tuple(sorted(opts.items())), 1)
+        t0a = bjmod._get_table("default.cache_t", opts, k0)
+        t0b = bjmod._get_table("default.cache_t", opts, k0)
+        t1 = bjmod._get_table("default.cache_t", opts, k1)
+        self.assertIs(t0a, t0b)      # same schema id -> cached
+        self.assertIsNot(t0a, t1)    # different schema id -> reloaded
 
     def test_empty_result_keeps_schema(self):
         # No shared bucket -> 0 rows, but the join schema must survive.
@@ -190,6 +263,23 @@ class RayBucketJoinTest(unittest.TestCase):
         self._create_bucketed("default.col2", sch, "url", 8)
         with self.assertRaises(ValueError):
             bucket_join("default.col1", "default.col2", self.catalog_options, on="url")
+
+    def test_rejects_different_bucket_function(self):
+        # Same bucket-key/count but different bucket function -> same key may land in
+        # different buckets, so co-location is not guaranteed.
+        sch = pa.schema([("k", pa.int64())])
+        self._create_bucketed("default.bf_default", sch, "k", 8)
+        self._create_bucketed("default.bf_mod", sch, "k", 8,
+                              extra_opts={"bucket-function.type": "mod"})
+        with self.assertRaises(ValueError):
+            bucket_join("default.bf_default", "default.bf_mod", self.catalog_options, on="k")
+
+    def test_rejects_mismatched_key_type(self):
+        # Same bucket-key name but different type hashes differently -> reject.
+        self._create_bucketed("default.ty_str", pa.schema([("k", pa.string())]), "k", 8)
+        self._create_bucketed("default.ty_int", pa.schema([("k", pa.int64())]), "k", 8)
+        with self.assertRaises(ValueError):
+            bucket_join("default.ty_str", "default.ty_int", self.catalog_options, on="k")
 
     def test_rejects_partitioned_table(self):
         # Bucket ids are per-partition, so bucket-only grouping would join across

--- a/paimon-python/pypaimon/tests/ray_bucket_join_test.py
+++ b/paimon-python/pypaimon/tests/ray_bucket_join_test.py
@@ -138,8 +138,10 @@ class RayBucketJoinTest(unittest.TestCase):
         self._bucketed_table(
             "default.disp_in", ins, "url",
             pa.Table.from_pydict({"url": [f"u{i}" for i in range(100)]}, schema=ins))
-        lbb = bjmod._plan_splits_by_bucket("default.disp_in", self.catalog_options, ["url"])
-        rbb = bjmod._plan_splits_by_bucket("default.disp_loc", self.catalog_options, ["url", "row_id"])
+        lbb = bjmod._plan_splits_by_bucket(
+            "default.disp_in", self.catalog_options, ["url"], self.NUM_BUCKETS)
+        rbb = bjmod._plan_splits_by_bucket(
+            "default.disp_loc", self.catalog_options, ["url", "row_id"], self.NUM_BUCKETS)
         shared = set(lbb) & set(rbb)
         self.assertGreater(len(shared), 1)  # genuinely spread across buckets
 
@@ -280,6 +282,18 @@ class RayBucketJoinTest(unittest.TestCase):
         self._create_bucketed("default.ty_int", pa.schema([("k", pa.int64())]), "k", 8)
         with self.assertRaises(ValueError):
             bucket_join("default.ty_str", "default.ty_int", self.catalog_options, on="k")
+
+    def test_rejects_rescaled_mixed_buckets(self):
+        # Files left under an old bucket count (rescale not yet rewritten) would carry a
+        # different total_buckets; the same bucket id must not be treated as co-located.
+        import types
+        from pypaimon.read.scanner.file_scanner import FileScanner
+        self._create_bucketed("default.rs_a", pa.schema([("url", pa.string())]), "url", 8)
+        self._create_bucketed("default.rs_b", pa.schema([("url", pa.string())]), "url", 8)
+        stale = [types.SimpleNamespace(total_buckets=4)]  # a file from a 4-bucket era
+        with mock.patch.object(FileScanner, "plan_files", return_value=stale):
+            with self.assertRaises(ValueError):
+                bucket_join("default.rs_a", "default.rs_b", self.catalog_options, on="url")
 
     def test_rejects_partitioned_table(self):
         # Bucket ids are per-partition, so bucket-only grouping would join across

--- a/paimon-python/pypaimon/tests/ray_bucket_join_test.py
+++ b/paimon-python/pypaimon/tests/ray_bucket_join_test.py
@@ -113,6 +113,14 @@ class RayBucketJoinTest(unittest.TestCase):
         with self.assertRaises(ValueError):  # on=k but bucket-key=url
             bucket_join("default.k1", "default.k2", self.catalog_options, on="k")
 
+    def test_rejects_non_inner_join(self):
+        sch = pa.schema([("url", pa.string())])
+        self._create_bucketed("default.ji1", sch, "url", 8)
+        self._create_bucketed("default.ji2", sch, "url", 8)
+        with self.assertRaises(ValueError):
+            bucket_join("default.ji1", "default.ji2", self.catalog_options,
+                        on="url", join_type="left outer")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/paimon-python/pypaimon/tests/ray_bucket_join_test.py
+++ b/paimon-python/pypaimon/tests/ray_bucket_join_test.py
@@ -65,9 +65,12 @@ class RayBucketJoinTest(unittest.TestCase):
         w.close()
         return name
 
-    def _create_bucketed(self, name, schema, key, num_buckets):
+    def _create_bucketed(self, name, schema, key, num_buckets, partition_keys=None):
         opts = {"bucket": str(num_buckets), "bucket-key": key}
-        self.catalog.create_table(name, Schema.from_pyarrow_schema(schema, options=opts), False)
+        self.catalog.create_table(
+            name,
+            Schema.from_pyarrow_schema(schema, partition_keys=partition_keys, options=opts),
+            False)
         return name
 
     def test_bucket_join_matches_global_join(self):
@@ -144,6 +147,15 @@ class RayBucketJoinTest(unittest.TestCase):
         self._create_bucketed("default.k2", sch, "url", 8)
         with self.assertRaises(ValueError):  # on=k but bucket-key=url
             bucket_join("default.k1", "default.k2", self.catalog_options, on="k")
+
+    def test_rejects_partitioned_table(self):
+        # Bucket ids are per-partition, so bucket-only grouping would join across
+        # partitions; partitioned tables are rejected until (partition, bucket) grouping.
+        sch = pa.schema([("url", pa.string()), ("dt", pa.string())])
+        self._create_bucketed("default.part_p", sch, "url", 8, partition_keys=["dt"])
+        self._create_bucketed("default.part_np", sch, "url", 8)
+        with self.assertRaises(ValueError):
+            bucket_join("default.part_p", "default.part_np", self.catalog_options, on="url")
 
     def test_rejects_non_inner_join(self):
         sch = pa.schema([("url", pa.string())])

--- a/paimon-python/pypaimon/tests/ray_bucket_join_test.py
+++ b/paimon-python/pypaimon/tests/ray_bucket_join_test.py
@@ -54,9 +54,15 @@ class RayBucketJoinTest(unittest.TestCase):
             pass
         shutil.rmtree(cls.tempdir, ignore_errors=True)
 
-    def _bucketed_table(self, name, schema, key, data):
-        opts = {"bucket": str(self.NUM_BUCKETS), "bucket-key": key}
-        self.catalog.create_table(name, Schema.from_pyarrow_schema(schema, options=opts), False)
+    def _bucketed_table(self, name, schema, key, data, primary_keys=None):
+        opts = {"bucket": str(self.NUM_BUCKETS)}
+        if primary_keys is None:  # append table: bucket-key must be explicit
+            opts["bucket-key"] = key
+        # PK table: leave bucket-key unset so it defaults to the primary key.
+        self.catalog.create_table(
+            name,
+            Schema.from_pyarrow_schema(schema, primary_keys=primary_keys, options=opts),
+            False)
         t = self.catalog.get_table(name)
         wb = t.new_batch_write_builder()
         w = wb.new_write()
@@ -147,6 +153,43 @@ class RayBucketJoinTest(unittest.TestCase):
         self._create_bucketed("default.k2", sch, "url", 8)
         with self.assertRaises(ValueError):  # on=k but bucket-key=url
             bucket_join("default.k1", "default.k2", self.catalog_options, on="k")
+
+    def test_primary_key_default_bucket_key(self):
+        # PK tables bucket by their primary key without an explicit bucket-key option;
+        # bucket_join must resolve that and join on the PK.
+        loc_schema = pa.schema([("url", pa.string()), ("row_id", pa.int64())])
+        in_schema = pa.schema([("url", pa.string())])
+        self._bucketed_table(
+            "default.pk_loc", loc_schema, "url",
+            pa.Table.from_pydict({"url": [f"u{i}" for i in range(100)],
+                                  "row_id": list(range(100))}, schema=loc_schema),
+            primary_keys=["url"])
+        self._bucketed_table(
+            "default.pk_in", in_schema, "url",
+            pa.Table.from_pydict({"url": [f"u{i}" for i in range(40)]}, schema=in_schema),
+            primary_keys=["url"])
+        ds = bucket_join(
+            "default.pk_in", "default.pk_loc", self.catalog_options,
+            on="url", left_projection=["url"], right_projection=["url", "row_id"])
+        got = {r["url"]: r["row_id"] for r in ds.take_all()}
+        self.assertEqual(set(got), {f"u{i}" for i in range(40)})
+        self.assertTrue(all(got[f"u{i}"] == i for i in range(40)))
+
+    def test_rejects_projection_missing_join_key(self):
+        sch = pa.schema([("url", pa.string()), ("v", pa.int64())])
+        self._create_bucketed("default.pmj1", sch, "url", 8)
+        self._create_bucketed("default.pmj2", sch, "url", 8)
+        with self.assertRaises(ValueError):  # left projection drops the join key
+            bucket_join("default.pmj1", "default.pmj2", self.catalog_options,
+                        on="url", left_projection=["v"], right_projection=["url"])
+
+    def test_rejects_colliding_columns(self):
+        # Both sides expose a non-key column "v" -> pyarrow join would collide.
+        sch = pa.schema([("url", pa.string()), ("v", pa.int64())])
+        self._create_bucketed("default.col1", sch, "url", 8)
+        self._create_bucketed("default.col2", sch, "url", 8)
+        with self.assertRaises(ValueError):
+            bucket_join("default.col1", "default.col2", self.catalog_options, on="url")
 
     def test_rejects_partitioned_table(self):
         # Bucket ids are per-partition, so bucket-only grouping would join across

--- a/paimon-python/pypaimon/tests/ray_bucket_join_test.py
+++ b/paimon-python/pypaimon/tests/ray_bucket_join_test.py
@@ -1,0 +1,102 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import pyarrow as pa
+import pytest
+
+pypaimon = pytest.importorskip("pypaimon")
+ray = pytest.importorskip("ray")
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.ray import bucket_join
+
+
+class RayBucketJoinTest(unittest.TestCase):
+    """Bucket-aligned join between two HASH_FIXED tables must equal a global join,
+    with each bucket joined only against the same bucket (no cross-bucket shuffle)."""
+
+    NUM_BUCKETS = 8
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        cls.catalog_options = {"warehouse": os.path.join(cls.tempdir, "wh")}
+        cls.catalog = CatalogFactory.create(cls.catalog_options)
+        cls.catalog.create_database("default", True)
+        if not ray.is_initialized():
+            ray.init(ignore_reinit_error=True, num_cpus=4)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            if ray.is_initialized():
+                ray.shutdown()
+        except Exception:
+            pass
+        shutil.rmtree(cls.tempdir, ignore_errors=True)
+
+    def _bucketed_table(self, name, schema, key, data):
+        opts = {"bucket": str(self.NUM_BUCKETS), "bucket-key": key}
+        self.catalog.create_table(name, Schema.from_pyarrow_schema(schema, options=opts), False)
+        t = self.catalog.get_table(name)
+        wb = t.new_batch_write_builder()
+        w = wb.new_write()
+        w.write_arrow(data)
+        wb.new_commit().commit(w.prepare_commit())
+        w.close()
+        return name
+
+    def test_bucket_join_matches_global_join(self):
+        loc_schema = pa.schema([("url", pa.string()), ("row_id", pa.int64())])
+        in_schema = pa.schema([("url", pa.string())])
+        self._bucketed_table(
+            "default.locator", loc_schema, "url",
+            pa.Table.from_pydict({"url": [f"u{i}" for i in range(1000)],
+                                  "row_id": list(range(1000))}, schema=loc_schema))
+        self._bucketed_table(
+            "default.input", in_schema, "url",
+            pa.Table.from_pydict({"url": [f"u{i}" for i in range(0, 400)]}, schema=in_schema))
+
+        ds = bucket_join(
+            "default.input", "default.locator", self.catalog_options,
+            on="url", left_projection=["url"], right_projection=["url", "row_id"])
+        got = {r["url"]: r["row_id"] for r in ds.take_all()}
+
+        # every input url (u0..u399) is matched to its locator row_id
+        self.assertEqual(set(got), {f"u{i}" for i in range(400)})
+        self.assertEqual(got["u0"], 0)
+        self.assertEqual(got["u399"], 399)
+        self.assertTrue(all(got[f"u{i}"] == i for i in range(400)))
+
+    def test_rejects_incompatible_bucketing(self):
+        # different bucket count -> not bucket-aligned -> must reject
+        sch = pa.schema([("url", pa.string())])
+        self._bucketed_table("default.in_8", sch, "url", pa.Table.from_pydict({"url": ["a"]}))
+        self.catalog.create_table(
+            "default.loc_16",
+            Schema.from_pyarrow_schema(sch, options={"bucket": "16", "bucket-key": "url"}), False)
+        with self.assertRaises(ValueError):
+            bucket_join("default.in_8", "default.loc_16", self.catalog_options, on="url")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/ray_bucket_join_test.py
+++ b/paimon-python/pypaimon/tests/ray_bucket_join_test.py
@@ -92,6 +92,38 @@ class RayBucketJoinTest(unittest.TestCase):
         self.assertEqual(got["u399"], 399)
         self.assertTrue(all(got[f"u{i}"] == i for i in range(400)))
 
+    def test_fan_out_one_url_many_row_ids(self):
+        # A url may map to several locator rows; every match must be emitted.
+        loc_schema = pa.schema([("url", pa.string()), ("row_id", pa.int64())])
+        in_schema = pa.schema([("url", pa.string())])
+        self._bucketed_table(
+            "default.loc_fan", loc_schema, "url",
+            pa.Table.from_pydict({"url": ["u0", "u0", "u1"], "row_id": [0, 1, 2]},
+                                 schema=loc_schema))
+        self._bucketed_table(
+            "default.in_fan", in_schema, "url",
+            pa.Table.from_pydict({"url": ["u0"]}, schema=in_schema))
+        ds = bucket_join(
+            "default.in_fan", "default.loc_fan", self.catalog_options,
+            on="url", left_projection=["url"], right_projection=["url", "row_id"])
+        self.assertEqual(sorted(r["row_id"] for r in ds.take_all()), [0, 1])
+
+    def test_empty_result_keeps_schema(self):
+        # No shared bucket -> 0 rows, but the join schema must survive.
+        loc_schema = pa.schema([("url", pa.string()), ("row_id", pa.int64())])
+        in_schema = pa.schema([("url", pa.string())])
+        self._bucketed_table(
+            "default.loc_empty", loc_schema, "url",
+            pa.Table.from_pydict({"url": ["u0", "u1"], "row_id": [0, 1]}, schema=loc_schema))
+        self._bucketed_table(
+            "default.in_empty", in_schema, "url",
+            pa.Table.from_pydict({"url": []}, schema=in_schema))  # no rows -> no buckets
+        ds = bucket_join(
+            "default.in_empty", "default.loc_empty", self.catalog_options,
+            on="url", left_projection=["url"], right_projection=["url", "row_id"])
+        self.assertEqual(ds.count(), 0)
+        self.assertIn("row_id", ds.schema().names)
+
     def test_rejects_different_bucket_count(self):
         sch = pa.schema([("url", pa.string())])
         self._create_bucketed("default.cnt_8", sch, "url", 8)

--- a/paimon-python/pypaimon/tests/ray_bucket_join_test.py
+++ b/paimon-python/pypaimon/tests/ray_bucket_join_test.py
@@ -65,6 +65,11 @@ class RayBucketJoinTest(unittest.TestCase):
         w.close()
         return name
 
+    def _create_bucketed(self, name, schema, key, num_buckets):
+        opts = {"bucket": str(num_buckets), "bucket-key": key}
+        self.catalog.create_table(name, Schema.from_pyarrow_schema(schema, options=opts), False)
+        return name
+
     def test_bucket_join_matches_global_join(self):
         loc_schema = pa.schema([("url", pa.string()), ("row_id", pa.int64())])
         in_schema = pa.schema([("url", pa.string())])
@@ -87,15 +92,26 @@ class RayBucketJoinTest(unittest.TestCase):
         self.assertEqual(got["u399"], 399)
         self.assertTrue(all(got[f"u{i}"] == i for i in range(400)))
 
-    def test_rejects_incompatible_bucketing(self):
-        # different bucket count -> not bucket-aligned -> must reject
+    def test_rejects_different_bucket_count(self):
         sch = pa.schema([("url", pa.string())])
-        self._bucketed_table("default.in_8", sch, "url", pa.Table.from_pydict({"url": ["a"]}))
-        self.catalog.create_table(
-            "default.loc_16",
-            Schema.from_pyarrow_schema(sch, options={"bucket": "16", "bucket-key": "url"}), False)
+        self._create_bucketed("default.cnt_8", sch, "url", 8)
+        self._create_bucketed("default.cnt_16", sch, "url", 16)
         with self.assertRaises(ValueError):
-            bucket_join("default.in_8", "default.loc_16", self.catalog_options, on="url")
+            bucket_join("default.cnt_8", "default.cnt_16", self.catalog_options, on="url")
+
+    def test_rejects_different_bucket_key(self):
+        sch = pa.schema([("url", pa.string()), ("k", pa.string())])
+        self._create_bucketed("default.by_url", sch, "url", 8)
+        self._create_bucketed("default.by_k", sch, "k", 8)
+        with self.assertRaises(ValueError):
+            bucket_join("default.by_url", "default.by_k", self.catalog_options, on="url")
+
+    def test_rejects_join_key_not_bucket_key(self):
+        sch = pa.schema([("url", pa.string()), ("k", pa.string())])
+        self._create_bucketed("default.k1", sch, "url", 8)
+        self._create_bucketed("default.k2", sch, "url", 8)
+        with self.assertRaises(ValueError):  # on=k but bucket-key=url
+            bucket_join("default.k1", "default.k2", self.catalog_options, on="k")
 
 
 if __name__ == "__main__":

--- a/paimon-python/pypaimon/tests/ray_bucket_join_test.py
+++ b/paimon-python/pypaimon/tests/ray_bucket_join_test.py
@@ -178,19 +178,18 @@ class RayBucketJoinTest(unittest.TestCase):
         self.assertEqual(len(got), 20)
         self.assertTrue(all(got[(f"k{i}", i)] == i for i in range(20)))
 
-    def test_read_cache_keyed_by_schema_id(self):
-        # A schema change must invalidate the per-worker table cache: different schema
-        # id -> different cache entry (reload), same id -> reuse.
+    def test_read_cache_by_schema_id_and_staleness(self):
+        # Same schema id -> cached (reused). A schema id that is no longer current means
+        # the plan is stale -> fail fast instead of reading with the wrong schema.
         self._create_bucketed("default.cache_t", pa.schema([("url", pa.string())]), "url", 8)
         bjmod._TABLE_CACHE.clear()
         opts = self.catalog_options
-        k0 = ("default.cache_t", tuple(sorted(opts.items())), 0)
-        k1 = ("default.cache_t", tuple(sorted(opts.items())), 1)
-        t0a = bjmod._get_table("default.cache_t", opts, k0)
-        t0b = bjmod._get_table("default.cache_t", opts, k0)
-        t1 = bjmod._get_table("default.cache_t", opts, k1)
-        self.assertIs(t0a, t0b)      # same schema id -> cached
-        self.assertIsNot(t0a, t1)    # different schema id -> reloaded
+        sid = self.catalog.get_table("default.cache_t").table_schema.id
+        t1 = bjmod._get_table("default.cache_t", opts, sid)
+        t2 = bjmod._get_table("default.cache_t", opts, sid)
+        self.assertIs(t1, t2)                       # same schema id -> cached
+        with self.assertRaises(ValueError):         # stale plan: requested schema not current
+            bjmod._get_table("default.cache_t", opts, sid + 99)
 
     def test_empty_result_keeps_schema(self):
         # No shared bucket -> 0 rows, but the join schema must survive.
@@ -288,8 +287,11 @@ class RayBucketJoinTest(unittest.TestCase):
         # different total_buckets; the same bucket id must not be treated as co-located.
         import types
         from pypaimon.read.scanner.file_scanner import FileScanner
-        self._create_bucketed("default.rs_a", pa.schema([("url", pa.string())]), "url", 8)
-        self._create_bucketed("default.rs_b", pa.schema([("url", pa.string())]), "url", 8)
+        sch = pa.schema([("url", pa.string())])
+        self._bucketed_table("default.rs_a", sch, "url",
+                             pa.Table.from_pydict({"url": ["u0", "u1"]}, schema=sch))
+        self._bucketed_table("default.rs_b", sch, "url",
+                             pa.Table.from_pydict({"url": ["u0"]}, schema=sch))
         stale = [types.SimpleNamespace(total_buckets=4)]  # a file from a 4-bucket era
         with mock.patch.object(FileScanner, "plan_files", return_value=stale):
             with self.assertRaises(ValueError):

--- a/paimon-python/pypaimon/tests/ray_bucket_join_test.py
+++ b/paimon-python/pypaimon/tests/ray_bucket_join_test.py
@@ -138,9 +138,9 @@ class RayBucketJoinTest(unittest.TestCase):
         self._bucketed_table(
             "default.disp_in", ins, "url",
             pa.Table.from_pydict({"url": [f"u{i}" for i in range(100)]}, schema=ins))
-        lbb = bjmod._plan_splits_by_bucket(
+        lbb, _ = bjmod._plan_splits_by_bucket(
             "default.disp_in", self.catalog_options, ["url"], self.NUM_BUCKETS)
-        rbb = bjmod._plan_splits_by_bucket(
+        rbb, _ = bjmod._plan_splits_by_bucket(
             "default.disp_loc", self.catalog_options, ["url", "row_id"], self.NUM_BUCKETS)
         shared = set(lbb) & set(rbb)
         self.assertGreater(len(shared), 1)  # genuinely spread across buckets


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New distributed read/join path can mis-join or OOM on skewed buckets if bucketing assumptions are violated; extensive validation and tests mitigate but partitioned tables and outer joins are still unsupported.
> 
> **Overview**
> Adds **`bucket_join`** to `pypaimon.ray`: an inner join of two fixed-bucket Paimon tables that share bucket count, bucket-key, and bucket function, **without a global shuffle**. The driver plans splits by bucket (latest snapshot per side, with guards for rescale-in-progress and schema drift), then runs one Ray task per overlapping bucket that reads Arrow and PyArrow-joins locally; results stay distributed via `ray.data.from_arrow_refs`.
> 
> The public API is exported from `pypaimon.ray` and documented in the Ray Data guide (parameters, constraints, and a key→`_ROW_ID` lookup example). Validation rejects partitioned tables (for now), non-inner joins, join keys that are not the bucket-key, colliding non-key column names, and mismatched bucketing metadata.
> 
> Adds **`ray_bucket_join_test.py`** with correctness checks (including PK-default bucket-key and composite keys), one-task-per-bucket dispatch, and broad error-path coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 031c693b9c96a127756cebf787c8c52cf879ef2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->