### PR TITLE
Read by row

### DIFF
--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -570,8 +570,8 @@ ds = read_by_row_id(
 - `row_ids`: a `ray.data.Dataset`, `pyarrow.Table`, or `pandas.DataFrame` carrying the
   target row ids in column `row_id_col`; other columns are ignored. A table-name source
   is not accepted (a table's system `_ROW_ID` is its own and cannot address the target).
-- `projection`: columns to read. Blob columns are resolved to their payloads. Must be
-  non-empty.
+- `projection`: top-level columns to read (nested paths are not supported). Blob columns
+  are resolved to their payloads. Must be non-empty.
 - `row_id_col`: the source column holding the row ids (default `_ROW_ID`); set e.g.
   `row_id_col="row_id"` to consume a `bucket_join` locator directly.
 - `num_partitions`: parallelism for grouping the row ids by target file; defaults to
@@ -587,3 +587,6 @@ ds = read_by_row_id(
 - The row ids must exist in the target's current snapshot; a foreign `_ROW_ID` raises.
 - Deletion-vectors-enabled tables are not supported yet, for the same reason as
   `update_by_row_id`.
+- Prefer a materialized `row_ids` source (a `bucket_join` result already is one): the
+  emptiness check reads one block up front, which would otherwise re-run a lazy source's
+  first block.

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -542,3 +542,48 @@ print(metrics)   # {"num_updated": 50}
 - Partition columns cannot be updated (in-place rewrite can't move a row across partitions).
 - Deletion-vectors-enabled tables are not supported yet: a DV-deleted row still lives
   in its data file, so it can't be told apart from a live row without reading the target.
+
+## Read By Row Id
+
+`read_by_row_id` is the read-side mirror of `update_by_row_id`: it reads columns
+(including blob) of a **data-evolution** table for a set of `_ROW_ID`s, without
+scanning or joining the whole target. Each row id is routed to the data file that
+owns it and only those files — and only the matched rows — are read. It pairs with
+`bucket_join` (which produces the row ids) and feeds `update_by_row_id`: match by
+key → read the matched rows → transform → write back by row id. Requires
+`ray >= 2.50` and a target with `data-evolution.enabled` and `row-tracking.enabled`.
+
+```python
+from pypaimon.ray import read_by_row_id
+
+ds = read_by_row_id(
+    target="database_name.table_name",
+    row_ids=locator_ds,          # ray.data.Dataset / pa.Table / pandas, carrying the row ids
+    catalog_options={"warehouse": "/path/to/warehouse"},
+    projection=["image", "feature"],   # columns to read; may include blob columns
+    row_id_col="row_id",         # source column holding the row ids (default "_ROW_ID")
+)
+# ds: ray.data.Dataset of (image, feature, _ROW_ID) for the matched rows
+```
+
+**Parameters:**
+- `row_ids`: a `ray.data.Dataset`, `pyarrow.Table`, or `pandas.DataFrame` carrying the
+  target row ids in column `row_id_col`; other columns are ignored. A table-name source
+  is not accepted (a table's system `_ROW_ID` is its own and cannot address the target).
+- `projection`: columns to read. Blob columns are resolved to their payloads. Must be
+  non-empty.
+- `row_id_col`: the source column holding the row ids (default `_ROW_ID`); set e.g.
+  `row_id_col="row_id"` to consume a `bucket_join` locator directly.
+- `num_partitions`: parallelism for grouping the row ids by target file; defaults to
+  `max(1, cluster_cpus * 2)`.
+- `ray_remote_args`: Ray remote options applied to the read tasks.
+
+**Returns:** a `ray.data.Dataset` of `(*projection, _ROW_ID)`.
+
+**Notes:**
+- Lookup/set semantics, like SQL `... WHERE _ROW_ID IN (...)`: one row per **distinct**
+  matched row id (duplicates deduplicated), input order not preserved (rows come out
+  grouped by owning file). An empty source yields an empty but correctly-typed Dataset.
+- The row ids must exist in the target's current snapshot; a foreign `_ROW_ID` raises.
+- Deletion-vectors-enabled tables are not supported yet, for the same reason as
+  `update_by_row_id`.

--- a/paimon-python/pypaimon/ray/__init__.py
+++ b/paimon-python/pypaimon/ray/__init__.py
@@ -28,6 +28,7 @@ from pypaimon.ray.data_evolution_merge_transform import (
     lit,
 )
 from pypaimon.ray.update_by_row_id import update_by_row_id
+from pypaimon.ray.read_by_row_id import read_by_row_id
 
 __all__ = [
     "read_paimon",
@@ -36,6 +37,7 @@ __all__ = [
     "bucket_join",
     "merge_into",
     "update_by_row_id",
+    "read_by_row_id",
     "WhenMatched",
     "WhenNotMatched",
     "source_col",

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -608,6 +608,7 @@ def distributed_read_by_row_id(
     from pypaimon.common.options.core_options import CoreOptions
     from pypaimon.globalindex.indexed_split import IndexedSplit
     from pypaimon.read.split import DataSplit
+    from pypaimon.schema.data_types import PyarrowFieldParser
     from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
     from pypaimon.table.special_fields import SpecialFields
     from pypaimon.utils.range import Range
@@ -617,6 +618,15 @@ def distributed_read_by_row_id(
     read_cols = list(projection)
     if row_id_name not in read_cols:
         read_cols.append(row_id_name)
+
+    # The exact output schema (projection order, then _ROW_ID); used to emit a
+    # correctly-typed empty block if a group is ever empty, so all output blocks
+    # share one schema.
+    full_pa = PyarrowFieldParser.from_paimon_schema(table.table_schema.fields)
+    empty_out = pa.schema([
+        (col, pa.int64() if col == row_id_name else full_pa.field(col).type)
+        for col in read_cols
+    ]).empty_table()
 
     # Pin the planner to the caller's base snapshot so row-id routing is stable
     # even if a concurrent commit lands (mirrors the update path).
@@ -669,10 +679,11 @@ def distributed_read_by_row_id(
 
     captured_table = table
     captured_read_cols = read_cols
+    captured_empty = empty_out
 
     def _read_group(group: pa.Table) -> pa.Table:
         if group.num_rows == 0:
-            return group.drop_columns([frid_col])
+            return captured_empty
         frid = int(group.column(frid_col)[0].as_py())
         info = ray.get(precomputed_info_ref)
         owning_split, target_files = info.first_row_id_index[frid]

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -585,9 +585,8 @@ def distributed_update_apply(
 
 
 def _read_output_schema(table, read_cols: Sequence[str]) -> "pa.Schema":
-    """Arrow schema of a read-by-row-id result: each projected column's type plus
-    int64 ``_ROW_ID``, in ``read_cols`` order. Shared by the empty-result paths so
-    the schema of an empty read can't drift from a non-empty one."""
+    """Result schema: each projected column's type plus int64 ``_ROW_ID``, in
+    ``read_cols`` order. Shared by the empty-result paths so they can't drift."""
     from pypaimon.schema.data_types import PyarrowFieldParser
     from pypaimon.table.special_fields import SpecialFields
 
@@ -633,14 +632,11 @@ def distributed_read_by_row_id(
     if row_id_name not in read_cols:
         read_cols.append(row_id_name)
 
-    # A correctly-typed empty block, in case a group is ever empty, so every output
-    # block shares one schema.
+    # Typed empty block so all output blocks share one schema.
     empty_out = _read_output_schema(table, read_cols).empty_table()
 
-    # Reuse TableUpdateByRowId purely as a read-only planner: its constructor only
-    # scans the manifest to index files by first_row_id (no staging dirs, locks or
-    # commits). Pin it to the caller's base snapshot so routing is stable even if a
-    # concurrent commit lands (mirrors the update path).
+    # Read-only planner: construction only scans the manifest (no writes). Pin to the
+    # base snapshot so routing is stable under concurrent commits (as the update path).
     scan_table = (
         table.copy({CoreOptions.SCAN_SNAPSHOT_ID.key(): str(base_snapshot_id)})
         if base_snapshot_id is not None else table
@@ -654,8 +650,7 @@ def distributed_read_by_row_id(
     if not sorted_first_row_ids:
         return None
 
-    # Broadcast the file index once; workers route + read without re-scanning the
-    # manifest (mirrors the update path's precomputed-info ref).
+    # Broadcast the file index once so workers don't re-scan the manifest.
     precomputed_info_ref = ray.put(planner._snapshot_files_info())
     frid_col = "_FIRST_ROW_ID"
     sorted_arr = np.asarray(sorted_first_row_ids, dtype=np.int64)
@@ -693,9 +688,8 @@ def distributed_read_by_row_id(
     captured_empty = empty_out
 
     def _read_group(group: pa.Table) -> pa.Table:
-        # The group supplies only row ids (all owned by the same file, keyed by
-        # frid); output columns come from the fresh projected read below, so the
-        # injected frid_col never leaks into the result.
+        # Group supplies only row ids; output comes from the fresh read, so frid_col
+        # never leaks.
         if group.num_rows == 0:
             return captured_empty
         frid = int(group.column(frid_col)[0].as_py())
@@ -707,11 +701,8 @@ def distributed_read_by_row_id(
             bucket=owning_split.bucket,
             raw_convertible=True,
         )
-        # Read only the matched rows: contiguous row ids are compressed into
-        # ranges (so a dense group is a few ranges, not one object per row). For
-        # blob format this becomes native row-index pushdown, so unmatched rows in
-        # the owning file are never materialised. Duplicate row ids are deduplicated
-        # (each matched row is returned once, like SQL ``IN``).
+        # Read only the matched rows (deduped, contiguous ids compressed to ranges);
+        # blob format gets native row-index pushdown, so unmatched rows aren't read.
         wanted = set(group.column(row_id_name).to_pylist())
         indexed = IndexedSplit(origin_split, Range.to_ranges(list(wanted)))
         read = captured_table.new_read_builder().with_projection(

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -592,8 +592,9 @@ def _read_output_schema(table, read_cols: Sequence[str]) -> "pa.Schema":
 
     rid = SpecialFields.ROW_ID.name
     full = PyarrowFieldParser.from_paimon_schema(table.table_schema.fields)
+    # Keep each field's nullability so an empty result matches a non-empty read.
     return pa.schema([
-        (col, pa.int64() if col == rid else full.field(col).type)
+        pa.field(rid, pa.int64(), nullable=False) if col == rid else full.field(col)
         for col in read_cols
     ])
 

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -685,7 +685,7 @@ def distributed_read_by_row_id(
             frid_col, pa.array(sorted_arr[idx], type=pa.int64())
         )
 
-    captured_table = table
+    captured_table = scan_table  # read at the same pinned snapshot the planner routed on
     captured_read_cols = read_cols
     captured_empty = empty_out
 

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -584,6 +584,123 @@ def distributed_update_apply(
     return all_msgs, num_updated, action_row_ids
 
 
+def distributed_read_by_row_id(
+    row_ids_ds,
+    table,
+    projection: Sequence[str],
+    *,
+    num_partitions: int,
+    ray_remote_args: Optional[Dict[str, Any]] = None,
+    base_snapshot_id: Optional[int] = None,
+):
+    """Read ``projection`` columns for the row ids in ``row_ids_ds`` (must carry
+    ``_ROW_ID``). Each row id is routed to its owning data file, then only those
+    files -- and only the matched rows -- are read via ``IndexedSplit`` row-range
+    slicing (blob columns resolved). Returns a ``ray.data.Dataset`` of
+    ``(*projection, _ROW_ID)``, or ``None`` when the target is empty. The read-side
+    mirror of ``distributed_update_apply``; the target is never fully scanned.
+    """
+    import numpy as np
+    import uuid
+
+    import ray
+
+    from pypaimon.common.options.core_options import CoreOptions
+    from pypaimon.globalindex.indexed_split import IndexedSplit
+    from pypaimon.read.split import DataSplit
+    from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
+    from pypaimon.table.special_fields import SpecialFields
+    from pypaimon.utils.range import Range
+    from pypaimon.write.table_update_by_row_id import TableUpdateByRowId
+
+    row_id_name = SpecialFields.ROW_ID.name
+    read_cols = list(projection)
+    if row_id_name not in read_cols:
+        read_cols.append(row_id_name)
+
+    # Pin the planner to the caller's base snapshot so row-id routing is stable
+    # even if a concurrent commit lands (mirrors the update path).
+    scan_table = (
+        table.copy({CoreOptions.SCAN_SNAPSHOT_ID.key(): str(base_snapshot_id)})
+        if base_snapshot_id is not None else table
+    )
+    planner = TableUpdateByRowId(
+        scan_table,
+        "_read_by_row_id_planner_" + uuid.uuid4().hex[:8],
+        BATCH_COMMIT_IDENTIFIER,
+    )
+    sorted_first_row_ids = list(planner.first_row_ids)
+    if not sorted_first_row_ids:
+        return None
+
+    # Broadcast the file index once; workers route + read without re-scanning the
+    # manifest (mirrors the update path's precomputed-info ref).
+    precomputed_info_ref = ray.put(planner._snapshot_files_info())
+    frid_col = "_FIRST_ROW_ID"
+    sorted_arr = np.asarray(sorted_first_row_ids, dtype=np.int64)
+    valid_ranges = planner.valid_row_id_ranges
+    range_starts = np.asarray([r.from_ for r in valid_ranges], dtype=np.int64)
+    range_ends = np.asarray([r.to for r in valid_ranges], dtype=np.int64)
+
+    def _assign_frid(batch: pa.Table) -> pa.Table:
+        if batch.num_rows == 0:
+            return batch.append_column(frid_col, pa.array([], type=pa.int64()))
+        rid_col = batch.column(row_id_name)
+        if rid_col.null_count:
+            raise ValueError(
+                "_ROW_ID is null; the planner snapshot is stale or the row ids "
+                "come from a different table."
+            )
+        rids = rid_col.to_numpy(zero_copy_only=False)
+        in_range = np.zeros(len(rids), dtype=bool)
+        for s, e in zip(range_starts, range_ends):
+            in_range |= (rids >= s) & (rids <= e)
+        if not in_range.all():
+            bad = rids[~in_range][0]
+            raise ValueError(
+                f"_ROW_ID {bad} does not belong to any valid range "
+                f"{[f'[{r.from_}, {r.to}]' for r in valid_ranges]}; the planner "
+                f"snapshot is stale or the row ids come from a different table."
+            )
+        idx = np.searchsorted(sorted_arr, rids, side="right") - 1
+        return batch.append_column(
+            frid_col, pa.array(sorted_arr[idx], type=pa.int64())
+        )
+
+    captured_table = table
+    captured_read_cols = read_cols
+
+    def _read_group(group: pa.Table) -> pa.Table:
+        if group.num_rows == 0:
+            return group.drop_columns([frid_col])
+        frid = int(group.column(frid_col)[0].as_py())
+        info = ray.get(precomputed_info_ref)
+        owning_split, target_files = info.first_row_id_index[frid]
+        origin_split = DataSplit(
+            files=target_files,
+            partition=owning_split.partition,
+            bucket=owning_split.bucket,
+            raw_convertible=True,
+        )
+        # Read only the matched rows: one discrete [rid, rid] range per row id.
+        # For blob format this becomes native row-index pushdown, so unmatched
+        # rows in the owning file are never materialised. Duplicate row ids are
+        # deduplicated (each matched row is returned once, like SQL ``IN``).
+        wanted = sorted(set(group.column(row_id_name).to_pylist()))
+        indexed = IndexedSplit(origin_split, [Range(r, r) for r in wanted])
+        read = captured_table.new_read_builder().with_projection(
+            captured_read_cols
+        ).new_read()
+        return read.to_arrow([indexed])
+
+    map_kwargs = _map_kwargs(ray_remote_args)
+    with_frid = row_ids_ds.map_batches(_assign_frid, **map_kwargs)
+    group_partitions = max(1, min(len(sorted_first_row_ids), num_partitions))
+    return with_frid.groupby(frid_col, num_partitions=group_partitions).map_groups(
+        _read_group, **map_kwargs
+    )
+
+
 def distributed_delete_apply(
     delete_ds,
     table,

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -584,6 +584,21 @@ def distributed_update_apply(
     return all_msgs, num_updated, action_row_ids
 
 
+def _read_output_schema(table, read_cols: Sequence[str]) -> "pa.Schema":
+    """Arrow schema of a read-by-row-id result: each projected column's type plus
+    int64 ``_ROW_ID``, in ``read_cols`` order. Shared by the empty-result paths so
+    the schema of an empty read can't drift from a non-empty one."""
+    from pypaimon.schema.data_types import PyarrowFieldParser
+    from pypaimon.table.special_fields import SpecialFields
+
+    rid = SpecialFields.ROW_ID.name
+    full = PyarrowFieldParser.from_paimon_schema(table.table_schema.fields)
+    return pa.schema([
+        (col, pa.int64() if col == rid else full.field(col).type)
+        for col in read_cols
+    ])
+
+
 def distributed_read_by_row_id(
     row_ids_ds,
     table,
@@ -608,7 +623,6 @@ def distributed_read_by_row_id(
     from pypaimon.common.options.core_options import CoreOptions
     from pypaimon.globalindex.indexed_split import IndexedSplit
     from pypaimon.read.split import DataSplit
-    from pypaimon.schema.data_types import PyarrowFieldParser
     from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
     from pypaimon.table.special_fields import SpecialFields
     from pypaimon.utils.range import Range
@@ -619,17 +633,14 @@ def distributed_read_by_row_id(
     if row_id_name not in read_cols:
         read_cols.append(row_id_name)
 
-    # The exact output schema (projection order, then _ROW_ID); used to emit a
-    # correctly-typed empty block if a group is ever empty, so all output blocks
-    # share one schema.
-    full_pa = PyarrowFieldParser.from_paimon_schema(table.table_schema.fields)
-    empty_out = pa.schema([
-        (col, pa.int64() if col == row_id_name else full_pa.field(col).type)
-        for col in read_cols
-    ]).empty_table()
+    # A correctly-typed empty block, in case a group is ever empty, so every output
+    # block shares one schema.
+    empty_out = _read_output_schema(table, read_cols).empty_table()
 
-    # Pin the planner to the caller's base snapshot so row-id routing is stable
-    # even if a concurrent commit lands (mirrors the update path).
+    # Reuse TableUpdateByRowId purely as a read-only planner: its constructor only
+    # scans the manifest to index files by first_row_id (no staging dirs, locks or
+    # commits). Pin it to the caller's base snapshot so routing is stable even if a
+    # concurrent commit lands (mirrors the update path).
     scan_table = (
         table.copy({CoreOptions.SCAN_SNAPSHOT_ID.key(): str(base_snapshot_id)})
         if base_snapshot_id is not None else table
@@ -682,6 +693,9 @@ def distributed_read_by_row_id(
     captured_empty = empty_out
 
     def _read_group(group: pa.Table) -> pa.Table:
+        # The group supplies only row ids (all owned by the same file, keyed by
+        # frid); output columns come from the fresh projected read below, so the
+        # injected frid_col never leaks into the result.
         if group.num_rows == 0:
             return captured_empty
         frid = int(group.column(frid_col)[0].as_py())

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -607,12 +607,10 @@ def distributed_read_by_row_id(
     ray_remote_args: Optional[Dict[str, Any]] = None,
     base_snapshot_id: Optional[int] = None,
 ):
-    """Read ``projection`` columns for the row ids in ``row_ids_ds`` (must carry
-    ``_ROW_ID``). Each row id is routed to its owning data file, then only those
-    files -- and only the matched rows -- are read via ``IndexedSplit`` row-range
-    slicing (blob columns resolved). Returns a ``ray.data.Dataset`` of
-    ``(*projection, _ROW_ID)``, or ``None`` when the target is empty. The read-side
-    mirror of ``distributed_update_apply``; the target is never fully scanned.
+    """Read ``projection`` for the ``_ROW_ID``s in ``row_ids_ds``, routing each to its
+    owning file and reading only the matched rows via ``IndexedSplit`` slicing (blob
+    resolved). Returns a ``ray.data.Dataset`` of ``(*projection, _ROW_ID)``, or ``None``
+    if the target is empty. Read-side mirror of ``distributed_update_apply``.
     """
     import numpy as np
     import uuid
@@ -635,8 +633,7 @@ def distributed_read_by_row_id(
     # Typed empty block so all output blocks share one schema.
     empty_out = _read_output_schema(table, read_cols).empty_table()
 
-    # Read-only planner: construction only scans the manifest (no writes). Pin to the
-    # base snapshot so routing is stable under concurrent commits (as the update path).
+    # Read-only planner (only scans the manifest); pinned to the base snapshot for stable routing.
     scan_table = (
         table.copy({CoreOptions.SCAN_SNAPSHOT_ID.key(): str(base_snapshot_id)})
         if base_snapshot_id is not None else table
@@ -650,7 +647,6 @@ def distributed_read_by_row_id(
     if not sorted_first_row_ids:
         return None
 
-    # Broadcast the file index once so workers don't re-scan the manifest.
     precomputed_info_ref = ray.put(planner._snapshot_files_info())
     frid_col = "_FIRST_ROW_ID"
     sorted_arr = np.asarray(sorted_first_row_ids, dtype=np.int64)
@@ -668,9 +664,15 @@ def distributed_read_by_row_id(
                 "come from a different table."
             )
         rids = rid_col.to_numpy(zero_copy_only=False)
-        in_range = np.zeros(len(rids), dtype=bool)
-        for s, e in zip(range_starts, range_ends):
-            in_range |= (rids >= s) & (rids <= e)
+        # Foreign-id check: valid_ranges are sorted+merged, so one searchsorted finds
+        # the candidate range (O(rows log ranges), like distributed_delete_apply).
+        ridx = np.searchsorted(range_starts, rids, side="right") - 1
+        safe = np.clip(ridx, 0, len(range_starts) - 1)
+        in_range = (
+            (ridx >= 0)
+            & (rids >= range_starts[safe])
+            & (rids <= range_ends[safe])
+        )
         if not in_range.all():
             bad = rids[~in_range][0]
             raise ValueError(
@@ -688,8 +690,6 @@ def distributed_read_by_row_id(
     captured_empty = empty_out
 
     def _read_group(group: pa.Table) -> pa.Table:
-        # Group supplies only row ids; output comes from the fresh read, so frid_col
-        # never leaks.
         if group.num_rows == 0:
             return captured_empty
         frid = int(group.column(frid_col)[0].as_py())
@@ -701,8 +701,7 @@ def distributed_read_by_row_id(
             bucket=owning_split.bucket,
             raw_convertible=True,
         )
-        # Read only the matched rows (deduped, contiguous ids compressed to ranges);
-        # blob format gets native row-index pushdown, so unmatched rows aren't read.
+        # Only matched rows (deduped, contiguous ids -> ranges); blob gets row-index pushdown.
         wanted = set(group.column(row_id_name).to_pylist())
         indexed = IndexedSplit(origin_split, Range.to_ranges(list(wanted)))
         read = captured_table.new_read_builder().with_projection(

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -693,12 +693,13 @@ def distributed_read_by_row_id(
             bucket=owning_split.bucket,
             raw_convertible=True,
         )
-        # Read only the matched rows: one discrete [rid, rid] range per row id.
-        # For blob format this becomes native row-index pushdown, so unmatched
-        # rows in the owning file are never materialised. Duplicate row ids are
-        # deduplicated (each matched row is returned once, like SQL ``IN``).
-        wanted = sorted(set(group.column(row_id_name).to_pylist()))
-        indexed = IndexedSplit(origin_split, [Range(r, r) for r in wanted])
+        # Read only the matched rows: contiguous row ids are compressed into
+        # ranges (so a dense group is a few ranges, not one object per row). For
+        # blob format this becomes native row-index pushdown, so unmatched rows in
+        # the owning file are never materialised. Duplicate row ids are deduplicated
+        # (each matched row is returned once, like SQL ``IN``).
+        wanted = set(group.column(row_id_name).to_pylist())
+        indexed = IndexedSplit(origin_split, Range.to_ranges(list(wanted)))
         read = captured_table.new_read_builder().with_projection(
             captured_read_cols
         ).new_read()

--- a/paimon-python/pypaimon/ray/read_by_row_id.py
+++ b/paimon-python/pypaimon/ray/read_by_row_id.py
@@ -64,12 +64,18 @@ def read_by_row_id(
 
     ``row_ids`` (a ``ray.data.Dataset`` / ``pyarrow.Table`` / ``pandas.DataFrame``)
     must carry the target row ids in column ``row_id_col`` (default ``_ROW_ID``; set
-    e.g. ``row_id_col="row_id"`` for a ``bucket_join`` locator); any other columns are
-    ignored. Each row id is routed to the data file owning it and only those files --
-    and only the matched rows -- are read, so the target is never fully scanned and
-    there is no join against it. ``projection`` may include blob columns, which are
-    resolved to their payloads. Requires ``ray >= 2.50`` and a target with
-    ``data-evolution.enabled`` + ``row-tracking.enabled``.
+    e.g. ``row_id_col="row_id"`` for a ``bucket_join`` locator). Each row id is routed
+    to the data file owning it and only those files -- and only the matched rows --
+    are read, so the target is never fully scanned and there is no join against it.
+    ``projection`` may include blob columns, which are resolved to their payloads.
+    Requires ``ray >= 2.50`` and a target with ``data-evolution.enabled`` +
+    ``row-tracking.enabled``.
+
+    Lookup/set semantics, like SQL ``... WHERE _ROW_ID IN (...)``: the result has one
+    row per *distinct* matched row id -- duplicate row ids are deduplicated, source
+    columns other than ``row_id_col`` are dropped, and the input row order is not
+    preserved (rows come out grouped by owning file). An empty source yields an empty
+    but correctly-typed Dataset.
 
     Returns a ``ray.data.Dataset`` of ``(*projection, _ROW_ID)``.
     """

--- a/paimon-python/pypaimon/ray/read_by_row_id.py
+++ b/paimon-python/pypaimon/ray/read_by_row_id.py
@@ -34,25 +34,20 @@ from pypaimon.ray.data_evolution_merge_into import (
     _require_ray_join,
     _resolve_num_partitions,
 )
-from pypaimon.ray.data_evolution_merge_join import distributed_read_by_row_id
+from pypaimon.ray.data_evolution_merge_join import (
+    _read_output_schema,
+    distributed_read_by_row_id,
+)
 
 __all__ = ["read_by_row_id"]
 
 
 def _empty_result(table: "FileStoreTable", read_cols: List[str]):
-    """An empty ``ray.data.Dataset`` with the projected schema (empty target)."""
+    """An empty ``ray.data.Dataset`` with the projected read schema (empty source
+    or target). Uses the same schema builder as the read path so they can't drift."""
     import ray
 
-    from pypaimon.schema.data_types import PyarrowFieldParser
-    from pypaimon.table.special_fields import SpecialFields
-
-    rid = SpecialFields.ROW_ID.name
-    full = PyarrowFieldParser.from_paimon_schema(table.table_schema.fields)
-    arrays = {}
-    for col in read_cols:
-        col_type = pa.int64() if col == rid else full.field(col).type
-        arrays[col] = pa.array([], type=col_type)
-    return ray.data.from_arrow(pa.table(arrays))
+    return ray.data.from_arrow(_read_output_schema(table, read_cols).empty_table())
 
 
 def read_by_row_id(

--- a/paimon-python/pypaimon/ray/read_by_row_id.py
+++ b/paimon-python/pypaimon/ray/read_by_row_id.py
@@ -61,18 +61,20 @@ def read_by_row_id(
     catalog_options: Dict[str, str],
     *,
     projection: List[str],
+    row_id_col: Optional[str] = None,
     num_partitions: Optional[int] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
 ):
     """Read ``projection`` columns of a data-evolution table by ``_ROW_ID``.
 
     ``row_ids`` (a ``ray.data.Dataset`` / ``pyarrow.Table`` / ``pandas.DataFrame``)
-    must carry the target ``_ROW_ID``; any other columns are ignored. Each row id is
-    routed to the data file owning it and only those files -- and only the matched
-    rows -- are read, so the target is never fully scanned and there is no join
-    against it. ``projection`` may include blob columns, which are resolved to their
-    payloads. Requires ``ray >= 2.50`` and a target with ``data-evolution.enabled`` +
-    ``row-tracking.enabled``.
+    must carry the target row ids in column ``row_id_col`` (default ``_ROW_ID``; set
+    e.g. ``row_id_col="row_id"`` for a ``bucket_join`` locator); any other columns are
+    ignored. Each row id is routed to the data file owning it and only those files --
+    and only the matched rows -- are read, so the target is never fully scanned and
+    there is no join against it. ``projection`` may include blob columns, which are
+    resolved to their payloads. Requires ``ray >= 2.50`` and a target with
+    ``data-evolution.enabled`` + ``row-tracking.enabled``.
 
     Returns a ``ray.data.Dataset`` of ``(*projection, _ROW_ID)``.
     """
@@ -100,6 +102,7 @@ def read_by_row_id(
             f"'{target}'.")
 
     rid = SpecialFields.ROW_ID.name
+    src_rid_col = row_id_col or rid  # source column holding the target row ids
     for col in projection:
         if col != rid and col not in table.field_names:
             raise ValueError(f"projection column {col!r} is not in target '{target}'.")
@@ -110,25 +113,32 @@ def read_by_row_id(
         # already carries the target row ids (e.g. produced by bucket_join).
         raise ValueError(
             "read_by_row_id does not accept a table-name source; pass a ray.data."
-            f"Dataset / pyarrow.Table / pandas.DataFrame carrying the target {rid}.")
+            "Dataset / pyarrow.Table / pandas.DataFrame carrying the target row ids.")
     source_ds = _normalize_source(row_ids, catalog_options)
-    if rid not in set(source_ds.schema().names):
-        raise ValueError(f"row_ids source is missing the {rid} column.")
+    if src_rid_col not in set(source_ds.schema().names):
+        raise ValueError(f"row_ids source is missing the {src_rid_col!r} column.")
 
-    # Route on _ROW_ID alone (int64); drop any other source columns.
+    # Route on the row ids alone (int64), renamed to _ROW_ID; drop other columns.
     def _project_rid(batch: pa.Table) -> pa.Table:
-        return batch.select([rid]).cast(pa.schema([(rid, pa.int64())]))
+        return pa.table({rid: batch.column(src_rid_col).cast(pa.int64())})
 
     rid_ds = source_ds.map_batches(_project_rid, batch_format="pyarrow")
     read_cols = list(projection) + ([rid] if rid not in projection else [])
+
+    # An empty source yields an empty result whatever the target holds. Return a
+    # typed empty Dataset up front: a groupby over zero rows produces zero groups,
+    # so the read map is never called and the output would otherwise be schema-less.
+    source_empty = rid_ds.limit(1).count() == 0
 
     base = table.snapshot_manager().get_latest_snapshot()
     # Without deletion vectors (rejected above), total_record_count is the live row
     # count, so 0 means the target is empty (never written, or emptied by overwrite).
     if base is None or base.total_record_count == 0:
-        if rid_ds.limit(1).count() > 0:
+        if not source_empty:
             raise ValueError(
                 f"target '{target}' has no rows; every _ROW_ID in the source is foreign.")
+        return _empty_result(table, read_cols)
+    if source_empty:
         return _empty_result(table, read_cols)
     try:
         result = distributed_read_by_row_id(

--- a/paimon-python/pypaimon/ray/read_by_row_id.py
+++ b/paimon-python/pypaimon/ray/read_by_row_id.py
@@ -96,8 +96,7 @@ def read_by_row_id(
         raise ValueError(
             f"read_by_row_id requires 'row-tracking.enabled'='true' on '{target}'.")
     if table.options.deletion_vectors_enabled():
-        # A DV-deleted row still lives in its data file, so row-id slicing can't tell
-        # it apart without extra reads; refuse rather than surface a deleted row.
+        # A DV-deleted row still lives in its file, so slicing would surface it.
         raise ValueError(
             f"read_by_row_id does not support deletion-vectors-enabled tables yet: "
             f"'{target}'.")
@@ -109,9 +108,7 @@ def read_by_row_id(
             raise ValueError(f"projection column {col!r} is not in target '{target}'.")
 
     if isinstance(row_ids, str):
-        # A table's system _ROW_ID is its own, independent of the target's, so a
-        # table-name source can't address target rows. Require in-memory data that
-        # already carries the target row ids (e.g. produced by bucket_join).
+        # A source table's _ROW_ID is its own, not the target's; require in-memory ids.
         raise ValueError(
             "read_by_row_id does not accept a table-name source; pass a ray.data."
             "Dataset / pyarrow.Table / pandas.DataFrame carrying the target row ids.")
@@ -126,14 +123,12 @@ def read_by_row_id(
     rid_ds = source_ds.map_batches(_project_rid, batch_format="pyarrow")
     read_cols = list(projection) + ([rid] if rid not in projection else [])
 
-    # An empty source yields an empty result whatever the target holds. Return a
-    # typed empty Dataset up front: a groupby over zero rows produces zero groups,
-    # so the read map is never called and the output would otherwise be schema-less.
+    # Empty source -> typed empty Dataset up front: a zero-row groupby yields no
+    # groups, so the read never runs and the output would otherwise be schema-less.
     source_empty = rid_ds.limit(1).count() == 0
 
     base = table.snapshot_manager().get_latest_snapshot()
-    # Without deletion vectors (rejected above), total_record_count is the live row
-    # count, so 0 means the target is empty (never written, or emptied by overwrite).
+    # No DV (rejected above) -> total_record_count is the live row count; 0 = empty.
     if base is None or base.total_record_count == 0:
         if not source_empty:
             raise ValueError(

--- a/paimon-python/pypaimon/ray/read_by_row_id.py
+++ b/paimon-python/pypaimon/ray/read_by_row_id.py
@@ -17,11 +17,9 @@
 
 """Distributed row-id read on Ray for data-evolution tables.
 
-Read columns (including blob) of a data-evolution table straight from a Ray Dataset
-that carries ``_ROW_ID`` -- no full-target read and no big-table shuffle join. Each
-row id is routed to the data file owning it and only those files (and only the matched
-rows) are read. The read-side mirror of ``update_by_row_id``; pairs with ``bucket_join``,
-which produces the row ids.
+The read-side mirror of ``update_by_row_id``: read columns (including blob) for a set
+of ``_ROW_ID``s by routing each to its owning data file -- no full-target read, no
+shuffle join. Pairs with ``bucket_join``, which produces the row ids.
 """
 
 from typing import Any, Dict, List, Optional
@@ -67,7 +65,7 @@ def read_by_row_id(
     e.g. ``row_id_col="row_id"`` for a ``bucket_join`` locator). Each row id is routed
     to the data file owning it and only those files -- and only the matched rows --
     are read, so the target is never fully scanned and there is no join against it.
-    ``projection`` may include blob columns, which are resolved to their payloads.
+    ``projection`` lists top-level columns; blob columns are resolved to their payloads.
     Requires ``ray >= 2.50`` and a target with ``data-evolution.enabled`` +
     ``row-tracking.enabled``.
 
@@ -85,7 +83,7 @@ def read_by_row_id(
     _require_ray_join()
     if not projection:
         raise ValueError("projection must be non-empty.")
-    projection = list(dict.fromkeys(projection))  # de-dup, keep order
+    projection = list(dict.fromkeys(projection))
     num_partitions = _resolve_num_partitions(num_partitions)
 
     table = CatalogFactory.create(catalog_options).get_table(target)
@@ -102,7 +100,7 @@ def read_by_row_id(
             f"'{target}'.")
 
     rid = SpecialFields.ROW_ID.name
-    src_rid_col = row_id_col or rid  # source column holding the target row ids
+    src_rid_col = row_id_col or rid
     for col in projection:
         if col != rid and col not in table.field_names:
             raise ValueError(f"projection column {col!r} is not in target '{target}'.")
@@ -116,15 +114,13 @@ def read_by_row_id(
     if src_rid_col not in set(source_ds.schema().names):
         raise ValueError(f"row_ids source is missing the {src_rid_col!r} column.")
 
-    # Route on the row ids alone (int64), renamed to _ROW_ID; drop other columns.
     def _project_rid(batch: pa.Table) -> pa.Table:
         return pa.table({rid: batch.column(src_rid_col).cast(pa.int64())})
 
     rid_ds = source_ds.map_batches(_project_rid, batch_format="pyarrow")
     read_cols = list(projection) + ([rid] if rid not in projection else [])
 
-    # Empty source -> typed empty Dataset up front: a zero-row groupby yields no
-    # groups, so the read never runs and the output would otherwise be schema-less.
+    # Empty source -> typed empty Dataset (a zero-row groupby has no schema).
     source_empty = rid_ds.limit(1).count() == 0
 
     base = table.snapshot_manager().get_latest_snapshot()
@@ -145,7 +141,7 @@ def read_by_row_id(
         )
     except Exception as e:
         _reraise_inner(e)
-        raise  # _reraise_inner always raises; keeps result defined for linters
+        raise  # _reraise_inner always raises
     if result is None:
         return _empty_result(table, read_cols)
     return result

--- a/paimon-python/pypaimon/ray/read_by_row_id.py
+++ b/paimon-python/pypaimon/ray/read_by_row_id.py
@@ -1,0 +1,145 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+"""Distributed row-id read on Ray for data-evolution tables.
+
+Read columns (including blob) of a data-evolution table straight from a Ray Dataset
+that carries ``_ROW_ID`` -- no full-target read and no big-table shuffle join. Each
+row id is routed to the data file owning it and only those files (and only the matched
+rows) are read. The read-side mirror of ``update_by_row_id``; pairs with ``bucket_join``,
+which produces the row ids.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import pyarrow as pa
+
+from pypaimon.ray.data_evolution_merge_into import (
+    _normalize_source,
+    _reraise_inner,
+    _require_ray_join,
+    _resolve_num_partitions,
+)
+from pypaimon.ray.data_evolution_merge_join import distributed_read_by_row_id
+
+__all__ = ["read_by_row_id"]
+
+
+def _empty_result(table: "FileStoreTable", read_cols: List[str]):
+    """An empty ``ray.data.Dataset`` with the projected schema (empty target)."""
+    import ray
+
+    from pypaimon.schema.data_types import PyarrowFieldParser
+    from pypaimon.table.special_fields import SpecialFields
+
+    rid = SpecialFields.ROW_ID.name
+    full = PyarrowFieldParser.from_paimon_schema(table.table_schema.fields)
+    arrays = {}
+    for col in read_cols:
+        col_type = pa.int64() if col == rid else full.field(col).type
+        arrays[col] = pa.array([], type=col_type)
+    return ray.data.from_arrow(pa.table(arrays))
+
+
+def read_by_row_id(
+    target: str,
+    row_ids: Any,
+    catalog_options: Dict[str, str],
+    *,
+    projection: List[str],
+    num_partitions: Optional[int] = None,
+    ray_remote_args: Optional[Dict[str, Any]] = None,
+):
+    """Read ``projection`` columns of a data-evolution table by ``_ROW_ID``.
+
+    ``row_ids`` (a ``ray.data.Dataset`` / ``pyarrow.Table`` / ``pandas.DataFrame``)
+    must carry the target ``_ROW_ID``; any other columns are ignored. Each row id is
+    routed to the data file owning it and only those files -- and only the matched
+    rows -- are read, so the target is never fully scanned and there is no join
+    against it. ``projection`` may include blob columns, which are resolved to their
+    payloads. Requires ``ray >= 2.50`` and a target with ``data-evolution.enabled`` +
+    ``row-tracking.enabled``.
+
+    Returns a ``ray.data.Dataset`` of ``(*projection, _ROW_ID)``.
+    """
+    from pypaimon.catalog.catalog_factory import CatalogFactory
+    from pypaimon.table.special_fields import SpecialFields
+
+    _require_ray_join()
+    if not projection:
+        raise ValueError("projection must be non-empty.")
+    projection = list(dict.fromkeys(projection))  # de-dup, keep order
+    num_partitions = _resolve_num_partitions(num_partitions)
+
+    table = CatalogFactory.create(catalog_options).get_table(target)
+    if not table.options.data_evolution_enabled():
+        raise ValueError(
+            f"read_by_row_id requires 'data-evolution.enabled'='true' on '{target}'.")
+    if not table.options.row_tracking_enabled():
+        raise ValueError(
+            f"read_by_row_id requires 'row-tracking.enabled'='true' on '{target}'.")
+    if table.options.deletion_vectors_enabled():
+        # A DV-deleted row still lives in its data file, so row-id slicing can't tell
+        # it apart without extra reads; refuse rather than surface a deleted row.
+        raise ValueError(
+            f"read_by_row_id does not support deletion-vectors-enabled tables yet: "
+            f"'{target}'.")
+
+    rid = SpecialFields.ROW_ID.name
+    for col in projection:
+        if col != rid and col not in table.field_names:
+            raise ValueError(f"projection column {col!r} is not in target '{target}'.")
+
+    if isinstance(row_ids, str):
+        # A table's system _ROW_ID is its own, independent of the target's, so a
+        # table-name source can't address target rows. Require in-memory data that
+        # already carries the target row ids (e.g. produced by bucket_join).
+        raise ValueError(
+            "read_by_row_id does not accept a table-name source; pass a ray.data."
+            f"Dataset / pyarrow.Table / pandas.DataFrame carrying the target {rid}.")
+    source_ds = _normalize_source(row_ids, catalog_options)
+    if rid not in set(source_ds.schema().names):
+        raise ValueError(f"row_ids source is missing the {rid} column.")
+
+    # Route on _ROW_ID alone (int64); drop any other source columns.
+    def _project_rid(batch: pa.Table) -> pa.Table:
+        return batch.select([rid]).cast(pa.schema([(rid, pa.int64())]))
+
+    rid_ds = source_ds.map_batches(_project_rid, batch_format="pyarrow")
+    read_cols = list(projection) + ([rid] if rid not in projection else [])
+
+    base = table.snapshot_manager().get_latest_snapshot()
+    # Without deletion vectors (rejected above), total_record_count is the live row
+    # count, so 0 means the target is empty (never written, or emptied by overwrite).
+    if base is None or base.total_record_count == 0:
+        if rid_ds.limit(1).count() > 0:
+            raise ValueError(
+                f"target '{target}' has no rows; every _ROW_ID in the source is foreign.")
+        return _empty_result(table, read_cols)
+    try:
+        result = distributed_read_by_row_id(
+            rid_ds, table, projection,
+            num_partitions=num_partitions,
+            ray_remote_args=ray_remote_args,
+            base_snapshot_id=base.id,
+        )
+    except Exception as e:
+        _reraise_inner(e)
+        raise  # _reraise_inner always raises; keeps result defined for linters
+    if result is None:
+        return _empty_result(table, read_cols)
+    return result

--- a/paimon-python/pypaimon/tests/ray_read_by_row_id_test.py
+++ b/paimon-python/pypaimon/tests/ray_read_by_row_id_test.py
@@ -277,6 +277,16 @@ class RayReadByRowIdTest(unittest.TestCase):
         ds = read_by_row_id(target, empty_src, self.catalog_options, projection=["age"])
         self.assertEqual(ds.count(), 0)
 
+    def test_foreign_row_id_raises(self):
+        # A row id outside the target's valid ranges is rejected (surfaces on read).
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1, 2], "name": ["a", "b"], "age": [1, 2]}, schema=self.pa_schema))
+        src = pa.table({"_ROW_ID": [10_000]}, schema=pa.schema([("_ROW_ID", pa.int64())]))
+        ds = read_by_row_id(target, src, self.catalog_options, projection=["age"])
+        with self.assertRaises(Exception):
+            ds.take_all()
+
     def test_empty_source_non_empty_target_keeps_schema(self):
         # A groupby over zero rows yields zero groups, so the output must still carry
         # the projected schema (projection + _ROW_ID), not be schema-less.

--- a/paimon-python/pypaimon/tests/ray_read_by_row_id_test.py
+++ b/paimon-python/pypaimon/tests/ray_read_by_row_id_test.py
@@ -125,6 +125,31 @@ class RayReadByRowIdTest(unittest.TestCase):
         self.assertEqual(rows[0]["id"], 21)
         self.assertEqual(rows[0]["age"], 21)
 
+    def test_reads_across_evolution_split_files(self):
+        # update_by_row_id writes a column delta, splitting a row's range across the
+        # original file and the delta. read_by_row_id must merge them: the updated
+        # column comes from the delta, the untouched column from the original file.
+        from pypaimon.ray import update_by_row_id
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1, 2, 3], "name": ["a", "b", "c"], "age": [10, 20, 30]},
+            schema=self.pa_schema))
+        rid = self._rowid_by_id(target)
+        update_by_row_id(
+            target,
+            pa.table({"_ROW_ID": [rid[2]], "age": [999]},
+                     schema=pa.schema([("_ROW_ID", pa.int64()), ("age", pa.int32())])),
+            self.catalog_options, update_cols=["age"])
+        ds = read_by_row_id(
+            target,
+            pa.table({"_ROW_ID": [rid[2]]}, schema=pa.schema([("_ROW_ID", pa.int64())])),
+            self.catalog_options, projection=["id", "name", "age"])
+        rows = ds.take_all()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["id"], 2)
+        self.assertEqual(rows[0]["name"], "b")     # untouched, from original file
+        self.assertEqual(rows[0]["age"], 999)      # updated, from delta file
+
     def test_reads_blob_column(self):
         blob_schema = pa.schema([("id", pa.int32()), ("payload", pa.large_binary())])
         target = self._create(schema=blob_schema)

--- a/paimon-python/pypaimon/tests/ray_read_by_row_id_test.py
+++ b/paimon-python/pypaimon/tests/ray_read_by_row_id_test.py
@@ -104,13 +104,12 @@ class RayReadByRowIdTest(unittest.TestCase):
         ds = read_by_row_id(target, ray.data.from_arrow(src), self.catalog_options,
                             projection=["id", "name", "age"])
         got = self._rows_by_id(ds)
-        self.assertEqual(set(got), set(want))                 # only requested rows
+        self.assertEqual(set(got), set(want))
         self.assertEqual(got[2]["age"], 20)
         self.assertEqual(got[5]["name"], "n5")
-        self.assertEqual(got[2]["_ROW_ID"], rid[2])           # _ROW_ID carried through
+        self.assertEqual(got[2]["_ROW_ID"], rid[2])
 
     def test_reads_correct_row_across_files(self):
-        # A _ROW_ID owned by a middle data file must return only that row.
         target = self._create()
         for chunk in ([10, 11, 12], [20, 21], [30, 31, 32, 33]):
             self._write(target, pa.Table.from_pydict(
@@ -126,9 +125,7 @@ class RayReadByRowIdTest(unittest.TestCase):
         self.assertEqual(rows[0]["age"], 21)
 
     def test_reads_across_evolution_split_files(self):
-        # update_by_row_id writes a column delta, splitting a row's range across the
-        # original file and the delta. read_by_row_id must merge them: the updated
-        # column comes from the delta, the untouched column from the original file.
+        # update_by_row_id writes a column delta (splits the row's range); the read must merge original + delta.
         from pypaimon.ray import update_by_row_id
         target = self._create()
         self._write(target, pa.Table.from_pydict(
@@ -147,8 +144,8 @@ class RayReadByRowIdTest(unittest.TestCase):
         rows = ds.take_all()
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["id"], 2)
-        self.assertEqual(rows[0]["name"], "b")     # untouched, from original file
-        self.assertEqual(rows[0]["age"], 999)      # updated, from delta file
+        self.assertEqual(rows[0]["name"], "b")
+        self.assertEqual(rows[0]["age"], 999)
 
     def test_reads_blob_column(self):
         blob_schema = pa.schema([("id", pa.int32()), ("payload", pa.large_binary())])
@@ -164,13 +161,12 @@ class RayReadByRowIdTest(unittest.TestCase):
                             projection=["id", "payload"])
         got = self._rows_by_id(ds)
         self.assertEqual(set(got), {2, 4})
-        self.assertEqual(bytes(got[2]["payload"]), payloads[1])   # blob resolved to payload
+        self.assertEqual(bytes(got[2]["payload"]), payloads[1])
         self.assertEqual(bytes(got[4]["payload"]), payloads[3])
 
     def test_pins_base_snapshot(self):
-        # The read pins its base snapshot and threads it to distributed_read_by_row_id.
         import importlib
-        m = importlib.import_module("pypaimon.ray.read_by_row_id")  # module, not the fn
+        m = importlib.import_module("pypaimon.ray.read_by_row_id")
         target = self._create()
         self._write(target, pa.Table.from_pydict(
             {"id": [1, 2], "name": ["a", "b"], "age": [1, 2]}, schema=self.pa_schema))
@@ -196,12 +192,10 @@ class RayReadByRowIdTest(unittest.TestCase):
             {"id": [1, 2, 3], "name": ["a", "b", "c"], "age": [1, 2, 3]},
             schema=self.pa_schema))
         rid = self._rowid_by_id(target)
-        # pyarrow.Table source
         ds = read_by_row_id(
             target, pa.table({"_ROW_ID": [rid[2]]}, schema=pa.schema([("_ROW_ID", pa.int64())])),
             self.catalog_options, projection=["name"])
         self.assertEqual([r["name"] for r in ds.take_all()], ["b"])
-        # pandas.DataFrame source
         import pandas as pd
         ds = read_by_row_id(
             target, pd.DataFrame({"_ROW_ID": pd.array([rid[3]], dtype="int64")}),
@@ -213,7 +207,6 @@ class RayReadByRowIdTest(unittest.TestCase):
         self._write(target, pa.Table.from_pydict(
             {"id": [1, 2], "name": ["a", "b"], "age": [1, 2]}, schema=self.pa_schema))
         rid = self._rowid_by_id(target)
-        # source carries junk columns and a duplicate row id -> junk ignored, row deduped
         src = pa.table({"_ROW_ID": [rid[2], rid[2]], "junk": ["x", "y"]},
                        schema=pa.schema([("_ROW_ID", pa.int64()), ("junk", pa.string())]))
         ds = read_by_row_id(target, ray.data.from_arrow(src), self.catalog_options,
@@ -231,7 +224,7 @@ class RayReadByRowIdTest(unittest.TestCase):
                            projection=["age"])
 
     def test_rejects_non_data_evolution_table(self):
-        target = self._create(options={})  # plain append table
+        target = self._create(options={})
         self._write(target, pa.Table.from_pydict(
             {"id": [1], "name": ["a"], "age": [1]}, schema=self.pa_schema))
         src = pa.table({"_ROW_ID": [0]}, schema=pa.schema([("_ROW_ID", pa.int64())]))
@@ -269,16 +262,13 @@ class RayReadByRowIdTest(unittest.TestCase):
         src = pa.table({"_ROW_ID": [0]}, schema=pa.schema([("_ROW_ID", pa.int64())]))
         empty_src = pa.table({"_ROW_ID": pa.array([], pa.int64())})
 
-        # never written -> a foreign row id raises
         target = self._create()
         with self.assertRaises(ValueError):
             read_by_row_id(target, src, self.catalog_options, projection=["age"])
-        # empty source against an empty target -> empty result, not an error
         ds = read_by_row_id(target, empty_src, self.catalog_options, projection=["age"])
         self.assertEqual(ds.count(), 0)
 
     def test_foreign_row_id_raises(self):
-        # A row id outside the target's valid ranges is rejected (surfaces on read).
         target = self._create()
         self._write(target, pa.Table.from_pydict(
             {"id": [1, 2], "name": ["a", "b"], "age": [1, 2]}, schema=self.pa_schema))
@@ -288,8 +278,6 @@ class RayReadByRowIdTest(unittest.TestCase):
             ds.take_all()
 
     def test_empty_source_non_empty_target_keeps_schema(self):
-        # A groupby over zero rows yields zero groups, so the output must still carry
-        # the projected schema (projection + _ROW_ID), not be schema-less.
         target = self._create()
         self._write(target, pa.Table.from_pydict(
             {"id": [1, 2], "name": ["a", "b"], "age": [1, 2]}, schema=self.pa_schema))
@@ -299,8 +287,26 @@ class RayReadByRowIdTest(unittest.TestCase):
         self.assertIsNotNone(ds.schema())
         self.assertEqual(set(ds.schema().names), {"id", "age", "_ROW_ID"})
 
+    def test_empty_result_schema_matches_nonempty_read(self):
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1, 2], "name": ["a", "b"], "age": [1, 2]}, schema=self.pa_schema))
+        rid = self._rowid_by_id(target)
+        proj = ["id", "age"]
+        nonempty = read_by_row_id(
+            target, pa.table({"_ROW_ID": [rid[1]]}, schema=pa.schema([("_ROW_ID", pa.int64())])),
+            self.catalog_options, projection=proj)
+        real_schema = None
+        for b in nonempty.iter_batches(batch_format="pyarrow"):
+            real_schema = b.schema
+            break
+        empty = read_by_row_id(
+            target, pa.table({"_ROW_ID": pa.array([], pa.int64())}),
+            self.catalog_options, projection=proj)
+        self.assertTrue(real_schema.equals(empty.schema().base_schema))
+        self.assertFalse(empty.schema().base_schema.field("_ROW_ID").nullable)
+
     def test_custom_row_id_col(self):
-        # bucket_join locators expose "row_id", not the system "_ROW_ID".
         target = self._create()
         self._write(target, pa.Table.from_pydict(
             {"id": [1, 2, 3], "name": ["a", "b", "c"], "age": [1, 2, 3]},
@@ -312,7 +318,7 @@ class RayReadByRowIdTest(unittest.TestCase):
                             projection=["name"], row_id_col="row_id")
         rows = ds.take_all()
         self.assertEqual([r["name"] for r in rows], ["b"])
-        self.assertEqual(rows[0]["_ROW_ID"], rid[2])   # output still uses _ROW_ID
+        self.assertEqual(rows[0]["_ROW_ID"], rid[2])
 
 
 if __name__ == "__main__":

--- a/paimon-python/pypaimon/tests/ray_read_by_row_id_test.py
+++ b/paimon-python/pypaimon/tests/ray_read_by_row_id_test.py
@@ -277,6 +277,33 @@ class RayReadByRowIdTest(unittest.TestCase):
         ds = read_by_row_id(target, empty_src, self.catalog_options, projection=["age"])
         self.assertEqual(ds.count(), 0)
 
+    def test_empty_source_non_empty_target_keeps_schema(self):
+        # A groupby over zero rows yields zero groups, so the output must still carry
+        # the projected schema (projection + _ROW_ID), not be schema-less.
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1, 2], "name": ["a", "b"], "age": [1, 2]}, schema=self.pa_schema))
+        empty_src = pa.table({"_ROW_ID": pa.array([], pa.int64())})
+        ds = read_by_row_id(target, empty_src, self.catalog_options, projection=["id", "age"])
+        self.assertEqual(ds.count(), 0)
+        self.assertIsNotNone(ds.schema())
+        self.assertEqual(set(ds.schema().names), {"id", "age", "_ROW_ID"})
+
+    def test_custom_row_id_col(self):
+        # bucket_join locators expose "row_id", not the system "_ROW_ID".
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1, 2, 3], "name": ["a", "b", "c"], "age": [1, 2, 3]},
+            schema=self.pa_schema))
+        rid = self._rowid_by_id(target)
+        src = pa.table({"row_id": [rid[2]], "url": ["u2"]},
+                       schema=pa.schema([("row_id", pa.int64()), ("url", pa.string())]))
+        ds = read_by_row_id(target, src, self.catalog_options,
+                            projection=["name"], row_id_col="row_id")
+        rows = ds.take_all()
+        self.assertEqual([r["name"] for r in rows], ["b"])
+        self.assertEqual(rows[0]["_ROW_ID"], rid[2])   # output still uses _ROW_ID
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/paimon-python/pypaimon/tests/ray_read_by_row_id_test.py
+++ b/paimon-python/pypaimon/tests/ray_read_by_row_id_test.py
@@ -1,0 +1,257 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import os
+import shutil
+import tempfile
+import unittest
+import uuid
+from unittest import mock
+
+import pyarrow as pa
+import pytest
+
+pypaimon = pytest.importorskip("pypaimon")
+ray = pytest.importorskip("ray")
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.ray import read_by_row_id
+
+
+class RayReadByRowIdTest(unittest.TestCase):
+    """Distributed row-id read: read only the files owning the given row ids (and
+    only the matched rows), without reading or joining the whole target. The
+    read-side mirror of update_by_row_id."""
+
+    pa_schema = pa.schema([
+        ("id", pa.int32()),
+        ("name", pa.string()),
+        ("age", pa.int32()),
+    ])
+    de_options = {"row-tracking.enabled": "true", "data-evolution.enabled": "true"}
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        cls.catalog_options = {"warehouse": os.path.join(cls.tempdir, "wh")}
+        cls.catalog = CatalogFactory.create(cls.catalog_options)
+        cls.catalog.create_database("default", True)
+        if not ray.is_initialized():
+            ray.init(ignore_reinit_error=True, num_cpus=2)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            if ray.is_initialized():
+                ray.shutdown()
+        except Exception:
+            pass
+        shutil.rmtree(cls.tempdir, ignore_errors=True)
+
+    def _create(self, options=None, schema=None):
+        name = f"default.r_{uuid.uuid4().hex[:8]}"
+        opts = self.de_options if options is None else options
+        self.catalog.create_table(
+            name, Schema.from_pyarrow_schema(schema or self.pa_schema, options=opts), False)
+        return name
+
+    def _write(self, target, data):
+        t = self.catalog.get_table(target)
+        wb = t.new_batch_write_builder()
+        w = wb.new_write()
+        w.write_arrow(data)
+        wb.new_commit().commit(w.prepare_commit())
+        w.close()
+
+    def _read(self, target, projection=None):
+        t = self.catalog.get_table(target)
+        rb = t.new_read_builder()
+        if projection is not None:
+            rb = rb.with_projection(projection)
+        return rb.new_read().to_arrow(rb.new_scan().plan().splits())
+
+    def _rowid_by_id(self, target):
+        tab = self._read(target, ["_ROW_ID", "id"])
+        return dict(zip(tab.column("id").to_pylist(), tab.column("_ROW_ID").to_pylist()))
+
+    def _rows_by_id(self, ds):
+        return {r["id"]: r for r in ds.take_all()}
+
+    def test_read_by_row_id_basic(self):
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": list(range(1, 7)), "name": [f"n{i}" for i in range(1, 7)],
+             "age": [i * 10 for i in range(1, 7)]}, schema=self.pa_schema))
+        rid = self._rowid_by_id(target)
+
+        want = [2, 5]
+        src = pa.table({"_ROW_ID": [rid[i] for i in want]},
+                       schema=pa.schema([("_ROW_ID", pa.int64())]))
+        ds = read_by_row_id(target, ray.data.from_arrow(src), self.catalog_options,
+                            projection=["id", "name", "age"])
+        got = self._rows_by_id(ds)
+        self.assertEqual(set(got), set(want))                 # only requested rows
+        self.assertEqual(got[2]["age"], 20)
+        self.assertEqual(got[5]["name"], "n5")
+        self.assertEqual(got[2]["_ROW_ID"], rid[2])           # _ROW_ID carried through
+
+    def test_reads_correct_row_across_files(self):
+        # A _ROW_ID owned by a middle data file must return only that row.
+        target = self._create()
+        for chunk in ([10, 11, 12], [20, 21], [30, 31, 32, 33]):
+            self._write(target, pa.Table.from_pydict(
+                {"id": chunk, "name": ["x"] * len(chunk), "age": [c for c in chunk]},
+                schema=self.pa_schema))
+        rid = self._rowid_by_id(target)
+        src = pa.table({"_ROW_ID": [rid[21]]}, schema=pa.schema([("_ROW_ID", pa.int64())]))
+        ds = read_by_row_id(target, ray.data.from_arrow(src), self.catalog_options,
+                            projection=["id", "age"])
+        rows = ds.take_all()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["id"], 21)
+        self.assertEqual(rows[0]["age"], 21)
+
+    def test_reads_blob_column(self):
+        blob_schema = pa.schema([("id", pa.int32()), ("payload", pa.large_binary())])
+        target = self._create(schema=blob_schema)
+        payloads = [bytes([i]) * (i + 1) for i in range(1, 5)]
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1, 2, 3, 4], "payload": pa.array(payloads, pa.large_binary())},
+            schema=blob_schema))
+        rid = self._rowid_by_id(target)
+        src = pa.table({"_ROW_ID": [rid[2], rid[4]]},
+                       schema=pa.schema([("_ROW_ID", pa.int64())]))
+        ds = read_by_row_id(target, ray.data.from_arrow(src), self.catalog_options,
+                            projection=["id", "payload"])
+        got = self._rows_by_id(ds)
+        self.assertEqual(set(got), {2, 4})
+        self.assertEqual(bytes(got[2]["payload"]), payloads[1])   # blob resolved to payload
+        self.assertEqual(bytes(got[4]["payload"]), payloads[3])
+
+    def test_pins_base_snapshot(self):
+        # The read pins its base snapshot and threads it to distributed_read_by_row_id.
+        import importlib
+        m = importlib.import_module("pypaimon.ray.read_by_row_id")  # module, not the fn
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1, 2], "name": ["a", "b"], "age": [1, 2]}, schema=self.pa_schema))
+        expected_sid = self.catalog.get_table(
+            target).snapshot_manager().get_latest_snapshot().id
+        rid = self._rowid_by_id(target)
+        src = pa.table({"_ROW_ID": [rid[1]]}, schema=pa.schema([("_ROW_ID", pa.int64())]))
+
+        captured = {}
+
+        def fake_read(rid_ds, table, projection, *, num_partitions,
+                      ray_remote_args=None, base_snapshot_id=None):
+            captured["base_snapshot_id"] = base_snapshot_id
+            return ray.data.from_arrow(pa.table({"_ROW_ID": pa.array([], pa.int64())}))
+
+        with mock.patch.object(m, "distributed_read_by_row_id", fake_read):
+            read_by_row_id(target, src, self.catalog_options, projection=["age"])
+        self.assertEqual(captured["base_snapshot_id"], expected_sid)
+
+    def test_accepts_pyarrow_and_pandas_source(self):
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1, 2, 3], "name": ["a", "b", "c"], "age": [1, 2, 3]},
+            schema=self.pa_schema))
+        rid = self._rowid_by_id(target)
+        # pyarrow.Table source
+        ds = read_by_row_id(
+            target, pa.table({"_ROW_ID": [rid[2]]}, schema=pa.schema([("_ROW_ID", pa.int64())])),
+            self.catalog_options, projection=["name"])
+        self.assertEqual([r["name"] for r in ds.take_all()], ["b"])
+        # pandas.DataFrame source
+        import pandas as pd
+        ds = read_by_row_id(
+            target, pd.DataFrame({"_ROW_ID": pd.array([rid[3]], dtype="int64")}),
+            self.catalog_options, projection=["name"])
+        self.assertEqual([r["name"] for r in ds.take_all()], ["c"])
+
+    def test_ignores_extra_source_columns_and_dedups(self):
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1, 2], "name": ["a", "b"], "age": [1, 2]}, schema=self.pa_schema))
+        rid = self._rowid_by_id(target)
+        # source carries junk columns and a duplicate row id -> junk ignored, row deduped
+        src = pa.table({"_ROW_ID": [rid[2], rid[2]], "junk": ["x", "y"]},
+                       schema=pa.schema([("_ROW_ID", pa.int64()), ("junk", pa.string())]))
+        ds = read_by_row_id(target, ray.data.from_arrow(src), self.catalog_options,
+                            projection=["id", "name"])
+        rows = ds.take_all()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["name"], "b")
+
+    def test_rejects_table_name_source(self):
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1], "name": ["a"], "age": [1]}, schema=self.pa_schema))
+        with self.assertRaises(ValueError):
+            read_by_row_id(target, "default.some_source", self.catalog_options,
+                           projection=["age"])
+
+    def test_rejects_non_data_evolution_table(self):
+        target = self._create(options={})  # plain append table
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1], "name": ["a"], "age": [1]}, schema=self.pa_schema))
+        src = pa.table({"_ROW_ID": [0]}, schema=pa.schema([("_ROW_ID", pa.int64())]))
+        with self.assertRaises(ValueError):
+            read_by_row_id(target, src, self.catalog_options, projection=["age"])
+
+    def test_rejects_deletion_vectors_table(self):
+        opts = dict(self.de_options, **{"deletion-vectors.enabled": "true"})
+        target = self._create(options=opts)
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1], "name": ["a"], "age": [1]}, schema=self.pa_schema))
+        src = pa.table({"_ROW_ID": [0]}, schema=pa.schema([("_ROW_ID", pa.int64())]))
+        with self.assertRaises(ValueError):
+            read_by_row_id(target, src, self.catalog_options, projection=["age"])
+
+    def test_rejects_missing_row_id_column(self):
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1], "name": ["a"], "age": [1]}, schema=self.pa_schema))
+        src = pa.table({"id": [1]}, schema=pa.schema([("id", pa.int32())]))
+        with self.assertRaises(ValueError):
+            read_by_row_id(target, src, self.catalog_options, projection=["age"])
+
+    def test_rejects_unknown_and_empty_projection(self):
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1], "name": ["a"], "age": [1]}, schema=self.pa_schema))
+        src = pa.table({"_ROW_ID": [0]}, schema=pa.schema([("_ROW_ID", pa.int64())]))
+        with self.assertRaises(ValueError):
+            read_by_row_id(target, src, self.catalog_options, projection=["nope"])
+        with self.assertRaises(ValueError):
+            read_by_row_id(target, src, self.catalog_options, projection=[])
+
+    def test_empty_target(self):
+        src = pa.table({"_ROW_ID": [0]}, schema=pa.schema([("_ROW_ID", pa.int64())]))
+        empty_src = pa.table({"_ROW_ID": pa.array([], pa.int64())})
+
+        # never written -> a foreign row id raises
+        target = self._create()
+        with self.assertRaises(ValueError):
+            read_by_row_id(target, src, self.catalog_options, projection=["age"])
+        # empty source against an empty target -> empty result, not an error
+        ds = read_by_row_id(target, empty_src, self.catalog_options, projection=["age"])
+        self.assertEqual(ds.count(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Purpose

### Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New read path touches snapshot-pinned row-id routing and indexed file reads on data-evolution tables; mistakes could return wrong rows or mis-handle edge cases, but behavior is guarded by validation and extensive tests.
> 
> **Overview**
> Adds **`read_by_row_id`** to `pypaimon.ray` as the read counterpart to `update_by_row_id`: for data-evolution tables with row tracking, callers pass in-memory row ids (Ray Dataset / PyArrow / pandas) and a column projection, and get back a Ray Dataset without a full-table scan or shuffle join.
> 
> Routing reuses the same **`TableUpdateByRowId`** planner as the update path: ids are validated against snapshot row-id ranges, grouped by owning data file, and read through **`IndexedSplit`** row slicing (including blob payloads and post-evolution file splits). Reads are pinned to the latest snapshot at call time; foreign or stale `_ROW_ID`s fail loudly. Deletion-vector tables and table-name row-id sources are rejected up front.
> 
> The public API is exported from `pypaimon.ray`, documented in the Ray Data guide, and covered by a broad Ray integration test suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50d674ed5b113b2aa56a9cd30fe924577ff97570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->