### PR TITLE
[python][daft] Push partition_filters into plan-time pruning

### DIFF
--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -851,7 +851,10 @@ class PaimonDataSource(DataSource):
         if partition_filters is None:
             return None
         py_expr = getattr(partition_filters, "_expr", partition_filters)
-        _, _, paimon_predicate = convert_filters_to_paimon(self._table, [py_expr])
+        _, remaining, paimon_predicate = convert_filters_to_paimon(self._table, [py_expr])
+        if remaining:
+            # Unconverted parts still apply via _partition_filter_skips_split.
+            logger.debug("Partition filter not pushed to plan: %s", remaining)
         return paimon_predicate
 
     @staticmethod

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -845,8 +845,9 @@ class PaimonDataSource(DataSource):
 
     def _partition_planning_predicate(self, pushdowns: Pushdowns) -> Predicate | None:
         """Convert Daft's partition_filters channel to a Paimon predicate for
-        plan-time partition pruning (always safe: pruning uses exact partition
-        values, not column stats)."""
+        plan-time pruning. Gated by _can_plan_predicate (excludes isNull): plan
+        pruning can only over-prune, and the Python post-filter cannot restore a
+        null partition it drops, so isNull is left to the post-filter."""
         partition_filters = getattr(pushdowns, "partition_filters", None)
         if partition_filters is None:
             return None
@@ -855,6 +856,10 @@ class PaimonDataSource(DataSource):
         if remaining:
             # Unconverted parts still apply via _partition_filter_skips_split.
             logger.debug("Partition filter not pushed to plan: %s", remaining)
+        if paimon_predicate is None or self._predicate_contains_is_null(paimon_predicate):
+            # isNull can over-prune the null partition at plan time and the
+            # post-filter can't restore it; leave it to _partition_filter_skips_split.
+            return None
         return paimon_predicate
 
     @staticmethod

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -844,10 +844,10 @@ class PaimonDataSource(DataSource):
         return None
 
     def _partition_planning_predicate(self, pushdowns: Pushdowns) -> Predicate | None:
-        """Convert Daft's partition_filters channel to a Paimon predicate for
-        plan-time pruning. Gated by _can_plan_predicate (excludes isNull): plan
-        pruning can only over-prune, and the Python post-filter cannot restore a
-        null partition it drops, so isNull is left to the post-filter."""
+        """partition_filters -> Paimon predicate for plan-time pruning. Excludes
+        isNull (_predicate_contains_is_null): pruning drops the whole null
+        partition, which the post-filter can't restore -- so exclude it even for
+        PK tables (stricter than the row path's _can_plan_predicate)."""
         partition_filters = getattr(pushdowns, "partition_filters", None)
         if partition_filters is None:
             return None
@@ -857,9 +857,7 @@ class PaimonDataSource(DataSource):
             # Unconverted parts still apply via _partition_filter_skips_split.
             logger.debug("Partition filter not pushed to plan: %s", remaining)
         if paimon_predicate is None or self._predicate_contains_is_null(paimon_predicate):
-            # isNull can over-prune the null partition at plan time and the
-            # post-filter can't restore it; leave it to _partition_filter_skips_split.
-            return None
+            return None  # isNull -> post-filter only (see docstring)
         return paimon_predicate
 
     @staticmethod

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -800,6 +800,12 @@ class PaimonDataSource(DataSource):
     ) -> _ReadPushdownState:
         reader_predicate, filters_consumed = self._pushdown_filter_state(pushdowns)
         planning_predicate = self._planning_predicate(reader_predicate)
+        # Partition filters arrive on a separate Daft channel (pushdowns.
+        # partition_filters), not in pushdowns.filters. Convert and AND them in
+        # so plan() prunes partitions at the manifest level; otherwise plan()
+        # enumerates every split and we skip in Python -- a full-table plan.
+        planning_predicate = self._and_predicates(
+            planning_predicate, self._partition_planning_predicate(pushdowns))
         requested_columns = self._valid_output_columns(pushdowns.columns)
         task_columns = self._task_columns(table, requested_columns, pushdowns)
         read_columns = self._fallback_read_columns(table, task_columns, reader_predicate)
@@ -836,6 +842,26 @@ class PaimonDataSource(DataSource):
         if self._paimon_predicate is not None or self._requires_fallback_reader():
             return pushdown_predicate
         return None
+
+    def _partition_planning_predicate(self, pushdowns: Pushdowns) -> Predicate | None:
+        """Convert Daft's partition_filters channel to a Paimon predicate for
+        plan-time partition pruning (always safe: pruning uses exact partition
+        values, not column stats)."""
+        partition_filters = getattr(pushdowns, "partition_filters", None)
+        if partition_filters is None:
+            return None
+        py_expr = getattr(partition_filters, "_expr", partition_filters)
+        _, _, paimon_predicate = convert_filters_to_paimon(self._table, [py_expr])
+        return paimon_predicate
+
+    @staticmethod
+    def _and_predicates(left: Predicate | None, right: Predicate | None) -> Predicate | None:
+        if left is None:
+            return right
+        if right is None:
+            return left
+        from pypaimon.common.predicate_builder import PredicateBuilder
+        return PredicateBuilder.and_predicates([left, right])
 
     @staticmethod
     def _source_limit(

--- a/paimon-python/pypaimon/tests/daft/daft_data_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_data_test.py
@@ -765,6 +765,46 @@ def test_read_paimon_partition_filter(append_only_table):
     assert all(dt == "2024-01-01" for dt in result.column("dt").to_pylist())
 
 
+def test_partition_filter_prunes_at_plan_level(append_only_table):
+    """Regression: Daft routes partition predicates to pushdowns.partition_filters
+    (a separate channel from pushdowns.filters). They must become a plan-time
+    predicate so plan() prunes partitions, instead of planning every split and
+    skipping in Python (a full-table plan)."""
+    from daft import context, runners
+    from daft.daft import StorageConfig
+    from daft.io.pushdowns import Pushdowns
+
+    from pypaimon.daft.daft_datasource import PaimonDataSource
+
+    table, _ = append_only_table
+    data = pa.table(
+        {
+            "id": pa.array([1, 2, 3], pa.int64()),
+            "name": pa.array(["a", "b", "c"], pa.string()),
+            "value": pa.array([1.0, 2.0, 3.0], pa.float64()),
+            "dt": pa.array(["2024-01-01", "2024-01-02", "2024-01-03"], pa.string()),
+        }
+    )
+    _write_to_paimon(table, data)
+
+    io_config = context.get_context().daft_planning_config.default_io_config
+    storage_config = StorageConfig(runners.get_or_create_runner().name != "ray", io_config)
+    source = PaimonDataSource(table, storage_config=storage_config, catalog_options={})
+
+    pushdowns = Pushdowns(partition_filters=(col("dt") == "2024-01-02"))
+
+    state = source._read_pushdown_state(table, pushdowns)
+    # partition filter must become a plan-time predicate
+    assert state.planning_predicate is not None
+
+    pruned = source._scan_read_builder(table, state).new_scan().plan().splits()
+    all_splits = table.new_read_builder().new_scan().plan().splits()
+
+    # pruning reduced the planned splits, and only the matching partition remains
+    assert 0 < len(pruned) < len(all_splits)
+    assert all(s.partition.to_dict().get("dt") == "2024-01-02" for s in pruned)
+
+
 def test_read_paimon_row_filter(append_only_table):
     """Row-level filter should be applied after reading data."""
     table, _ = append_only_table

--- a/paimon-python/pypaimon/tests/daft/daft_data_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_data_test.py
@@ -805,6 +805,41 @@ def test_partition_filter_prunes_at_plan_level(append_only_table):
     assert all(s.partition.to_dict().get("dt") == "2024-01-02" for s in pruned)
 
 
+def test_row_and_partition_filters_both_reach_planning_predicate(append_only_table):
+    """filters and partition_filters arrive on separate Daft channels; both must
+    fold into the planning predicate (via _and_predicates)."""
+    from daft import context, runners
+    from daft.daft import StorageConfig
+    from daft.io.pushdowns import Pushdowns
+
+    from pypaimon.daft.daft_datasource import PaimonDataSource
+
+    table, _ = append_only_table
+    _write_to_paimon(table, pa.table(
+        {
+            "id": pa.array([1, 2, 3], pa.int64()),
+            "name": pa.array(["a", "b", "c"], pa.string()),
+            "value": pa.array([1.0, 2.0, 3.0], pa.float64()),
+            "dt": pa.array(["2024-01-01", "2024-01-02", "2024-01-02"], pa.string()),
+        }
+    ))
+
+    io_config = context.get_context().daft_planning_config.default_io_config
+    storage_config = StorageConfig(runners.get_or_create_runner().name != "ray", io_config)
+    source = PaimonDataSource(table, storage_config=storage_config, catalog_options={})
+    source.push_filters([(col("id") > 1)._expr])
+    pushdowns = Pushdowns(filters=(col("id") > 1),
+                          partition_filters=(col("dt") == "2024-01-02"))
+
+    state = source._read_pushdown_state(table, pushdowns)
+    # both channels combined into one AND planning predicate
+    assert state.planning_predicate is not None
+    assert state.planning_predicate.method == "and"
+
+    pruned = source._scan_read_builder(table, state).new_scan().plan().splits()
+    assert pruned and all(s.partition.to_dict().get("dt") == "2024-01-02" for s in pruned)
+
+
 def test_read_paimon_row_filter(append_only_table):
     """Row-level filter should be applied after reading data."""
     table, _ = append_only_table

--- a/paimon-python/pypaimon/tests/daft/daft_data_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_data_test.py
@@ -861,6 +861,30 @@ def test_isnull_partition_filter_keeps_null_partition(append_only_table):
     assert result.column("dt").to_pylist() == [None]
 
 
+def test_isnull_partition_filter_not_pushed_even_for_pk_table(pk_table):
+    """isNull must be excluded from plan pushdown for ALL tables. The row gate
+    (_can_plan_predicate) would allow isNull on a PK table without deletion
+    vectors; the partition path must be stricter (_predicate_contains_is_null),
+    else a PK table would lose its null partition."""
+    from daft import context, runners
+    from daft.daft import StorageConfig
+    from daft.io.pushdowns import Pushdowns
+
+    from pypaimon.daft.daft_datasource import PaimonDataSource
+
+    table, _ = pk_table
+    io_config = context.get_context().daft_planning_config.default_io_config
+    storage_config = StorageConfig(runners.get_or_create_runner().name != "ray", io_config)
+    source = PaimonDataSource(table, storage_config=storage_config, catalog_options={})
+
+    st_null = source._read_pushdown_state(
+        table, Pushdowns(partition_filters=col("dt").is_null()))
+    assert st_null.planning_predicate is None  # would be non-None via _can_plan_predicate
+    st_eq = source._read_pushdown_state(
+        table, Pushdowns(partition_filters=col("dt") == "2024-01-02"))
+    assert st_eq.planning_predicate is not None
+
+
 def test_read_paimon_row_filter(append_only_table):
     """Row-level filter should be applied after reading data."""
     table, _ = append_only_table

--- a/paimon-python/pypaimon/tests/daft/daft_data_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_data_test.py
@@ -840,6 +840,27 @@ def test_row_and_partition_filters_both_reach_planning_predicate(append_only_tab
     assert pruned and all(s.partition.to_dict().get("dt") == "2024-01-02" for s in pruned)
 
 
+def test_isnull_partition_filter_keeps_null_partition(append_only_table):
+    """isNull must NOT be pushed to plan pruning: plan pruning would drop the
+    null partition and the Python post-filter can't restore it. It must be left
+    to the post-filter so col(dt).is_null() still returns the null-partition row."""
+    table, _ = append_only_table
+    _write_to_paimon(table, pa.table(
+        {
+            "id": pa.array([1, 2], pa.int64()),
+            "name": pa.array(["a", "b"], pa.string()),
+            "value": pa.array([1.0, 2.0], pa.float64()),
+            "dt": pa.array([None, "2024-01-02"], pa.string()),
+        }
+    ))
+
+    result = _read_table(table).where(col("dt").is_null()).to_arrow()
+
+    assert result.num_rows == 1
+    assert result.column("id").to_pylist() == [1]
+    assert result.column("dt").to_pylist() == [None]
+
+
 def test_read_paimon_row_filter(append_only_table):
     """Row-level filter should be applied after reading data."""
     table, _ = append_only_table

--- a/paimon-python/pypaimon/tests/daft/daft_explain_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_explain_test.py
@@ -278,7 +278,9 @@ def test_explain_scan_applies_partition_filters_to_reader_counts(catalog_options
         verbose=True,
     )
 
-    assert result.paimon_scan.split_count == 2
+    # partition_filters are pushed into the plan, so it prunes to the matching
+    # partition (1 split) instead of planning both and skipping in Python.
+    assert result.paimon_scan.split_count == 1
     assert result.native_parquet_split_count == 1
     assert result.pypaimon_fallback_split_count == 0
     assert any("dt" in partition_filter for partition_filter in result.partition_filters)


### PR DESCRIPTION
Daft delivers partition predicates on pushdowns.partition_filters, a channel separate from pushdowns.filters. The datasource only converted filters, so a partition-only predicate produced no planning predicate: plan() enumerated every split and we skipped in Python -- a full-table plan on large tables. Convert partition_filters and AND them into the planning predicate so plan() prunes partitions at the manifest level. Add a plan-level pruning test.

### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scan planning and filter pushdown on the Daft read path; incorrect predicate handling could skip partitions or over-scan, though isNull is explicitly guarded and covered by new tests.
> 
> **Overview**
> **Daft partition predicates** on `pushdowns.partition_filters` were ignored for scan planning, so `plan()` listed every split and pruning happened only in Python—effectively a full-table plan on large partitioned tables.
> 
> This change converts `partition_filters` to Paimon predicates, **ANDs** them with the existing row `planning_predicate` via new `_partition_planning_predicate` and `_and_predicates`, and passes the combined predicate into the read builder so manifests are pruned before splits are enumerated. **Null-partition safety:** `isNull` on partition columns is **not** pushed to plan pruning (even on PK tables where row filters might allow it), so null partitions are not dropped incorrectly; those filters still apply through the existing post-plan partition skip path.
> 
> Tests cover plan-level split reduction, row + partition AND pushdown, `is_null()` end-to-end reads, and PK-table planning behavior; explain scan expectations now reflect one planned split when a partition filter matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7265472c67384d476b6b694f5f623ea51d5b895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->